### PR TITLE
Adds a preference for facing your mouse while in combat mode

### DIFF
--- a/code/game/atom/_atom.dm
+++ b/code/game/atom/_atom.dm
@@ -853,6 +853,9 @@
 	if (isnull(user))
 		return
 
+	if(user.face_mouse) // DOPPLER SHIFT ADDITION
+		user.face_atom(src) // DOPPLER SHIFT ADDITION
+
 	// Screentips
 	var/datum/hud/active_hud = user.hud_used
 	if(!active_hud)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -126,6 +126,9 @@
 	/// Example: If req_one_access = list(ACCESS_ENGINE, ACCESS_CE)- then the user must have either ACCESS_ENGINE or ACCESS_CE in order to use the object.
 	var/list/req_one_access
 
+	/// Whether a user will face atoms on entering them with a mouse. Despite being a mob variable, it is here for performances // DOPPLER SHIFT ADDITION
+	var/face_mouse = FALSE // DOPPLER SHIFT ADDITION
+
 /mutable_appearance/emissive_blocker
 
 /mutable_appearance/emissive_blocker/New()
@@ -634,7 +637,7 @@
 	if(!direction)
 		direction = get_dir(src, newloc)
 
-	if(set_dir_on_move && dir != direction && update_dir)
+	if(set_dir_on_move && dir != direction && update_dir && !face_mouse) // DOPPLER SHIFT EDIT : ORIGINAL : if(set_dir_on_move && dir != direction && update_dir)
 		setDir(direction)
 
 	var/is_multi_tile_object = is_multi_tile_object(src)
@@ -761,7 +764,7 @@
 						moving_diagonally = SECOND_DIAG_STEP
 						. = step(src, SOUTH)
 			if(moving_diagonally == SECOND_DIAG_STEP)
-				if(!. && set_dir_on_move && update_dir)
+				if(!. && set_dir_on_move && update_dir && !face_mouse) // DOPPLER SHIFT EDIT : ORIGINAL : if(!. && set_dir_on_move && update_dir)
 					setDir(first_step_dir)
 				else if(!inertia_moving)
 					newtonian_move(direct)
@@ -808,7 +811,7 @@
 
 	last_move = direct
 
-	if(set_dir_on_move && dir != direct && update_dir)
+	if(set_dir_on_move && dir != direct && update_dir && !face_mouse) // DOPPLER SHIFT EDIT : ORIGINAL : if(set_dir_on_move && dir != direct && update_dir)
 		setDir(direct)
 	if(. && has_buckled_mobs() && !handle_buckled_mob_movement(loc, direct, glide_size_override)) //movement failed due to buckled mob(s)
 		. = FALSE

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -151,6 +151,7 @@
 	combat_mode = new_mode
 	if(hud_used?.action_intent)
 		hud_used.action_intent.update_appearance()
+	face_mouse = (client?.prefs?.read_preference(/datum/preference/toggle/face_cursor_combat_mode) && combat_mode) ? TRUE : FALSE // DOPPLER SHIFT ADDITION
 	if(silent || !(client?.prefs.read_preference(/datum/preference/toggle/sound_combatmode)))
 		return
 	if(combat_mode)

--- a/modular_doppler/face_mouse_preferences/code/face_mouse_pref.dm
+++ b/modular_doppler/face_mouse_preferences/code/face_mouse_pref.dm
@@ -1,0 +1,4 @@
+/datum/preference/toggle/face_cursor_combat_mode
+	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
+	savefile_key = "face_cursor_combat_mode"
+	savefile_identifier = PREFERENCE_PLAYER

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6353,4 +6353,5 @@
 #include "interface\fonts\spess_font.dm"
 #include "interface\fonts\tiny_unicode.dm"
 #include "interface\fonts\vcr_osd_mono.dm"
+#include "modular_doppler\face_mouse_preferences\code\face_mouse_pref.dm"
 // END_INCLUDE

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/face_mouse_combat.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/face_mouse_combat.tsx
@@ -1,0 +1,9 @@
+import { CheckboxInput, FeatureToggle } from '../base';
+
+export const face_cursor_combat_mode: FeatureToggle = {
+  name: 'Face mouse in combat mode',
+  category: 'GAMEPLAY',
+  description:
+    'If your character should face towards your cursor while in combat mode.',
+  component: CheckboxInput,
+};


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

When the preference is enabled (true by default) your character will face the mouse while you are in combat mode

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It probably isn't that much good but it's cool and I can spin really fast with it

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Adds a preference (true by default) for facing your cursor in combat mode
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
