### PR TITLE
[not the least bit modular] changes minimum and maximum ages, adds age requirements to certain jobs, touches the config file with my dirty little hands

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -441,9 +441,9 @@
 #define OFFSET_HELD "held"
 
 //MINOR TWEAKS/MISC
-#define AGE_MIN 17 //youngest a character can be
-#define AGE_MAX 85 //oldest a character can be
-#define AGE_MINOR 20 //legal age of space drinking and smoking
+#define AGE_MIN 18 //youngest a character can be //DOPPLER EDIT was 17
+#define AGE_MAX 250 //oldest a character can be //DOPPLER EDIT was 85
+#define AGE_MINOR 21 //legal age of space drinking and smoking //DOPPLER EDIT was 20
 #define WIZARD_AGE_MIN 30 //youngest a wizard can be
 #define APPRENTICE_AGE_MIN 29 //youngest an apprentice can be
 #define SHOES_SLOWDOWN 0 //How much shoes slow you down by default. Negative values speed you up

--- a/config/jobconfig.toml
+++ b/config/jobconfig.toml
@@ -42,7 +42,7 @@
 [BARTENDER]
 "# Playtime Requirements" = 0
 "# Required Account Age" = 0
-"# Required Character Age" = 0
+"# Required Character Age" = 21
 "# Spawn Positions" = 1
 "# Total Positions" = 1
 
@@ -63,7 +63,7 @@
 [CAPTAIN]
 "# Playtime Requirements" = 180
 "# Required Account Age" = 14
-"# Required Character Age" = 0
+"# Required Character Age" = 30
 "# Spawn Positions" = 1
 "# Total Positions" = 1
 
@@ -91,14 +91,14 @@
 [CHIEF_ENGINEER]
 "# Playtime Requirements" = 180
 "# Required Account Age" = 7
-"# Required Character Age" = 0
+"# Required Character Age" = 25
 "# Spawn Positions" = 1
 "# Total Positions" = 1
 
 [CHIEF_MEDICAL_OFFICER]
 "# Playtime Requirements" = 180
 "# Required Account Age" = 7
-"# Required Character Age" = 0
+"# Required Character Age" = 30
 "# Spawn Positions" = 1
 "# Total Positions" = 1
 
@@ -154,14 +154,14 @@
 [HEAD_OF_PERSONNEL]
 "# Playtime Requirements" = 180
 "# Required Account Age" = 10
-"# Required Character Age" = 0
+"# Required Character Age" = 25
 "# Spawn Positions" = 1
 "# Total Positions" = 1
 
 [HEAD_OF_SECURITY]
 "# Playtime Requirements" = 300
 "# Required Account Age" = 14
-"# Required Character Age" = 0
+"# Required Character Age" = 25
 "# Spawn Positions" = 1
 "# Total Positions" = 1
 
@@ -217,14 +217,14 @@
 [QUARTERMASTER]
 "# Playtime Requirements" = 0
 "# Required Account Age" = 7
-"# Required Character Age" = 0
+"# Required Character Age" = 21
 "# Spawn Positions" = 1
 "# Total Positions" = 1
 
 [RESEARCH_DIRECTOR]
 "# Playtime Requirements" = 180
 "# Required Account Age" = 7
-"# Required Character Age" = 0
+"# Required Character Age" = 25
 "# Spawn Positions" = 1
 "# Total Positions" = 1
 
@@ -266,7 +266,7 @@
 [VETERAN_ADVISOR]
 "# Playtime Requirements" = 6000
 "# Required Account Age" = 7
-"# Required Character Age" = 0
+"# Required Character Age" = 45
 "# Spawn Positions" = 0
 "# Total Positions" = 0
 


### PR DESCRIPTION
## About The Pull Request

the last one got contaminated with wallening commits in a way that was easiest to fix with a fresh branch smileyface

the minimum character age is now 18
the maximum character age is now 250 cause ppl didnt seem to like 999
the age you get to drink and buy ciggies is 21

also:
the minimum age for the bartender is 21
the minimum age for captain is 30
the minimum age for chief engineer is 25
the minimum age for chief medical officer is 30
the minimum age for the head of personnel is 25
the minimum age for the head of security is 25
the minimum age for the research director is 25
the minimum age for quartermaster is 21
the minimum age for the veteran advisor station trait role is 45

ages were picked arbitrarily and the minimum set generously

## Why It's Good For The Game

it's heavy roleplay

## Changelog

:cl:
config: changed minimum and maximum values for character ages and minimum age values for certain roles.
:cl:
