### PR TITLE
Add automatic whitelist refreshing subsystem

### DIFF
--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -136,6 +136,7 @@
 #define INIT_ORDER_DBCORE 95
 #define INIT_ORDER_BLACKBOX 94
 #define INIT_ORDER_SERVER_MAINT 93
+#define INIT_ORDER_WHITELIST 92 // DOPPLER EDIT ADDITION - automatic whitelist refresh
 #define INIT_ORDER_INPUT 85
 #define INIT_ORDER_ADMIN_VERBS 84 // needs to be pretty high, admins can't do much without it
 #define INIT_ORDER_SOUNDS 83

--- a/modular_doppler/administration/code/whitelisting.dm
+++ b/modular_doppler/administration/code/whitelisting.dm
@@ -1,0 +1,11 @@
+SUBSYSTEM_DEF(whitelisting)
+	name = "Auto-Whitelist"
+	init_order = INIT_ORDER_WHITELIST
+	runlevels = RUNLEVEL_SETUP | RUNLEVEL_LOBBY | RUNLEVEL_GAME | RUNLEVEL_POSTGAME
+	wait = 5 MINUTES
+
+/datum/controller/subsystem/whitelisting/Initialize()
+	return SS_INIT_SUCCESS
+
+/datum/controller/subsystem/whitelisting/fire(resumed = FALSE)
+	load_whitelist() // yep that's it

--- a/modular_doppler/administration/readme.md
+++ b/modular_doppler/administration/readme.md
@@ -1,0 +1,27 @@
+## Title: Administration
+
+MODULE ID: ADMINISTRATION
+
+### Description:
+
+This module contains everything related to administration, as well as serving as a place to add more to it.
+
+### TG Proc Changes:
+
+N/A
+
+### Defines:
+
+- `code\__DEFINES\subsystems.dm` subsystem's define
+
+### Master file additions
+
+N/A
+
+### Included files that are not contained in this module:
+
+N/A
+
+### Credits:
+
+Ephemeralis

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6429,6 +6429,7 @@
 #include "modular_doppler\accessable_storage\accessable_storage.dm"
 #include "modular_doppler\accessable_storage\item.dm"
 #include "modular_doppler\accessable_storage\strippable.dm"
+#include "modular_doppler\administration\code\whitelisting.dm"
 #include "modular_doppler\advanced_reskin\code\advanced_reskin.dm"
 #include "modular_doppler\cell_component\code\cell_component.dm"
 #include "modular_doppler\colony_fabricator\code\colony_fabricator.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds the administration module which currently has the automatic whitelist refreshing subsystem requested by Kannthus.

## Why It's Good For The Game

Because automatization is good.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Kaostico
add: Add automatic whitelist refreshing subsystem.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
