### PR TITLE
Fix: Bowls no longer vanish & larger bottles

### DIFF
--- a/_maps/RandomRuins/IceRuins/doppler/icemoon_underground_icewalker_upper.dmm
+++ b/_maps/RandomRuins/IceRuins/doppler/icemoon_underground_icewalker_upper.dmm
@@ -349,6 +349,20 @@
 /obj/item/storage/fancy/candle_box,
 /turf/open/floor/stone/icemoon,
 /area/ruin/unpowered/primitive_catgirl_den)
+"sB" = (
+/obj/structure/rack/wooden,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/reagent_containers/cup/glass/bottle{
+	pixel_x = -8
+	},
+/obj/item/reagent_containers/cup/glass/bottle{
+	pixel_x = 1
+	},
+/obj/item/reagent_containers/cup/glass/bottle{
+	pixel_x = 7
+	},
+/turf/open/floor/stone/icemoon,
+/area/ruin/unpowered/primitive_catgirl_den)
 "sE" = (
 /obj/structure/railing/wooden_fencing{
 	dir = 8
@@ -889,17 +903,17 @@
 /area/ruin/unpowered/primitive_catgirl_den)
 "XV" = (
 /obj/structure/rack/wooden,
-/obj/item/reagent_containers/cup/glass/bottle/small{
-	pixel_x = -8
-	},
-/obj/item/reagent_containers/cup/glass/bottle/small{
-	pixel_x = 1
-	},
-/obj/item/reagent_containers/cup/glass/bottle/small{
-	pixel_x = 7
-	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/wall_torch/spawns_lit/directional/west,
+/obj/item/reagent_containers/cup/glass/bottle{
+	pixel_x = -8
+	},
+/obj/item/reagent_containers/cup/glass/bottle{
+	pixel_x = 1
+	},
+/obj/item/reagent_containers/cup/glass/bottle{
+	pixel_x = 7
+	},
 /turf/open/floor/stone/icemoon,
 /area/ruin/unpowered/primitive_catgirl_den)
 "Yj" = (
@@ -930,16 +944,16 @@
 /area/ruin/unpowered/primitive_catgirl_den)
 "YZ" = (
 /obj/structure/rack/wooden,
-/obj/item/reagent_containers/cup/glass/bottle/small{
-	pixel_x = -8
-	},
-/obj/item/reagent_containers/cup/glass/bottle/small{
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/reagent_containers/cup/glass/bottle{
 	pixel_x = 1
 	},
-/obj/item/reagent_containers/cup/glass/bottle/small{
+/obj/item/reagent_containers/cup/glass/bottle{
+	pixel_x = -8
+	},
+/obj/item/reagent_containers/cup/glass/bottle{
 	pixel_x = 7
 	},
-/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/stone/icemoon,
 /area/ruin/unpowered/primitive_catgirl_den)
 "Zv" = (
@@ -2192,7 +2206,7 @@ RX
 Uv
 Uv
 Uv
-YZ
+sB
 OG
 OG
 YZ

--- a/modular_doppler/hearthkin/primitive_production/code/ceramics.dm
+++ b/modular_doppler/hearthkin/primitive_production/code/ceramics.dm
@@ -140,6 +140,11 @@ GLOBAL_LIST_INIT(clay_recipes, list ( \
 	icon_state = "clay_bowl"
 	custom_materials = null
 
+/obj/item/reagent_containers/cup/bowl/ceramic/update_icon_state()
+	if(!reagents.total_volume)
+		icon_state = "clay_bowl"
+	return ..()
+
 /obj/item/ceramic/cup
 	name = "ceramic cup"
 	desc = "A piece of clay with high walls, in the shape of a cup. It can hold 120 units."

--- a/modular_doppler/hearthkin/tribal_extended/code/crafting.dm
+++ b/modular_doppler/hearthkin/tribal_extended/code/crafting.dm
@@ -19,7 +19,7 @@
 	fill_icon_state = "fullbowl"
 	fill_icon = 'icons/obj/mining_zones/ash_flora.dmi'
 
-/obj/item/reagent_containers/cup/bowl/mushroom_bowl/update_icon_state()
+/obj/item/reagent_containers/cup/bowl/wood_bowl/update_icon_state()
 	if(!reagents.total_volume)
 		icon_state = "wood_bowl"
 	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Placed some larger bottles in the hearthkin's hearth.

Also fixed the issue of wooden and ceramic bowls icons vanishing after their contents get emptied.

## Why It's Good For The Game

I hate bugs + larger bottles are more useful for hearthkin than the lack of them.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: MortoSasye
add: Swapped the smaller bottles with it's larger cousin, in the hearthkin's healing hut.
fix: Wood bowls and ceramic bowls will no longer magically vanish upon getting it's contents emptied.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
