### PR TITLE
Update preferences.dm to give us more character slots

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -9,7 +9,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	/// Ensures that we always load the last used save, QOL
 	var/default_slot = 1
 	/// The maximum number of slots we're allowed to contain
-	var/max_save_slots = 3
+	var/max_save_slots = 10 //DOPPLER EDIT - was 3
 
 	/// Bitflags for communications that are muted
 	var/muted = NONE

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -107,7 +107,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			try_savefile_type_migration()
 		unlock_content = !!parent.IsByondMember()
 		if(unlock_content)
-			max_save_slots = 8
+			max_save_slots = 10 //DOPPLER EDIT - was 8
 	else
 		CRASH("attempted to create a preferences datum without a client or mock!")
 	load_savefile()


### PR DESCRIPTION
## About The Pull Request

changes the default character slot count from 3 to 10. 10 was selected because we don't have a drop down menu right now, so it makes buttons at the top of the CC window.

## Why It's Good For The Game

:3