### PR TITLE
Some Shit That I Forgot (Golems & Snails)

### DIFF
--- a/code/game/objects/items/stacks/golem_food/golem_status_effects.dm
+++ b/code/game/objects/items/stacks/golem_food/golem_status_effects.dm
@@ -227,7 +227,7 @@
 
 //	 DOPPLER ADDITION START
 /datum/movespeed_modifier/status_effect/golem_plasteel
-	multiplicative_slowdown = 0.5 // Tank build?
+	multiplicative_slowdown = 0.7 // Tank build?
 // 	DOPPLER ADDITION END
 
 /datum/status_effect/golem/plasteel/on_apply()
@@ -238,7 +238,7 @@
 	// DOPPLER ADDITION START
 	owner.add_movespeed_modifier(/datum/movespeed_modifier/status_effect/golem_plasteel, update=TRUE)
 	var/mob/living/carbon/human/golem_owner = owner
-	golem_owner.physiology.damage_resistance += 15 // Gives them 15 extra damage resist. This basically means they soak 6 damage. In exchange, some more slowdown.
+	golem_owner.physiology.damage_resistance += 20 // Gives them 20 extra damage resist. This basically means they soak 6 damage. In exchange, some more slowdown.
 	// DOPPLER ADDITION END
 	return TRUE
 
@@ -247,7 +247,7 @@
 	// DOPPLER ADDITION START
 	owner.remove_movespeed_modifier(/datum/movespeed_modifier/status_effect/golem_plasteel, update=TRUE)
 	var/mob/living/carbon/human/golem_owner = owner
-	golem_owner.physiology.damage_resistance -= 15 // And God taketh away.
+	golem_owner.physiology.damage_resistance -= 20 // And God taketh away.
 	// DOPPLER ADDITION END
 	return ..()
 

--- a/code/game/objects/items/stacks/golem_food/golem_status_effects.dm
+++ b/code/game/objects/items/stacks/golem_food/golem_status_effects.dm
@@ -238,7 +238,7 @@
 	// DOPPLER ADDITION START
 	owner.add_movespeed_modifier(/datum/movespeed_modifier/status_effect/golem_plasteel, update=TRUE)
 	var/mob/living/carbon/human/golem_owner = owner
-	golem_owner.physiology.damage_resistance += 20 // Gives them 20 extra damage resist. This basically means they soak 6 damage. In exchange, some more slowdown.
+	golem_owner.physiology.damage_resistance += 15 // Gives them 15 extra damage resist. This totals out to 25. If you shot a golem with a 50 damage round, they'd eat 12.5 damage.
 	// DOPPLER ADDITION END
 	return TRUE
 
@@ -247,7 +247,7 @@
 	// DOPPLER ADDITION START
 	owner.remove_movespeed_modifier(/datum/movespeed_modifier/status_effect/golem_plasteel, update=TRUE)
 	var/mob/living/carbon/human/golem_owner = owner
-	golem_owner.physiology.damage_resistance -= 20 // And God taketh away.
+	golem_owner.physiology.damage_resistance -= 15 // And God taketh away.
 	// DOPPLER ADDITION END
 	return ..()
 

--- a/code/modules/mob/living/carbon/human/species_types/snail.dm
+++ b/code/modules/mob/living/carbon/human/species_types/snail.dm
@@ -27,7 +27,7 @@
 	)
 
 	///Multiplier for the speed we give them. Positive numbers make it move slower, negative numbers make it move faster.
-	var/snail_speed_mod = 6
+	var/snail_speed_mod = 0.5
 
 /datum/species/snail/prepare_human_for_preview(mob/living/carbon/human/human)
 	human.dna.features["mcolor"] = COLOR_BEIGE

--- a/code/modules/mob/living/carbon/human/species_types/snail.dm
+++ b/code/modules/mob/living/carbon/human/species_types/snail.dm
@@ -27,7 +27,7 @@
 	)
 
 	///Multiplier for the speed we give them. Positive numbers make it move slower, negative numbers make it move faster.
-	var/snail_speed_mod = 0.5
+	var/snail_speed_mod = 0.5 // Doppler Edit Change - Now they actually get a speedup, roughly equivalent to human crawl speed.
 
 /datum/species/snail/prepare_human_for_preview(mob/living/carbon/human/human)
 	human.dna.features["mcolor"] = COLOR_BEIGE

--- a/modular_doppler/modular_species/species_types/golem/golem.dm
+++ b/modular_doppler/modular_species/species_types/golem/golem.dm
@@ -26,7 +26,7 @@
 	no_equip_flags = ITEM_SLOT_MASK | ITEM_SLOT_OCLOTHING | ITEM_SLOT_FEET | ITEM_SLOT_ICLOTHING | ITEM_SLOT_SUITSTORE
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN //golem ERT
 
-	var/golem_speed_mod = 1
+	var/golem_speed_mod = 0.8
 
 /datum/species/golem/on_species_gain(mob/living/carbon/new_golem, datum/species/old_species, pref_load)
 	. = ..()

--- a/modular_doppler/modular_species/species_types/snails/snail_bodyparts.dm
+++ b/modular_doppler/modular_species/species_types/snails/snail_bodyparts.dm
@@ -25,7 +25,7 @@
 /obj/item/bodypart/leg/left/snail
 	icon_greyscale = BODYPART_ICON_SNAIL
 	bodyshape = BODYSHAPE_HUMANOID
-	unarmed_damage_low = 1.
+	unarmed_damage_low = 1
 	unarmed_damage_high = 5
 
 /obj/item/bodypart/leg/right/snail


### PR DESCRIPTION
## About The Pull Request
Snails now get actually sped up when they crawl; roughly equivalent to human crawl speed. Golems are a little faster than before, still mad slow with plasteel, plasteel now gives them a little bit more because I forgot to take into account that they can't otherwise wear armor.

## Why It's Good For The Game
I like walking at a decent pace.

## Changelog
:cl:
balance: Snails and golems walk faster, plasteel does a little more for golems.
/:cl:
