### PR TITLE
Fixes mob spawn restricted species validations

### DIFF
--- a/modular_doppler/modular_mob_spawn/code/mob_spawn.dm
+++ b/modular_doppler/modular_mob_spawn/code/mob_spawn.dm
@@ -3,7 +3,7 @@
 	var/list/restricted_species = list()
 
 /obj/effect/mob_spawn/ghost_role/create(mob/mob_possessor, newname)
-	if(restricted_species && !(mob_possessor?.client?.prefs?.read_preference(/datum/preference/choiced/species) in restricted_species))
+	if(restricted_species.len  && !(mob_possessor?.client?.prefs?.read_preference(/datum/preference/choiced/species) in restricted_species))
 		var/text = "Current loaded character doesn't match required species: "
 		var/i = 1
 		for(var/datum/species/speciesItem as anything in restricted_species)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixed restricted species not validating correctly when the restricted_species list is empty.

## Why It's Good For The Game

It's broken and we need to fix it.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Kaostico
fix: Fixed validation from restricted species in ghost roles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
