### PR TITLE
Evil Iceland Ruins Mini-Fix

### DIFF
--- a/_maps/doppler/automapper/automapper_config.toml
+++ b/_maps/doppler/automapper/automapper_config.toml
@@ -58,7 +58,7 @@ trait_name = "Station"
 map_files = ["icemoon_underground_icewalker_lower.dmm"]
 directory = "_maps/RandomRuins/IceRuins/doppler/"
 required_map = "Iceland.dmm"
-coordinates = [170, 16, 1]
+coordinates = [121, 203, 1]
 trait_name = "Mining"
 
 # Icecats Camp Upper Level: ICELAND ADDITION
@@ -66,7 +66,7 @@ trait_name = "Mining"
 map_files = ["icemoon_underground_icewalker_upper.dmm"]
 directory = "_maps/RandomRuins/IceRuins/doppler/"
 required_map = "Iceland.dmm"
-coordinates = [170, 16, 2]
+coordinates = [121, 203, 2]
 trait_name = "Mining"
 
 # TRAMSTATION MAP EDITS

--- a/_maps/mining_configs/iceland.json
+++ b/_maps/mining_configs/iceland.json
@@ -22,7 +22,6 @@
 			"Down": true,
 			"Mining": true,
 			"No Parallax": true,
-			"Ice Ruins": true,
 			"Ice Ruins Underground": true,
 			"Baseturf": "/turf/open/openspace/icemoon/keep_below",
 			"Gravity": true,

--- a/code/datums/ruins/icemoon.dm
+++ b/code/datums/ruins/icemoon.dm
@@ -73,6 +73,12 @@
 	description = "Here lies Charles Morlbaro. He died the way he lived."
 	suffix = "icemoon_surface_smoking_room.dmm"
 
+/datum/map_template/ruin/icemoon/lavaland // DOPPLER EDIT TO NOT BE UNDERGROUND
+	name = "Ice-Ruin Lavaland Incursion"
+	id = "lavalandsite"
+	description = "I guess we never really left you huh?"
+	suffix = "icemoon_underground_lavaland.dmm"
+
 // above and below ground together
 
 /datum/map_template/ruin/icemoon/mining_site
@@ -121,12 +127,6 @@
 	id = "hermitshack"
 	description = "A place of shelter for a lone hermit, scraping by to live another day."
 	suffix = "icemoon_underground_hermit.dmm"
-
-/datum/map_template/ruin/icemoon/underground/lavaland
-	name = "Ice-Ruin Lavaland Incursion"
-	id = "lavalandsite"
-	description = "I guess we never really left you huh?"
-	suffix = "icemoon_underground_lavaland.dmm"
 
 /datum/map_template/ruin/icemoon/underground/puzzle
 	name = "Ice-Ruin Ancient Puzzle"

--- a/config/iceruinblacklist.txt
+++ b/config/iceruinblacklist.txt
@@ -13,7 +13,7 @@
 ##MEGAFAUNA
 #_maps/RandomRuins/IceRuins/icemoon_surface_mining_site.dmm
 #_maps/RandomRuins/IceRuins/icemoon_underground_mining_site.dmm
-_maps/RandomRuins/IceRuins/icemoon_underground_lavaland.dmm
+#_maps/RandomRuins/IceRuins/icemoon_underground_lavaland.dmm
 #_maps/RandomRuins/IceRuins/icemoon_underground_wendigo_cave.dmm
 
 ##MISC

--- a/config/iceruinblacklist.txt
+++ b/config/iceruinblacklist.txt
@@ -13,7 +13,7 @@
 ##MEGAFAUNA
 #_maps/RandomRuins/IceRuins/icemoon_surface_mining_site.dmm
 #_maps/RandomRuins/IceRuins/icemoon_underground_mining_site.dmm
-#_maps/RandomRuins/IceRuins/icemoon_underground_lavaland.dmm
+_maps/RandomRuins/IceRuins/icemoon_underground_lavaland.dmm
 #_maps/RandomRuins/IceRuins/icemoon_underground_wendigo_cave.dmm
 
 ##MISC


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. Changed the hearthkin's location in Iceland to be in the middle instead.
2. To avoid an efficiency issue with the Icemoon Lavaland Drake boss arena, it was moved from being underground to surface level, and edited. (The efficiency issue was 400+ active turfs in multiple levels, INCLUDING the station)

## Why It's Good For The Game

The 400+ active turfs live in my nightmares.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: MortoSasye
qol: The hearthkin's base on Iceland is no longer directly above a plasma river, nor in direct proximity to the mining base.
fix: Moved the Ice-Ruin Lavaland Incursion (drake boss arena) to the surface level, to avoid over 400 active turfs in lower levels.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
