### PR TITLE
Adds Digilegs To Three Species

### DIFF
--- a/code/__DEFINES/~doppler_defines/is_helpers.dm
+++ b/code/__DEFINES/~doppler_defines/is_helpers.dm
@@ -5,4 +5,4 @@
 #define issnail(A) (is_species(A, /datum/species/snail))
 #define ishemophage(A) (is_species(A, /datum/species/genemod/hemophage))
 //Species with green blood
-#define hasgreenblood(A) (isinsectoid(A) || HAS_TRAIT(A, TRAIT_GREEN_BLOOD))
+#define hasgreenblood(A) (isinsectoid(A) || issnail(A) || HAS_TRAIT(A, TRAIT_GREEN_BLOOD))

--- a/modular_doppler/modular_species/species_types/genemod/genemod.dm
+++ b/modular_doppler/modular_species/species_types/genemod/genemod.dm
@@ -12,6 +12,12 @@
 	)
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 
+	digitigrade_customization = DIGITIGRADE_OPTIONAL
+	digi_leg_overrides = list(
+		BODY_ZONE_L_LEG = /obj/item/bodypart/leg/left/digitigrade/anthromorph,
+		BODY_ZONE_R_LEG = /obj/item/bodypart/leg/right/digitigrade/anthromorph,
+	)
+
 /datum/outfit/genemod_preview
 	name = "Gene-Mod (Species Preview)"
 	uniform = /obj/item/clothing/under/dress/sundress

--- a/modular_doppler/modular_species/species_types/hemophage/hemophage_species.dm
+++ b/modular_doppler/modular_species/species_types/hemophage/hemophage_species.dm
@@ -26,6 +26,12 @@
 	examine_limb_id = SPECIES_HUMAN
 	skinned_type = /obj/item/stack/sheet/animalhide/human
 
+	digitigrade_customization = DIGITIGRADE_OPTIONAL
+	digi_leg_overrides = list(
+		BODY_ZONE_L_LEG = /obj/item/bodypart/leg/left/digitigrade/anthromorph,
+		BODY_ZONE_R_LEG = /obj/item/bodypart/leg/right/digitigrade/anthromorph,
+	)
+
 /datum/species/genemod/hemophage/check_roundstart_eligible()
 	if(check_holidays(HALLOWEEN))
 		return TRUE

--- a/modular_doppler/modular_species/species_types/snails/modular_snail.dm
+++ b/modular_doppler/modular_species/species_types/snails/modular_snail.dm
@@ -3,12 +3,13 @@
 /datum/species/snail
 	mutantliver = /obj/item/organ/internal/liver/snail //This is just a better liver to deal with toxins, it's a thematic thing.
 	mutantheart = /obj/item/organ/internal/heart/snail //This gives them the shell buff where they take less damage from behind, and their heart's more durable.
-	exotic_blood = null
+	exotic_blood = /datum/reagent/blood/green
+	exotic_bloodtype = "I*"
 
 	digitigrade_customization = DIGITIGRADE_OPTIONAL
 	digi_leg_overrides = list(
-		BODY_ZONE_L_LEG = /obj/item/bodypart/leg/left/digitigrade/anthromorph,
-		BODY_ZONE_R_LEG = /obj/item/bodypart/leg/right/digitigrade/anthromorph,
+		BODY_ZONE_L_LEG = /obj/item/bodypart/leg/left/digitigrade/insectoid,
+		BODY_ZONE_R_LEG = /obj/item/bodypart/leg/right/digitigrade/insectoid,
 	)
 
 /datum/species/snail/on_species_gain(mob/living/carbon/new_snailperson, datum/species/old_species, pref_load)

--- a/modular_doppler/modular_species/species_types/snails/modular_snail.dm
+++ b/modular_doppler/modular_species/species_types/snails/modular_snail.dm
@@ -5,6 +5,12 @@
 	mutantheart = /obj/item/organ/internal/heart/snail //This gives them the shell buff where they take less damage from behind, and their heart's more durable.
 	exotic_blood = null
 
+	digitigrade_customization = DIGITIGRADE_OPTIONAL
+	digi_leg_overrides = list(
+		BODY_ZONE_L_LEG = /obj/item/bodypart/leg/left/digitigrade/anthromorph,
+		BODY_ZONE_R_LEG = /obj/item/bodypart/leg/right/digitigrade/anthromorph,
+	)
+
 /datum/species/snail/on_species_gain(mob/living/carbon/new_snailperson, datum/species/old_species, pref_load)
 	. = ..()
 	new_snailperson.update_icons()


### PR DESCRIPTION
## About The Pull Request
Genemodders, hemophages, and snails can now have weird fucked up evil legs. These will ideally be better with markings when we get them.

## Why It's Good For The Game
Further customization and one more item off the list, baybee.

## Changelog
:cl:
add: Hemophages, genemodders, and snails can now select digitigrade legs.
/:cl:
