### PR TITLE
Renameable Loadout Items (& Some More Ones)

### DIFF
--- a/code/modules/loadout/loadout_items.dm
+++ b/code/modules/loadout/loadout_items.dm
@@ -42,7 +42,7 @@ GLOBAL_LIST_INIT(all_loadout_categories, init_loadout_categories())
 	var/can_be_greyscale = FALSE
 	/// Whether this item can be renamed.
 	/// I recommend you apply this sparingly becuase it certainly can go wrong (or get reset / overridden easily)
-	var/can_be_named = FALSE
+	var/can_be_named = TRUE // DOPPLER EDIT - Everything can be renamed in the loadout - ORIGINAL: var/can_be_named = FALSE
 	/// Whether this item can be reskinned.
 	/// Only works if the item has a "unique reskin" list set.
 	var/can_be_reskinned = FALSE
@@ -255,6 +255,7 @@ GLOBAL_LIST_INIT(all_loadout_categories, init_loadout_categories())
 	if(can_be_named && item_details?[INFO_NAMED] && !visuals_only)
 		equipped_item.name = trim(item_details[INFO_NAMED], PREVENT_CHARACTER_TRIM_LOSS(MAX_NAME_LEN))
 		ADD_TRAIT(equipped_item, TRAIT_WAS_RENAMED, "Loadout")
+		equipped_item.on_loadout_custom_named() // NOVA EDIT ADDITION - Loadout item names
 
 	// DOPPLER EDIT ADDITION START - Loadout item descriptions
 	if(can_be_named && item_details?[INFO_DESCRIBED] && !visuals_only)
@@ -315,8 +316,10 @@ GLOBAL_LIST_INIT(all_loadout_categories, init_loadout_categories())
 	if(can_be_greyscale)
 		displayed_text += "Recolorable"
 
+	/* DOPPLER EDIT REMOVAL - Everything can be renamed in the loadout
 	if(can_be_named)
 		displayed_text += "Renamable"
+	*/ // DOPPLER EDIT END
 
 	if(can_be_reskinned)
 		displayed_text += "Reskinnable"

--- a/modular_doppler/loadout_categories/categories/clothing.dm
+++ b/modular_doppler/loadout_categories/categories/clothing.dm
@@ -275,6 +275,42 @@
 	name = "Recolorable Overalls"
 	item_path = /obj/item/clothing/suit/apron/overalls
 
+/datum/loadout_item/suit/wellwornshirt
+	name = "Well-worn Shirt"
+	item_path = /obj/item/clothing/suit/costume/wellworn_shirt
+
+/datum/loadout_item/suit/wellworn_graphicshirt
+	name = "Well-worn Graphic Shirt"
+	item_path = /obj/item/clothing/suit/costume/wellworn_shirt/graphic
+
+/datum/loadout_item/suit/ianshirt
+	name = "Well-worn Ian Shirt"
+	item_path = /obj/item/clothing/suit/costume/wellworn_shirt/graphic/ian
+
+/datum/loadout_item/suit/wornoutshirt
+	name = "Worn-out Shirt"
+	item_path = /obj/item/clothing/suit/costume/wellworn_shirt/wornout
+
+/datum/loadout_item/suit/wornout_graphicshirt
+	name = "Worn-out graphic Shirt"
+	item_path = /obj/item/clothing/suit/costume/wellworn_shirt/wornout/graphic
+
+/datum/loadout_item/suit/wornout_ianshirt
+	name = "Worn-out Ian Shirt"
+	item_path = /obj/item/clothing/suit/costume/wellworn_shirt/wornout/graphic/ian
+
+/datum/loadout_item/suit/messyshirt
+	name = "Messy Shirt"
+	item_path = /obj/item/clothing/suit/costume/wellworn_shirt/messy
+
+/datum/loadout_item/suit/messy_graphicshirt
+	name = "Messy Graphic Shirt"
+	item_path = /obj/item/clothing/suit/costume/wellworn_shirt/messy/graphic
+
+/datum/loadout_item/suit/messy_ianshirt
+	name = "Messy Ian Shirt"
+	item_path = /obj/item/clothing/suit/costume/wellworn_shirt/messy/graphic/ian
+
 /*
 *	HAWAIIAN
 */

--- a/modular_doppler/loadout_categories/loadout_checkers.dm
+++ b/modular_doppler/loadout_categories/loadout_checkers.dm
@@ -3,6 +3,10 @@
 /atom/proc/on_loadout_custom_described()
 	return
 
+/// Called after a loadout item gets custom named
+/atom/proc/on_loadout_custom_named()
+	return
+
 /*
  * Generate a list of singleton loadout_item datums from all subtypes of [type_to_generate]
  *


### PR DESCRIPTION
## About The Pull Request
This one properly turns on letting you rename and redescribe loadout items.
![image](https://github.com/user-attachments/assets/568f6201-aa1a-4931-86b9-6a1d65940b3b)
Also ports big shirts for comfy girls.

## Why It's Good For The Game
I NEED to rename everything that I have on my golem for aesthetics.

## Changelog
:cl:
add: You can now rename and redescribe loadout items.
add: Big shirts are in the loadout now.
/:cl: