### PR TITLE
Adds height scaling

### DIFF
--- a/modular_doppler/height_scaling/code/icons.dm
+++ b/modular_doppler/height_scaling/code/icons.dm
@@ -1,0 +1,12 @@
+// To speed up the preference menu, we apply 1 filter to the entire mob
+/mob/living/carbon/human/dummy/regenerate_icons()
+	. = ..()
+	apply_height_filters(src, TRUE)
+
+/mob/living/carbon/human/dummy/apply_height_filters(mutable_appearance/appearance, only_apply_in_prefs = FALSE)
+	if(only_apply_in_prefs)
+		return ..()
+
+// Not necessary with above
+/mob/living/carbon/human/dummy/apply_height_offsets(mutable_appearance/appearance, upper_torso)
+	return

--- a/modular_doppler/height_scaling/code/preferences.dm
+++ b/modular_doppler/height_scaling/code/preferences.dm
@@ -1,0 +1,61 @@
+/datum/preference/choiced/height_scaling
+	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
+	savefile_key = "height_scaling"
+	savefile_identifier = PREFERENCE_CHARACTER
+
+	/// Assoc list of stringified HUMAN_HEIGHT_### defines to string. Passed into CHOICED_PREFERENCE_DISPLAY_NAMES.
+	var/static/list/height_scaling_strings = list(
+		"[HUMAN_HEIGHT_SHORT]" = "Short",
+		"[HUMAN_HEIGHT_MEDIUM]" = "Medium",
+		"[HUMAN_HEIGHT_TALL]" = "Tall",
+	)
+
+	/// List of strings, representing quirk ids that prevent this from applying and being accessed.
+	var/static/list/incompatable_quirk_ids = list(
+		"Spacer",
+		"Settler"
+	)
+
+/datum/preference/choiced/height_scaling/init_possible_values()
+	// HUMAN_HEIGHT_SHORTEST and HUMAN_HEIGHT_TALLER are left out on maintainer request unless desired later
+	// HUMAN_HEIGHT_TALLEST is disabled because it constantly artifacts
+	return list(HUMAN_HEIGHT_SHORT, HUMAN_HEIGHT_MEDIUM, HUMAN_HEIGHT_TALL)
+
+/datum/preference/choiced/height_scaling/create_default_value()
+	return HUMAN_HEIGHT_MEDIUM
+
+/datum/preference/choiced/height_scaling/is_accessible(datum/preferences/preferences)
+	. = ..()
+
+	if(!.)
+		return
+
+	// if (ispath(preferences?.pref_species, /datum/species/dwarf)) // all 3 of these manually set your height
+	// 	return FALSE
+
+	for (var/quirk_id as anything in preferences?.all_quirks)
+		if (quirk_id in incompatable_quirk_ids)
+			return FALSE
+
+	return TRUE
+
+/datum/preference/choiced/height_scaling/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
+	if (HAS_TRAIT(target, TRAIT_DWARF)) // nuh uh. your height is set mf
+		return FALSE
+
+	for (var/quirk_id as anything in preferences?.all_quirks)
+		if (quirk_id in incompatable_quirk_ids)
+			return FALSE
+
+	// if (isteshari(target))
+	// 	value = (max(value, HUMAN_HEIGHT_MEDIUM)) // to respect junis tesh rework i am preventing them from getting shorter
+
+	target.set_mob_height(value)
+
+/datum/preference/choiced/height_scaling/compile_constant_data()
+	var/list/data = ..()
+
+	// An assoc list of values to display names so we don't show players numbers in their settings!
+	data[CHOICED_PREFERENCE_DISPLAY_NAMES] = height_scaling_strings
+
+	return data

--- a/modular_doppler/height_scaling/readme.md
+++ b/modular_doppler/height_scaling/readme.md
@@ -1,0 +1,26 @@
+## Title: Height scaling
+
+MODULE ID: HEIGHT_SCALING
+
+### Description:
+
+Allows people to change their characters height using tg's height framework
+
+### TG Proc Changes:
+
+- N/A
+
+### Defines:
+
+- N/A
+
+### Master file additions
+
+- N/A
+
+### Included files that are not contained in this module:
+
+- N/A
+
+### Credits:
+Niko - Original code

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6611,6 +6611,8 @@
 #include "modular_doppler\hearthkin\tribal_extended\code\weapons\bow.dm"
 #include "modular_doppler\hearthkin\tribal_extended\code\weapons\shield.dm"
 #include "modular_doppler\hearthkin\tribal_extended\code\weapons\sword.dm"
+#include "modular_doppler\height_scaling\code\icons.dm"
+#include "modular_doppler\height_scaling\code\preferences.dm"
 #include "modular_doppler\icspawn\cconsultant_items.dm"
 #include "modular_doppler\icspawn\observer_spawn.dm"
 #include "modular_doppler\icspawn\spell.dm"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/dopplershift_preferences/height_scaling.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/dopplershift_preferences/height_scaling.tsx
@@ -1,0 +1,8 @@
+// THIS IS A DOPPLER SECTOR UI FILE
+import { FeatureChoiced } from '../base';
+import { FeatureDropdownInput } from '../dropdowns';
+
+export const height_scaling: FeatureChoiced = {
+  name: 'Body Height',
+  component: FeatureDropdownInput,
+};


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds medium, short, and tall body heights. Works with all species (my husband made me check!!)

Original code is by nikothedude.

<details>

![JTQgOFF6zw](https://github.com/user-attachments/assets/01ed2cb7-831d-4a80-9069-64e23e6545d6)
![4v23GqNocC](https://github.com/user-attachments/assets/608e7848-2235-4019-a6a7-2e5ed682ee6e)
![JrurVVMnTv](https://github.com/user-attachments/assets/1967f5ac-d09d-4e94-906d-e76fdf199a47)

</details>

## Why It's Good For The Game

This is the lesser evil vs porting sprite scaling which ruins sprites. In this essay I will explain why-

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: 
add: Added height scaling. You can now be short, standard height, or tall.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
