### PR TITLE
Baton Rebalancing

### DIFF
--- a/code/__DEFINES/~doppler_defines/signals.dm
+++ b/code/__DEFINES/~doppler_defines/signals.dm
@@ -15,3 +15,5 @@
 #define COMSIG_PULSATING_TUMOR_REMOVED "pulsating_tumor_removed"
 /// From /obj/item/organ/internal/stomach/after_eat(atom/edible)
 #define COMSIG_STOMACH_AFTER_EAT "stomach_after_eat"
+/// Whenever a baton successfully executes its nonlethal attack. WARNING wonderful FUCKING CODE by niko THIS IS peak AAAAAAAAAAAAH
+#define COMSIG_PRE_BATON_FINALIZE_ATTACK "pre_baton_finalize_attack"

--- a/code/datums/components/jousting.dm
+++ b/code/datums/components/jousting.dm
@@ -115,6 +115,8 @@
 			target.Paralyze(knockdown_time)
 		user.visible_message(span_danger("[msg]!"))
 
+		return usable_charge // DOPPLER EDIT ADDITION - Baton jousting
+
 /**
  * Called when a mob moves.
  * Handles checking their direction, changing it if they turned,

--- a/code/game/objects/items/melee/baton.dm
+++ b/code/game/objects/items/melee/baton.dm
@@ -27,7 +27,7 @@
 	/// The length of the knockdown applied to the user on clumsy_check()
 	var/clumsy_knockdown_time = 18 SECONDS
 	/// How much stamina damage we deal on a successful hit against a living, non-cyborg mob.
-	var/stamina_damage = 55
+	var/stamina_damage = 35 // DOPPLER EDIT - Less Stamina Damage (Original: 55)
 	/// Chance of causing force_say() when stunning a human mob
 	var/force_say_chance = 33
 	/// Can we stun cyborgs?
@@ -185,6 +185,7 @@
 	if(!in_attack_chain && HAS_TRAIT_FROM(target, TRAIT_IWASBATONED, REF(user)))
 		return BATON_ATTACK_DONE
 
+	SEND_SIGNAL(src, COMSIG_PRE_BATON_FINALIZE_ATTACK, target, user, modifiers, in_attack_chain) // DOPPLER EDIT ADDITION
 	cooldown_check = world.time + cooldown
 	if(on_stun_sound)
 		playsound(get_turf(src), on_stun_sound, on_stun_volume, TRUE, -1)
@@ -404,7 +405,7 @@
 	force = 5
 	cooldown = 2.5 SECONDS
 	force_say_chance = 80 //very high force say chance because it's funny
-	stamina_damage = 85
+	stamina_damage = 115 // DOPPLER EDIT: Original 85
 	clumsy_knockdown_time = 24 SECONDS
 	affect_cyborg = TRUE
 	on_stun_sound = 'sound/items/weapons/contractor_baton/contractorbatonhit.ogg'
@@ -438,7 +439,7 @@
 	armor_type = /datum/armor/baton_security
 	throwforce = 7
 	force_say_chance = 50
-	stamina_damage = 60
+	stamina_damage = 35 // DOPPLER EDIT - 4 baton crit now (Original: 60)
 	knockdown_time = 5 SECONDS
 	clumsy_knockdown_time = 15 SECONDS
 	cooldown = 2.5 SECONDS
@@ -655,7 +656,7 @@
  */
 /obj/item/melee/baton/security/additional_effects_non_cyborg(mob/living/target, mob/living/user)
 	target.set_jitter_if_lower(40 SECONDS)
-	target.set_confusion_if_lower(10 SECONDS)
+	// target.set_confusion_if_lower(10 SECONDS) // DOPPLER EDIT REMOVAL
 	target.set_stutter_if_lower(16 SECONDS)
 
 	SEND_SIGNAL(target, COMSIG_LIVING_MINOR_SHOCK)

--- a/modular_doppler/modular_weapons/code/jousting.dm
+++ b/modular_doppler/modular_weapons/code/jousting.dm
@@ -1,0 +1,15 @@
+/datum/component/jousting/Initialize(damage_boost_per_tile, knockdown_chance_per_tile, knockdown_time, max_tile_charge, min_tile_charge, datum/callback/successful_joust_callback)
+	. = ..()
+
+	RegisterSignal(parent, COMSIG_PRE_BATON_FINALIZE_ATTACK, PROC_REF(on_successful_baton_attack))
+
+/datum/component/jousting/proc/on_successful_baton_attack(datum/source, mob/living/target, mob/user)
+	SIGNAL_HANDLER
+
+	if (!istype(parent, /obj/item/melee/baton/security))
+		return
+
+	var/obj/item/melee/baton/security/baton = parent
+	var/usable_charge = on_successful_attack(source, target, user)
+	if(usable_charge)
+		baton.on_successful_joust(target, user, usable_charge)

--- a/modular_doppler/modular_weapons/code/melee.dm
+++ b/modular_doppler/modular_weapons/code/melee.dm
@@ -1,0 +1,16 @@
+/obj/item/melee/baton
+	/// For use with jousting. For each usable jousting tile, increase the stamina damage of the jousting hit by this much.
+	var/stamina_damage_per_jousting_tile = 2
+
+/obj/item/melee/baton/Initialize(mapload)
+	. = ..()
+
+	add_jousting_component()
+
+/// Component adder proc for custom behavior, without needing to add more vars.
+/obj/item/melee/baton/proc/add_jousting_component()
+	AddComponent(/datum/component/jousting, damage_boost_per_tile = 0, knockdown_chance_per_tile = 6)
+
+/// For jousting. Called when a joust is considered successfully done.
+/obj/item/melee/baton/proc/on_successful_joust(mob/living/target, mob/user, usable_charge)
+	target.apply_damage(stamina_damage_per_jousting_tile * usable_charge, STAMINA)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6933,6 +6933,8 @@
 #include "modular_doppler\modular_vending\code\tg_vendors\megaseed.dm"
 #include "modular_doppler\modular_vending\code\tg_vendors\wardrobes.dm"
 #include "modular_doppler\modular_weapons\code\gunsets.dm"
+#include "modular_doppler\modular_weapons\code\jousting.dm"
+#include "modular_doppler\modular_weapons\code\melee.dm"
 #include "modular_doppler\modular_weapons\company_and_or_faction_based\carwo_defense_systems\gunsets.dm"
 #include "modular_doppler\modular_weapons\manufacturer_examine\code\gun_company_additions.dm"
 #include "modular_doppler\modular_weapons\manufacturer_examine\code\manufacturer_element.dm"


### PR DESCRIPTION
## About The Pull Request
Bringing them up to Nova par. You can joust with them too.

## Why It's Good For The Game
Zappy.

## Changelog
:cl:
balance: Batongs are no longer a two-hit stamcrit.
/:cl:
