### PR TITLE
fixes pockets overriding jacket transforms

### DIFF
--- a/modular_doppler/modular_cosmetics/code/jacket_pockets.dm
+++ b/modular_doppler/modular_cosmetics/code/jacket_pockets.dm
@@ -11,6 +11,7 @@
 /datum/storage/pockets/jacket
 	max_slots = 2
 	max_total_storage = 5
+	click_alt_open = FALSE
 
 /datum/storage/pockets/jacket/New(
 	atom/parent,


### PR DESCRIPTION
## About The Pull Request

jacket pockets were overriding alt click zips on jackets and such, this is a single line fix that ensures the alt click will transform jackets. pockets can still be accessed simply by clicking on the jacket, with sprite dragging being used to remove the jacket.

## Why It's Good For The Game

its a bug fix