### PR TITLE
Fix Batch | Plutonian & Age Descriptions

### DIFF
--- a/modular_doppler/languages/code/language_datums.dm
+++ b/modular_doppler/languages/code/language_datums.dm
@@ -1,11 +1,10 @@
 /obj/item/organ/internal/tongue/get_possible_languages()
-    var/list/langs = ..()
-    langs += /datum/language/konjin
-    langs += /datum/language/movespeak
-    langs += /datum/language/primitive_genemod
-    return langs
-
-
+	var/list/langs = ..()
+	langs += /datum/language/konjin
+	langs += /datum/language/gutter
+	langs += /datum/language/movespeak
+	langs += /datum/language/primitive_genemod
+	return langs
 
 /// ACTUAL LANGUAGES BEGIN HERE
 /datum/language/konjin

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/age.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/age.tsx
@@ -4,7 +4,7 @@ export const age: Feature<number> = {
   name: 'Age',
   /* DOPPLER ADDITION START */
   description:
-    "The effective and actual age of your character expressed in years. If they haven't entered cryostasis for any meaningful length of time or are otherwise uncommonly long-lived, this number is their age in years since birth.",
+    "The character's physical age, in years.  This is the age their body should be, ignoring any type of stasis or time manipulation.",
   /* DOPPLER ADDITION END */
   component: FeatureNumberInput,
 };

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/dopplershift_preferences/lore.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/dopplershift_preferences/lore.tsx
@@ -8,7 +8,7 @@ import {
 export const age_chronological: Feature<number> = {
   name: 'Age (Chronological)',
   description:
-    "The actual, physical age of your character. Applicable mostly in instances of prolonged cryogenic stasis or for lifeforms that mature or metabolize at much slower rates compared to 'standard' sector races.",
+    'The amount of time the character has existed in this world, in years.  This includes time spent in any kind of stasis, however other methods of spacetime manipulation (such as timeskips) may not necessarily apply.',
   component: FeatureNumberInput,
 };
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixed gutter (Plutonian) not being able to be spoken.

Also changed the age descriptions since they were interchanged, with the proposal by Iska.

<details>

![dreamseeker_RzpViTBwGI](https://github.com/user-attachments/assets/9d4218fc-f9c6-44ad-bbd1-66531b9c416e)
![AOQU3DpiWN](https://github.com/user-attachments/assets/8b13862a-86eb-4d65-89e0-6be2c3d24f40)
![Dhl1IFwJyW](https://github.com/user-attachments/assets/14433011-3bb1-4734-ab46-a22e713528bc)
![tuIXgzylLm](https://github.com/user-attachments/assets/fe347583-f943-472d-8f65-0dabb76cdbf2)

</details>

## Why It's Good For The Game

I HATE BUGS

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: MortoSasye
fix: Fixed Age and Age Chronological descriptions being incorrect. Also defined more what each age means.
fix: Plutonian is a tongue that can be spoken once more.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
