### PR TITLE
Fix | Iron Boots Sprite

### DIFF
--- a/modular_doppler/reagent_forging/code/forge_clothing.dm
+++ b/modular_doppler/reagent_forging/code/forge_clothing.dm
@@ -79,7 +79,7 @@
 	icon = 'modular_doppler/reagent_forging/icons/obj/forge_clothing.dmi'
 	worn_icon = 'modular_doppler/reagent_forging/icons/mob/clothing/forge_clothing.dmi'
 	supported_bodyshapes = list(BODYSHAPE_HUMANOID, BODYSHAPE_DIGITIGRADE)
-	bodyshape_icon_files = list(BODYSHAPE_HUMANOID_T = 'modular_doppler/food_replicator/icons/clothing_worn.dmi',
+	bodyshape_icon_files = list(BODYSHAPE_HUMANOID_T = 'modular_doppler/reagent_forging/icons/mob/clothing/forge_clothing.dmi',
 		BODYSHAPE_DIGITIGRADE_T = 'modular_doppler/reagent_forging/icons/mob/clothing/forge_clothing_digi.dmi')
 	icon_state = "plate_boots"
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes https://github.com/DopplerShift13/DopplerShift/issues/158 by pointing to the correct file for worn iron boots.

![Pvq5cngctw](https://github.com/user-attachments/assets/28c94547-704d-4a6d-a01b-28262b602cdd)

## Why It's Good For The Game

I Hate Bu-

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: MortoSasye
fix: Forged boots will show their correct icon once more.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
