### PR TITLE
Midround polling for antag and obsessed

### DIFF
--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_midround.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_midround.dm
@@ -263,9 +263,15 @@
 			candidates -= player // We don't autotator people in CentCom
 		else if(player.mind && (player.mind.special_role || player.mind.antag_datums?.len > 0))
 			candidates -= player // We don't autotator people with roles already
+		// DOPPLER ADDITION START
+		else if(player in rejected_traitor)
+			candidates -= player
+		else if(player in current_polling)
+			candidates -= player
+		// DOPPLER ADDITION END
 
 /datum/dynamic_ruleset/midround/from_living/autotraitor/execute()
-	var/mob/M = pick(candidates)
+	var/mob/M = pick(poll_candidates_for_one(candidates)) // DOPPLER EDIT, old code: var/mob/M = pick(candidates)
 	assigned += M
 	candidates -= M
 	var/datum/antagonist/traitor/infiltrator/sleeper_agent/newTraitor = new
@@ -848,11 +854,15 @@
 			|| candidate.stat == DEAD \
 			|| !(ROLE_OBSESSED in candidate.client?.prefs?.be_special) \
 			|| !candidate.mind.assigned_role \
+			// DOPPLER ADDITION START
+			|| (candidate in rejected_traitor) \
+			|| (candidate in current_polling) \
+			// DOPPLER ADDITION END
 		)
 			candidates -= candidate
 
 /datum/dynamic_ruleset/midround/from_living/obsessed/execute()
-	var/mob/living/carbon/human/obsessed = pick_n_take(candidates)
+	var/mob/living/carbon/human/obsessed = pick_n_take(poll_candidates_for_one(candidates)) // DOPPLER EDIT, old code: var/mob/living/carbon/human/obsessed = pick_n_take(candidates)
 	obsessed.gain_trauma(/datum/brain_trauma/special/obsessed)
 	message_admins("[ADMIN_LOOKUPFLW(obsessed)] has been made Obsessed by the midround ruleset.")
 	log_game("[key_name(obsessed)] was made Obsessed by the midround ruleset.")

--- a/modular_doppler/modular_antagonists/_dynamic_rulesets.dm
+++ b/modular_doppler/modular_antagonists/_dynamic_rulesets.dm
@@ -1,0 +1,40 @@
+/datum/dynamic_ruleset/midround/from_living
+	var/static/list/current_polling = list()
+	var/static/list/rejected_traitor = list()
+/**
+ * Polls a group of candidates to see if they want to be a sleeper agent.
+ *
+ * @param candidates a list containing a candidate mobs
+ */
+/datum/dynamic_ruleset/midround/from_living/proc/poll_candidates_for_one(candidates)
+	message_admins("Attempting to poll [length(candidates)] people individually to become [name].")
+	var/list/yes_candidates = list()
+	for(var/mob/living/candidate in candidates)
+		current_polling += candidate
+		yes_candidates += SSpolling.poll_candidates(
+		question = "Do you want to play as [name]? If you ignore this, you will be considered to have declined and will be inelegible for traitor/obsessed rolls this round.",
+		group = list(candidate),
+		poll_time = 15 SECONDS,
+		flash_window = TRUE,
+		start_signed_up = FALSE,
+		announce_chosen = FALSE,
+		role_name_text = "[name]",
+		alert_pic = /obj/structure/sign/poster/contraband/gorlex_recruitment,
+		custom_response_messages = list(
+			POLL_RESPONSE_SIGNUP = "You have signed up to be an antagonist!",
+			POLL_RESPONSE_ALREADY_SIGNED = "You are already signed up to be an antagonist.",
+			POLL_RESPONSE_NOT_SIGNED = "You aren't signed up to be an antagonist.",
+			POLL_RESPONSE_TOO_LATE_TO_UNREGISTER = "It's too late to decide against being antagonist.",
+			POLL_RESPONSE_UNREGISTERED = "You decide against being an antagonist.",
+		),
+		chat_text_border_icon = /obj/structure/sign/poster/contraband/gorlex_recruitment,
+	)
+		if(length(yes_candidates))
+			current_polling -= candidate
+			break
+		else
+			message_admins("Candidate [candidate] has declined to be [name].")
+			rejected_traitor += candidate
+			current_polling -= candidate
+
+	return yes_candidates

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6657,6 +6657,7 @@
 #include "modular_doppler\loadout_categories\categories\shoes.dm"
 #include "modular_doppler\loadout_categories\categories\toys.dm"
 #include "modular_doppler\loadout_categories\categories\undersuit.dm"
+#include "modular_doppler\modular_antagonists\_dynamic_rulesets.dm"
 #include "modular_doppler\modular_antagonists\changeling\changeling.dm"
 #include "modular_doppler\modular_antagonists\datums\antag_recipes.dm"
 #include "modular_doppler\modular_antagonists\sapper_gang\sapper.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

https://github.com/user-attachments/assets/93681233-70c0-488b-883f-87db7a3a2135

## Why It's Good For The Game

Like Nova, except it gets merged this time.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Midround antag and obsessed will now poll if you want the roll, instead of forcing itself upon you
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
