### PR TITLE
[TESTMERGE ONLY] ID Trim Fix (You Can Buy Shit Now)

### DIFF
--- a/code/datums/id_trim/_id_trim.dm
+++ b/code/datums/id_trim/_id_trim.dm
@@ -30,9 +30,6 @@
 	var/pointer_color
 
 /datum/id_trim/proc/find_job()
-	for (var/datum/job/job as anything in SSjob.all_occupations)
-		if (job.title == assignment)
-			return job
 	return null
 
 /// Returns the SecHUD job icon state for whatever this object's ID card is, if it has one.

--- a/code/datums/id_trim/jobs.dm
+++ b/code/datums/id_trim/jobs.dm
@@ -76,6 +76,9 @@
 
 	return TRUE
 
+/datum/id_trim/job/find_job()
+	return job
+
 /datum/id_trim/job/assistant
 	assignment = JOB_ASSISTANT
 	trim_state = "trim_assistant"


### PR DESCRIPTION
## About The Pull Request
Early pull of https://github.com/tgstation/tgstation/pull/86894

## Why It's Good For The Game
Vending machines

## Changelog
:cl:
fix: Fixed trims which did have an associated job but whose assignment didn't match a job title causing null jobs to be assigned to accounts. This fixes departmental security officers not being able to purchase things from the security vendors.
/:cl: