### PR TITLE
Adds the 'Synth-drink' tab to the booze-o-mat and improves the glassware tab

### DIFF
--- a/code/modules/vending/boozeomat.dm
+++ b/code/modules/vending/boozeomat.dm
@@ -58,7 +58,7 @@
 				/obj/item/reagent_containers/cup/soda_cans/melon_soda = 5,
 			),
 		),
-
+		/* DOPPLER EDIT REMOVAL START
 		list(
 			"name" = "Glassware",
 			"icon" = "wine-glass",
@@ -69,7 +69,7 @@
 				/obj/item/reagent_containers/cup/glass/bottle = 15,
 				/obj/item/reagent_containers/cup/glass/bottle/small = 15,
 			),
-		),
+		), DOPPLER EDIT REMOVAL END*/
 	)
 
 	contraband = list(

--- a/modular_doppler/modular_vending/code/tg_vendors/boozeomat.dm
+++ b/modular_doppler/modular_vending/code/tg_vendors/boozeomat.dm
@@ -1,10 +1,27 @@
 /obj/machinery/vending/boozeomat
 	product_categories_doppler = list(
 		list(
-			"name" = "Synth",
+			"name" = "Synth-Drinks",
 			"icon" = "robot",
 			"products" = list(
-	//		/obj/item/reagent_containers/cup/soda_cans/doppler/synthanolcan = 6,
-				),
+				/obj/item/reagent_containers/cup/soda_cans/doppler/synthanolcan = 6,
+				/obj/item/reagent_containers/cup/soda_cans/doppler/lubricola = 3,
+				/obj/item/reagent_containers/cup/soda_cans/doppler/welding_fizz = 3,
 			),
+		),
+		list(
+			"name" = "Glassware",
+			"icon" = "wine-glass",
+			"products" = list(
+				/obj/item/reagent_containers/cup/glass/drinkingglass = 30,
+				/obj/item/reagent_containers/cup/glass/drinkingglass/shotglass = 12,
+				/obj/item/reagent_containers/cup/glass/colocup = 12,
+				/obj/item/reagent_containers/cup/glass/flask = 3,
+				/obj/item/reagent_containers/cup/glass/bottle = 15,
+				/obj/item/reagent_containers/cup/glass/bottle/small = 15,
+				/obj/item/reagent_containers/cup/beaker/large = 3,
+				/obj/item/reagent_containers/cup/beaker = 6,
+				/obj/item/reagent_containers/cup/tube = 6,
+			),
+		),
 	)

--- a/modular_doppler/modular_vending/code/tg_vendors/cola.dm
+++ b/modular_doppler/modular_vending/code/tg_vendors/cola.dm
@@ -1,5 +1,0 @@
-/obj/machinery/vending/cola
-	products_doppler = list(
-		/obj/item/reagent_containers/cup/soda_cans/doppler/lubricola = 10,
-		/obj/item/reagent_containers/cup/soda_cans/doppler/welding_fizz = 10,
-	)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6934,7 +6934,6 @@
 #include "modular_doppler\modular_vending\code\tg_vendors\autodrobe.dm"
 #include "modular_doppler\modular_vending\code\tg_vendors\boozeomat.dm"
 #include "modular_doppler\modular_vending\code\tg_vendors\clothesmate.dm"
-#include "modular_doppler\modular_vending\code\tg_vendors\cola.dm"
 #include "modular_doppler\modular_vending\code\tg_vendors\engivend.dm"
 #include "modular_doppler\modular_vending\code\tg_vendors\games.dm"
 #include "modular_doppler\modular_vending\code\tg_vendors\megaseed.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![vEOBkkyKf1](https://github.com/user-attachments/assets/6ca62a3c-b1b2-460e-9275-373bba176a23)

## Why It's Good For The Game

Robots like to get drunk.

## Changelog
:cl:
add: Synthanol, welding fizz and lubricola is available in the booze-o-mat
add: The booze-o-mat glassware tab is improved
/:cl:
