### PR TITLE
[NONMODULAR] Xenomorph RR Nerfs

### DIFF
--- a/code/modules/mob/living/carbon/alien/adult/adult.dm
+++ b/code/modules/mob/living/carbon/alien/adult/adult.dm
@@ -94,26 +94,29 @@ GLOBAL_LIST_INIT(strippable_alien_humanoid_items, create_strippable_list(list(
 				ADD_TRAIT(pulling, TRAIT_FLOORED, CHOKEHOLD_TRAIT)
 
 /mob/living/carbon/alien/adult/mouse_drop_receive(atom/dropping, mob/user, params)
-	if(devour_lad(dropping))
-		return
+	/// DOPPLER SHIFT REMOVAL BEGN
+	/*if(devour_lad(dropping))
+		return*/
+	/// DOPPLER SHIFT REMOVAL END
 	return ..()
 
 /// Returns FALSE if we're not allowed to eat it, true otherwise
 /mob/living/carbon/alien/adult/proc/can_consume(atom/movable/poor_soul)
-	if(!isliving(poor_soul) || pulling != poor_soul)
+	/// DOPPLER SHIFT REMOVAL BEGIN
+	/*if(!isliving(poor_soul) || pulling != poor_soul)
 		return FALSE
 	if(incapacitated || grab_state < GRAB_AGGRESSIVE || stat != CONSCIOUS)
 		return FALSE
 	if(get_dir(src, poor_soul) != dir) // Gotta face em 4head
-		return FALSE
-	return TRUE
+		return FALSE*/
+	/// DOPPLER SHIFT REMOVAL END
+	return FALSE /// DOPPLER SHIFT EDIT: NEVER ALLOW THIS, NOT EVEN WITH ADMINBUS.
 
 /// Attempts to devour the passed in thing in devour_time seconds
 /// The mob needs to be consumable, as decided by [/mob/living/carbon/alien/adult/proc/can_consume]
 /// Returns FALSE if the attempt never even started, TRUE otherwise
 /mob/living/carbon/alien/adult/proc/devour_lad(atom/movable/candidate, devour_time = 13.5 SECONDS)
-	/// DOPPLER SHIFT REMOVAL BEGIN
-	/*setDir(get_dir(src, candidate))
+	setDir(get_dir(src, candidate))
 	if(!can_consume(candidate))
 		return FALSE
 	var/mob/living/lucky_winner = candidate
@@ -139,9 +142,7 @@ GLOBAL_LIST_INIT(strippable_alien_humanoid_items, create_strippable_list(list(
 			span_userdanger("[lucky_winner] devours you!"))
 	log_combat(src, lucky_winner, "devoured")
 	melting_pot.consume_thing(lucky_winner)
-	return TRUE*/
-	/// DOPPLER SHIFT REMOVAL END
-	return FALSE
+	return TRUE
 
 /mob/living/carbon/alien/adult/get_butt_sprite()
 	return icon('icons/mob/butts.dmi', BUTT_SPRITE_XENOMORPH)

--- a/code/modules/mob/living/carbon/alien/adult/adult.dm
+++ b/code/modules/mob/living/carbon/alien/adult/adult.dm
@@ -112,7 +112,8 @@ GLOBAL_LIST_INIT(strippable_alien_humanoid_items, create_strippable_list(list(
 /// The mob needs to be consumable, as decided by [/mob/living/carbon/alien/adult/proc/can_consume]
 /// Returns FALSE if the attempt never even started, TRUE otherwise
 /mob/living/carbon/alien/adult/proc/devour_lad(atom/movable/candidate, devour_time = 13.5 SECONDS)
-	setDir(get_dir(src, candidate))
+	/// DOPPLER SHIFT REMOVAL BEGIN
+	/*setDir(get_dir(src, candidate))
 	if(!can_consume(candidate))
 		return FALSE
 	var/mob/living/lucky_winner = candidate
@@ -138,7 +139,9 @@ GLOBAL_LIST_INIT(strippable_alien_humanoid_items, create_strippable_list(list(
 			span_userdanger("[lucky_winner] devours you!"))
 	log_combat(src, lucky_winner, "devoured")
 	melting_pot.consume_thing(lucky_winner)
-	return TRUE
+	return TRUE*/
+	/// DOPPLER SHIFT REMOVAL END
+	return FALSE
 
 /mob/living/carbon/alien/adult/get_butt_sprite()
 	return icon('icons/mob/butts.dmi', BUTT_SPRITE_XENOMORPH)

--- a/code/modules/mob/living/carbon/alien/organs.dm
+++ b/code/modules/mob/living/carbon/alien/organs.dm
@@ -199,12 +199,14 @@
 		thing.acid_act(75, 10)
 
 /obj/item/organ/internal/stomach/alien/proc/consume_thing(atom/movable/thing)
-	RegisterSignal(thing, COMSIG_MOVABLE_MOVED, PROC_REF(content_moved))
+	/// DOPPLER SHIFT REMOVAL BEGIN - we take no chances.
+	/*RegisterSignal(thing, COMSIG_MOVABLE_MOVED, PROC_REF(content_moved))
 	RegisterSignal(thing, COMSIG_QDELETING, PROC_REF(content_deleted))
 	if(isliving(thing))
 		RegisterSignal(thing, COMSIG_LIVING_DEATH, PROC_REF(content_died))
 	stomach_contents += thing
-	thing.forceMove(owner || src) // We assert that if we have no owner, we will not be nullspaced
+	thing.forceMove(owner || src)*/ // We assert that if we have no owner, we will not be nullspaced
+	/// DOPPLER SHIFT REMOVAL BEGIN
 
 /obj/item/organ/internal/stomach/alien/proc/content_died(atom/movable/source)
 	SIGNAL_HANDLER

--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -134,15 +134,18 @@
 		new_xeno.remove_traits(list(TRAIT_HANDS_BLOCKED, TRAIT_IMMOBILIZED, TRAIT_NO_TRANSFORM), type)
 		new_xeno.RemoveInvisibility(type)
 
-	if(gib_on_success)
+	/// DOPPLER SHIFT REMOVAL BEGIN
+	/*if(gib_on_success)
 		new_xeno.visible_message(span_danger("[new_xeno] bursts out of [owner] in a shower of gore!"), span_userdanger("You exit [owner], your previous host."), span_hear("You hear organic matter ripping and tearing!"))
 		owner.investigate_log("has been gibbed by an alien larva.", INVESTIGATE_DEATHS)
 		owner.gib(DROP_ORGANS|DROP_BODYPARTS)
-	else
-		new_xeno.visible_message(span_danger("[new_xeno] wriggles out of [owner]!"), span_userdanger("You exit [owner], your previous host."))
-		owner.log_message("had an alien larva within them escape (without being gibbed).", LOG_ATTACK, log_globally = FALSE)
-		owner.adjustBruteLoss(40)
-		owner.cut_overlay(overlay)
+	else*/
+	/// DOPPLER SHIFT REMOVAL END, EDIT BEGIN (REMOVING INDENTS)
+	new_xeno.visible_message(span_danger("[new_xeno] wriggles out of [owner]!"), span_userdanger("You exit [owner], your previous host."))
+	owner.log_message("had an alien larva within them escape (without being gibbed).", LOG_ATTACK, log_globally = FALSE)
+	owner.adjustBruteLoss(40)
+	owner.cut_overlay(overlay)
+	/// DOPPLER SHIFT EDIT END
 	qdel(src)
 
 


### PR DESCRIPTION
## About The Pull Request

Nerrfs xenomorphs by removing the ability to RR people with vore (adult xenomorphs) or debrain gib them as a larva.  TG "Close This Fetish PR" Station be like.

## Why It's Good For The Game

If we wanted vore, we'd be making Vorestation.  Fuck's sakes

## Changelog

:cl:
del: xenomorphs can't vore you
del: xenomorph larva won't debrain gib you
/:cl:

