### PR TITLE
Fixes a runtime issue involving character loading and languages.

### DIFF
--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -308,7 +308,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	//Quirks
 	all_quirks = save_data?["all_quirks"]
 	/// DOPPLER SHIFT ADDITION BEGIN
-	var/list/save_languages = SANITIZE_LIST(save_data["languages"])
+	var/list/save_languages = SANITIZE_LIST(save_data?["languages"])
 	for(var/language in save_languages)
 		var/value = save_languages[language]
 		save_languages -= language


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

hi yeah i was reading the repo and testing master while waiting for the application and this was getting in the way so-

Anyhow, it seems the occupation and language menus were breaking due to languages runtiming at this line:

https://github.com/DopplerShift13/DopplerShift/blob/c4f78bcac0ef990a240bff1f38fbb62fba9d4c98/modular_doppler/languages/code/language%20menu/client_languages.dm#L68

Which was due to `preferences.all_quirks` being `null` even though it should never be, which I traced back to us using `save_data["languages"]` where `save_data` could be `null` causing `load_character(...)` to runtime.

Setting it to `save_data?["languages"]` parallel to all the other `save_data` calls there seems to fix it just fine!

yep that's a languages menu 👍 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes runtimes.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed language, occupation, and quirk menu breaking if there is no existing save data.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
