### PR TITLE
Space Sappers credit miner balancing & fixes

### DIFF
--- a/_maps/shuttles/~doppler_shuttles/pirate_sapper.dmm
+++ b/_maps/shuttles/~doppler_shuttles/pirate_sapper.dmm
@@ -16,6 +16,7 @@
 	id = "pirate_sapper_shutter_L";
 	dir = 8
 	},
+/obj/structure/fans/tiny/shield,
 /turf/open/floor/plating,
 /area/shuttle/pirate/sapper)
 "fK" = (
@@ -105,6 +106,7 @@
 /obj/docking_port/mobile/pirate/sapper{
 	dir = 4
 	},
+/obj/structure/fans/tiny/shield,
 /turf/open/floor/plating,
 /area/shuttle/pirate/sapper)
 "pt" = (
@@ -212,11 +214,11 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/pirate/sapper)
 "uD" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/mask/gas/atmos/sapper{
 	pixel_x = -2;
 	pixel_y = -3
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/pirate/sapper)
 "vB" = (
@@ -237,6 +239,14 @@
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/pirate/sapper)
 "xf" = (
+/obj/machinery/ore_silo/colony_lathe,
+/obj/structure/sign/poster/contraband/power/directional/north,
+/obj/effect/turf_decal/stripes/box,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/hypernoblium_crystal,
+/obj/item/hypernoblium_crystal,
+/obj/item/hypernoblium_crystal,
+/obj/item/hypernoblium_crystal,
 /obj/item/stack/sheet/iron/twenty,
 /obj/item/stack/sheet/glass{
 	amount = 20
@@ -248,13 +258,9 @@
 /obj/item/stack/sheet/mineral/gold{
 	amount = 5
 	},
-/obj/machinery/ore_silo/colony_lathe,
 /obj/item/stack/sheet/mineral/silver{
 	amount = 5
 	},
-/obj/structure/sign/poster/contraband/power/directional/north,
-/obj/effect/turf_decal/stripes/box,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
 /area/shuttle/pirate/sapper)
 "xA" = (
@@ -280,9 +286,9 @@
 /area/shuttle/pirate/sapper)
 "zk" = (
 /obj/structure/cable,
-/obj/item/storage/toolbox/emergency/turret{
-	pixel_x = 10;
-	pixel_y = 9
+/obj/item/storage/toolbox/emergency/turret/sapper{
+	pixel_x = 3;
+	pixel_y = 4
 	},
 /turf/open/floor/catwalk_floor/iron_white,
 /area/shuttle/pirate/sapper)
@@ -337,6 +343,7 @@
 	id = "pirate_sapper_shutter_L";
 	dir = 8
 	},
+/obj/structure/fans/tiny/shield,
 /turf/open/floor/plating,
 /area/shuttle/pirate/sapper)
 "DT" = (
@@ -390,19 +397,19 @@
 /obj/item/stack/sheet/rglass{
 	amount = 20
 	},
-/obj/item/holosign_creator/atmos,
 /obj/item/radio/intercom/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/sheet/mineral/wood{
 	amount = 20
 	},
+/obj/item/forcefield_projector,
 /turf/open/floor/catwalk_floor/iron_white,
 /area/shuttle/pirate/sapper)
 "JD" = (
 /obj/structure/cable,
-/obj/item/storage/toolbox/emergency/turret{
-	pixel_x = -8;
-	pixel_y = -4
+/obj/item/storage/toolbox/emergency/turret/sapper{
+	pixel_x = -6;
+	pixel_y = -6
 	},
 /turf/open/floor/catwalk_floor/iron_white,
 /area/shuttle/pirate/sapper)
@@ -467,12 +474,12 @@
 /obj/item/stack/sheet/rglass{
 	amount = 20
 	},
-/obj/item/holosign_creator/atmos,
 /obj/item/radio/intercom/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/sheet/mineral/wood{
 	amount = 20
 	},
+/obj/item/forcefield_projector,
 /turf/open/floor/catwalk_floor/iron_white,
 /area/shuttle/pirate/sapper)
 "Sa" = (
@@ -491,6 +498,7 @@
 	id = "pirate_sapper_shutter_R";
 	dir = 4
 	},
+/obj/structure/fans/tiny/shield,
 /turf/open/floor/plating,
 /area/shuttle/pirate/sapper)
 "TF" = (
@@ -507,11 +515,11 @@
 /turf/open/floor/plating,
 /area/shuttle/pirate/sapper)
 "Wo" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/mask/gas/atmos/sapper/partner{
 	pixel_x = 2;
 	pixel_y = 4
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/pirate/sapper)
 "WY" = (

--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -2,7 +2,7 @@
 #define CLAMPED_OFF 1
 #define OPERATING 2
 
-#define FRACTION_TO_RELEASE 25
+#define FRACTION_TO_RELEASE 5 // DOPPLER EDIT - buff powersink/creditminer, old code: 25
 #define ALERT 90
 #define MINIMUM_HEAT 20000
 

--- a/modular_doppler/colony_fabricator/code/colony_fabricator.dm
+++ b/modular_doppler/colony_fabricator/code/colony_fabricator.dm
@@ -7,7 +7,7 @@
 	icon_state = "colony_lathe"
 	base_icon_state = "colony_lathe"
 	circuit = null
-	production_animation = "colony_lathe_n"
+	production_animation = "colony_lathe_working"
 	light_color = LIGHT_COLOR_BRIGHT_YELLOW
 	light_power = 5
 	allowed_buildtypes = COLONY_FABRICATOR

--- a/modular_doppler/modular_antagonists/sapper_gang/sapper_outfits.dm
+++ b/modular_doppler/modular_antagonists/sapper_gang/sapper_outfits.dm
@@ -128,12 +128,12 @@
 	preload = FALSE
 
 /obj/item/storage/belt/utility/sapper/PopulateContents() //its just a complete mishmash
-	new /obj/item/forcefield_projector(src)
+	new /obj/item/screwdriver/omni_drill(src)
 	new /obj/item/multitool(src)
 	new /obj/item/wrench/combat(src)
 	new /obj/item/construction/rcd/loaded(src)
 	new /obj/item/screwdriver/caravan(src)
-	new /obj/item/inducer/syndicate(src)
+	new /obj/item/crowbar/large/old(src)
 	new /obj/item/weldingtool/abductor(src)
 
 /obj/item/storage/toolbox/guncase/modular/carwo_large_case/sapper

--- a/modular_doppler/modular_antagonists/sapper_gang/sapper_shuttle_equipment.dm
+++ b/modular_doppler/modular_antagonists/sapper_gang/sapper_shuttle_equipment.dm
@@ -32,6 +32,9 @@
 	shuttleId = "pirate_sapper"
 	shuttlePortId = "sapper_custom"
 
+/obj/item/storage/toolbox/emergency/turret/sapper/set_faction(obj/machinery/porta_turret/turret, mob/user)
+	turret.faction = list(FACTION_SAPPER)
+
 /mob/living/basic/bot/medbot/sapper
 	name = "Manon"
 	medkit_type = /obj/item/storage/medkit/fire


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Still trying to make this playable :)

## Why It's Good For The Game

The sapper can sap properly, also the turrets don't friendly fire anymore lol.

## Changelog

:cl:
balance: Balances the powersink and creditminer to release more internal heat per tick (so they explode less likely)
fix: fixed the rapid construction fabricator's missing sprite when busy
fix: fixed the Space Sapper's turrets friendly firing
qol: Moves some of the Space Sapper's tools around
balance: Gives the Space Sappers hypernob crystals, just enough for both their uniforms.
balance: The Space Sapper Shuttle now has energy fields at their ports, but is no longer stocked with ATMOS fans
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
