### PR TITLE
Dopplerboop update: Adds mute option and volume

### DIFF
--- a/modular_doppler/_HELPERS/preferences.dm
+++ b/modular_doppler/_HELPERS/preferences.dm
@@ -12,5 +12,5 @@ GLOBAL_LIST_INIT(dopplerboop_voice_types, sort_list(list(
 	"jock",
 	"lazy",
 	"smug",
-	"mute"
+	"mute",
 )))

--- a/modular_doppler/_HELPERS/preferences.dm
+++ b/modular_doppler/_HELPERS/preferences.dm
@@ -11,5 +11,6 @@ GLOBAL_LIST_INIT(dopplerboop_voice_types, sort_list(list(
 	"grumpy",
 	"jock",
 	"lazy",
-	"smug"
+	"smug",
+	"mute"
 )))

--- a/modular_doppler/dopplerboop/dopplerboops.dm
+++ b/modular_doppler/dopplerboop/dopplerboops.dm
@@ -40,6 +40,8 @@
 
 /datum/component/dopplerboop/proc/handle_booping(mob/living/carbon/human/dopplerbooper, list/speech_args, list/speech_spans, list/speech_mods)
 	chosen_boop = dopplerbooper?.voice_type || random_voice_type() // Uses the boop chosen by the player. If it's null for whatever unholy reason, it should chose a completely random voice for every single phonetic which should be funny.
+	if(chosen_boop == "mute")
+		return
 	var/message = speech_args[SPEECH_MESSAGE]
 	var/initial_dopplerboop_time = last_dopplerboop
 	var/initial_volume = volume
@@ -97,4 +99,6 @@
 	if(!volume || (last_dopplerboop != initial_dopplerboop_time) || !final_boop)
 		return
 	for(var/mob/hearer as anything in hearers)
+		var/user_volume = hearer.client.prefs.read_preference(/datum/preference/numeric/voice_volume)
+		volume = volume*(user_volume / 10)
 		hearer.playsound_local(turf_source = get_turf(dopplerbooper), sound_to_use = final_boop, vol = volume, vary = TRUE, frequency = freq, falloff_distance = falloff_exponent, max_distance = 16)

--- a/modular_doppler/dopplerboop/dopplerboops.dm
+++ b/modular_doppler/dopplerboop/dopplerboops.dm
@@ -99,6 +99,6 @@
 	if(!volume || (last_dopplerboop != initial_dopplerboop_time) || !final_boop)
 		return
 	for(var/mob/hearer as anything in hearers)
-		var/user_volume = hearer.client.prefs.read_preference(/datum/preference/numeric/voice_volume)
+		var/user_volume = hearer.client?.prefs.read_preference(/datum/preference/numeric/voice_volume)
 		volume = volume*(user_volume / 10)
 		hearer.playsound_local(turf_source = get_turf(dopplerbooper), sound_to_use = final_boop, vol = volume, vary = TRUE, frequency = freq, falloff_distance = falloff_exponent, max_distance = 16)

--- a/modular_doppler/modular_customization/preferences/dopplerboop.dm
+++ b/modular_doppler/modular_customization/preferences/dopplerboop.dm
@@ -6,6 +6,16 @@
     savefile_key = "hear_dopplerboop"
     savefile_identifier = PREFERENCE_PLAYER
 
+/datum/preference/numeric/voice_volume
+	savefile_key = "voice_volume"
+	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
+	savefile_identifier = PREFERENCE_PLAYER
+	minimum = 0
+	maximum = 100
+
+/datum/preference/numeric/voice_volume/create_default_value()
+	return maximum
+
 //Character preferences
 
 /datum/preference/choiced/voice_type

--- a/modular_doppler/modular_customization/preferences/middleware/dopplerboops.dm
+++ b/modular_doppler/modular_customization/preferences/middleware/dopplerboops.dm
@@ -13,6 +13,7 @@
 	var/boop_letter = null
 	var/dopplerboop_delay_cumulative = 0
 	var/sound/final_boop = null
+	var/user_volume = user.client.prefs.read_preference(/datum/preference/numeric/voice_volume)
 
 	for(var/i in 1 to min(length(all_boops), MAX_DOPPLERBOOP_CHARACTERS))
 		var/volume = DOPPLERBOOP_DEFAULT_VOLUME
@@ -35,6 +36,7 @@
 			else
 				variation = rand(1, 5)
 			final_boop = "modular_doppler/dopplerboop/voices/[chosen_boop]/[boop_letter][variation].wav"
+		volume = volume*(user_volume / 10)
 		addtimer(CALLBACK(user, TYPE_PROC_REF(/mob, playsound_local), null, final_boop, volume), dopplerboop_delay_cumulative + current_delay)
 		dopplerboop_delay_cumulative += current_delay
 
@@ -43,5 +45,7 @@
 		return TRUE
 	COOLDOWN_START(src, dopplerboop_cooldown, 5 SECONDS)
 	var/chosen_boop = user?.client?.prefs.read_preference(/datum/preference/choiced/voice_type) || random_voice_type()
+	if(chosen_boop == "mute")
+		return
 	INVOKE_ASYNC(src, PROC_REF(debug_booping), user, chosen_boop)
 	return TRUE

--- a/modular_doppler/modular_customization/preferences/middleware/dopplerboops.dm
+++ b/modular_doppler/modular_customization/preferences/middleware/dopplerboops.dm
@@ -13,7 +13,7 @@
 	var/boop_letter = null
 	var/dopplerboop_delay_cumulative = 0
 	var/sound/final_boop = null
-	var/user_volume = user.client.prefs.read_preference(/datum/preference/numeric/voice_volume)
+	var/user_volume = user.client?.prefs.read_preference(/datum/preference/numeric/voice_volume)
 
 	for(var/i in 1 to min(length(all_boops), MAX_DOPPLERBOOP_CHARACTERS))
 		var/volume = DOPPLERBOOP_DEFAULT_VOLUME

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/dopplershift_preferences/dopplerboop.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/dopplershift_preferences/dopplerboop.tsx
@@ -1,4 +1,9 @@
-import { CheckboxInput, FeatureToggle } from '../base';
+import {
+  CheckboxInput,
+  FeatureNumeric,
+  FeatureSliderInput,
+  FeatureToggle,
+} from '../base';
 
 export const hear_dopplerboop: FeatureToggle = {
   name: 'Enable voice mumbles',
@@ -6,4 +11,11 @@ export const hear_dopplerboop: FeatureToggle = {
   description:
     'Adds a semi-syllable based voice generation system to all characters.',
   component: CheckboxInput,
+};
+
+export const voice_volume: FeatureNumeric = {
+  name: 'Voice volume',
+  category: 'SOUND',
+  description: 'Sets the volume used for dopplerboop voices.',
+  component: FeatureSliderInput,
 };


### PR DESCRIPTION
## About The Pull Request

Adds a volume slider under sound options for people that want them to be quieter. Also adds a 'mute' option to the voices for people that want to make no sound.

## Why It's Good For The Game

User requested features !!

## Changelog
:cl:
add: mute dopplerboop voice
add: dopplerboop volume slider
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
