### PR TITLE
[NONMODULAR] RadiationLand-B-Gone

### DIFF
--- a/_maps/mining_configs/iceland.json
+++ b/_maps/mining_configs/iceland.json
@@ -25,6 +25,7 @@
 			"Linkage": null
 		},
 		{
+			"Mining": true,
 			"No Parallax": true,
 			"Weather_Snowstorm": true,
 			"Ice Ruins": true,

--- a/code/datums/weather/weather_types/radiation_storm.dm
+++ b/code/datums/weather/weather_types/radiation_storm.dm
@@ -20,7 +20,7 @@
 	protected_areas = list(/area/station/maintenance, /area/station/ai_monitored/turret_protected/ai_upload, /area/station/ai_monitored/turret_protected/ai_upload_foyer,
 							/area/station/ai_monitored/turret_protected/aisat/maint, /area/station/ai_monitored/command/storage/satellite,
 							/area/station/ai_monitored/turret_protected/ai, /area/station/commons/storage/emergency/starboard, /area/station/commons/storage/emergency/port,
-							/area/shuttle, /area/station/security/prison/safe, /area/station/security/prison/toilet, /area/mine/maintenance, /area/icemoon/underground, /area/ruin/comms_agent/maint)
+							/area/shuttle, /area/station/security/prison/safe, /area/station/security/prison/toilet, /area/mine/maintenance, /area/icemoon/underground, /area/ruin/comms_agent/maint, /area/ruin, /area/ruin/unpowered/primitive_genemod_den) /// DOPPLER SHIFT EDIT: adding ruins as protected areas, hearthkin explicitly protected
 	target_trait = ZTRAIT_STATION
 
 	immunity_type = TRAIT_RADSTORM_IMMUNE
@@ -51,8 +51,10 @@
 	if (SSradiation.wearing_rad_protected_clothing(human))
 		return
 
-	human.random_mutate_unique_identity()
-	human.random_mutate_unique_features()
+	/// DOPPLER SHIFT REMOVAL BEGIN: getting bad mutations is horrid enough already, we don't need to be taking people's fucking snouts off
+	/*human.random_mutate_unique_identity()
+	human.random_mutate_unique_features()*/
+	/// DOPPLER SHIFT REMOVAL END
 
 	if(prob(50))
 		do_mutate(human)


### PR DESCRIPTION
## About The Pull Request

Protects ruins and explicitly Hearthkin ruins from radstorms.  Also minorly nerfs radstorms by removing their ability to scramble your features.  I don't care how fucking radioactive they are, your whole-ass snout isn't going to fall off after five seconds of exposure.  That was a stupid feature.  Also sets the top level of Iceland to have the Mining Z-Trait.  I don't know how I missed that on the first pass, but it's important.

## Why It's Good For The Game

Let's not give the poor cats cancer, yeah?

## Changelog

:cl:
del: feature mutations from radstorms, your snout won't fall off anymore
qol: hearthkin & ruins writ large are now protected from radstorms
/:cl:

