### PR TITLE
[NONMODULAR] Human Authority Defaults Consistency

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -108,7 +108,7 @@
 /datum/config_entry/flag/protect_assistant_from_antagonist //If assistants can be traitor/cult/other
 
 /datum/config_entry/string/human_authority //Controls how to enforce human authority
-	default = "HUMAN_WHITELIST"
+	default = "DISABLED"
 
 /////////////////////////////////////////////////Outdated human authority settings
 /datum/config_entry/flag/enforce_human_authority

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -108,7 +108,7 @@
 /datum/config_entry/flag/protect_assistant_from_antagonist //If assistants can be traitor/cult/other
 
 /datum/config_entry/string/human_authority //Controls how to enforce human authority
-	default = "DISABLED"
+	default = "DISABLED" /// DOPPLER SHIFT EDIT: disabled is default.
 
 /////////////////////////////////////////////////Outdated human authority settings
 /datum/config_entry/flag/enforce_human_authority

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -127,7 +127,8 @@ PROTECT_ROLES_FROM_ANTAGONIST
 ## "HUMAN_WHITELIST": all heads-of-staff jobs will be able to be played by non-humans, unless that job incorporates the "human only" flag (Which can be configured via a variable or the job config txt).
 ## "NON_HUMAN_WHITELIST": non-humans will not be able to play as heads of staff, unless that job incorporates the "allow non-humans" flag (Which can be configured via a variable or the job config txt).
 ## "ENFORCED": non-humans cannot be heads of staff, only humans can. the "allow non-humans" setting will be ignored.
-HUMAN_AUTHORITY HUMAN_WHITELIST
+## Uncomment to enable a human authority mode of your choice.
+#HUMAN_AUTHORITY HUMAN_WHITELIST
 
 ## If late-joining players have a chance to become a traitor/changeling
 ALLOW_LATEJOIN_ANTAGONISTS


### PR DESCRIPTION
## About The Pull Request

Port of tgstation/tgstation#87380 with an edit marker until such time as someone up there can actually be asked to re-review it and fix things.  This only effects test instances and servers without a static config, same as upstream.

## Why It's Good For The Game

I'm going to explode if human authority continues to be enforced.  Space racism is fucking cringe.

## Changelog

:cl:
del: human authority is no longer default for nonstatic configs
/:cl:
