### PR TITLE
[TM ONLY] Hotfix belt loadout eating PDA prefs, if there's a belt PDA it goes into left pocket and that goes into bacpack

### DIFF
--- a/modular_doppler/loadout_categories/categories/belts.dm
+++ b/modular_doppler/loadout_categories/categories/belts.dm
@@ -14,7 +14,7 @@
 /datum/loadout_item/belts/insert_path_into_outfit(datum/outfit/outfit, mob/living/carbon/human/equipper, visuals_only = FALSE)
 	if(outfit.belt)
 		if(istype(outfit, /datum/outfit/job))
-			var/datum/outfit/job/job_outfit
+			var/datum/outfit/job/job_outfit = outfit
 			if(job_outfit.pda_slot == ITEM_SLOT_BELT)
 				LAZYADD(job_outfit.backpack_contents, item_path)
 				return

--- a/modular_doppler/loadout_categories/categories/belts.dm
+++ b/modular_doppler/loadout_categories/categories/belts.dm
@@ -13,6 +13,11 @@
 
 /datum/loadout_item/belts/insert_path_into_outfit(datum/outfit/outfit, mob/living/carbon/human/equipper, visuals_only = FALSE)
 	if(outfit.belt)
+		if(istype(outfit, /datum/outfit/job))
+			var/datum/outfit/job/job_outfit
+			if(job_outfit.pda_slot == ITEM_SLOT_BELT)
+				LAZYADD(job_outfit.backpack_contents, item_path)
+				return
 		LAZYADD(outfit.backpack_contents, outfit.belt)
 	outfit.belt = item_path
 

--- a/modular_doppler/loadout_categories/categories/belts.dm
+++ b/modular_doppler/loadout_categories/categories/belts.dm
@@ -16,7 +16,10 @@
 		if(istype(outfit, /datum/outfit/job))
 			var/datum/outfit/job/job_outfit = outfit
 			if(job_outfit.pda_slot == ITEM_SLOT_BELT)
-				LAZYADD(job_outfit.backpack_contents, item_path)
+				LAZYADD(job_outfit.backpack_contents, job_outfit.l_pocket)
+				job_outfit.pda_slot = ITEM_SLOT_LPOCKET
+				job_outfit.l_pocket = outfit.belt
+				outfit.belt = item_path
 				return
 		LAZYADD(outfit.backpack_contents, outfit.belt)
 	outfit.belt = item_path


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

See title.
Belt loadouts were overriding job outfit belt PDAs going into the belt slot and thus blocking prefs from being set to them.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Test rounds less jank around the things we're actually testing.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: If your job has a PDA on the belt, PDA goes into the left pocket (which goes into your backpack instead) so it doesn't eat your PDA prefs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
