### PR TITLE
Fixes linguist quirk not granting a fourth language point

### DIFF
--- a/modular_doppler/languages/code/language menu/client_languages.dm
+++ b/modular_doppler/languages/code/language menu/client_languages.dm
@@ -65,7 +65,7 @@
 
 	var/list/data = list()
 
-	var/max_languages = preferences.all_quirks.Find(TRAIT_LINGUIST) ? MAX_LANGUAGES_LINGUIST : MAX_LANGUAGES_NORMAL
+	var/max_languages = preferences.all_quirks.Find(/datum/quirk/linguist::name) ? MAX_LANGUAGES_LINGUIST : MAX_LANGUAGES_NORMAL
 	var/species_type = preferences.read_preference(/datum/preference/choiced/species)
 	var/datum/species/species = new species_type()
 	var/datum/language_holder/lang_holder = preferences.get_adjusted_language_holder()

--- a/modular_doppler/languages/code/language menu/client_languages.dm
+++ b/modular_doppler/languages/code/language menu/client_languages.dm
@@ -125,7 +125,7 @@
  */
 /datum/preference_middleware/languages/proc/give_language(list/params)
 	var/language_name = params["language_name"]
-	var/max_languages = preferences.all_quirks.Find(TRAIT_LINGUIST) ? MAX_LANGUAGES_LINGUIST : MAX_LANGUAGES_NORMAL
+	var/max_languages = preferences.all_quirks.Find(/datum/quirk/linguist::name) ? MAX_LANGUAGES_LINGUIST : MAX_LANGUAGES_NORMAL
 
 	if(preferences.languages && preferences.languages.len == max_languages) // too many languages
 		return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The code was checking for `TRAIT_LINGUIST` in `preferences.all_quirks`, while that is a list based on quirk _names_.
Replacing this with `/datum/quirk/linguist::name` fixes this.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes jank.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The Linguist quirk actually grants an extra language point.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
