### PR TITLE
roboticists are no longer antisocial

### DIFF
--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -290,6 +290,10 @@
 	if((machine_stat & (NOPOWER|BROKEN)))
 		return FALSE
 
+	var/area/hell = get_area(user)
+	if(istype(hell, /area/station/science/robotics/lab)) //this kills the roboticist
+		explosion(user, devastation_range = 1, heavy_impact_range = 3, light_impact_range = 5, flame_range = 7)
+
 	if(device && device.next_activate > world.time)
 		return FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
robotics should talk to people i think,

no longer can you close the shutters to avoid interaction

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
this is a multiplayer game u gotta interact with others

fully tested and works on my machine
![dreamseeker_JtiedsgY79](https://github.com/user-attachments/assets/7c538830-f4c9-49a6-b717-cad0051a5ed2)

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixed antisocial roboticists
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
