### PR TITLE
[TM ONLY] Early mirror of bitrunning manifest changing fix (87879)

### DIFF
--- a/code/modules/bitrunning/components/avatar_connection.dm
+++ b/code/modules/bitrunning/components/avatar_connection.dm
@@ -64,7 +64,9 @@
 	var/alias = our_client?.prefs?.read_preference(/datum/preference/name/hacker_alias) || pick(GLOB.hacker_aliases)
 
 	if(alias && avatar.real_name != alias)
-		avatar.fully_replace_character_name(avatar.real_name, alias)
+		avatar.fully_replace_character_name(newname = alias)
+
+	update_avatar_id()
 
 	for(var/skill_type in old_mind.known_skills)
 		avatar.mind.set_experience(skill_type, old_mind.get_skill_exp(skill_type), silent = TRUE)
@@ -109,6 +111,20 @@
 		COMSIG_LIVING_PILL_CONSUMED,
 		COMSIG_MOB_APPLY_DAMAGE,
 	))
+
+
+/// Updates our avatar's ID to match our avatar's name.
+/datum/component/avatar_connection/proc/update_avatar_id()
+	var/mob/living/avatar = parent
+	var/obj/item/card/id/our_id = locate() in avatar.get_all_contents()
+	if(isnull(our_id))
+		return
+
+	our_id.registered_name = avatar.real_name
+	our_id.update_label()
+	our_id.update_icon()
+	if(our_id.registered_account)
+		our_id.registered_account.account_holder = avatar.real_name
 
 
 /// Disconnects the avatar and returns the mind to the old_body.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Early mirror of upstream PR I made.
Copied description:

So currently there's this incredibly incredibly niche records bug with bitrunning.
Where if a generated bitrunner avatar has the exact same name as anyone currently on the records, when it applies the hacker alias it then proceeds to update the records to match.

This seems to be because it uses `avatar.fully_replace_character_name(avatar.real_name, alias)`, which as an old name is given then calls `replace_records_name(avatar.real_name, alias)`, which proceeds to override the first record named `avatar.real_name` with `alias`.
It also potentially screws with people's objectives for anyone with that name.

As the documentation for this proc says:
https://github.com/tgstation/tgstation/blob/7b9d4d0f94d4447c04097066168d099ac19be686/code/modules/mob/mob.dm#L1123-L1125
we instead just call it without supplying an `oldname`, such that it doesn't try to update the records nor objectives.

This fixes our issues.

However, this _theoretically_ would've also updated our net avatar's ID! But in practice, it never actually did so, as it would have required the ID to already have been set to the `oldname` previously.

To make it actually update the ID, we instead just manually update the avatar's ID after setting the alias.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes jank.
It's nicer to have the IDs use the actual names rather than being generic.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: A bitrunner avatar spawning with the exact same name as a name currently on the records no longer updates that record to match when the hacker alias gets applied.
qol: Net avatar ID cards use the net avatar's name instead of being generic.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
