### PR TITLE
Adds a cryopod area to Nebula Station

### DIFF
--- a/_maps/doppler/automapper/automapper_config.toml
+++ b/_maps/doppler/automapper/automapper_config.toml
@@ -104,3 +104,12 @@ directory = "_maps/doppler/automapper/templates/wawastation/"
 required_map = "wawastation.dmm"
 coordinates = [83, 92, 1]
 trait_name = "Station"
+
+# NEBULASTATION MAP EDITS
+# Nebulastation Cryo
+[templates.nebulastation_cryo]
+map_files = ["nebulastation_cryo.dmm"]
+directory = "_maps/doppler/automapper/templates/nebulastation/"
+required_map = "NebulaStation.dmm"
+coordinates = [117, 137, 2]
+trait_name = "Station"

--- a/_maps/doppler/automapper/templates/nebulastation/nebulastation_cryo.dmm
+++ b/_maps/doppler/automapper/templates/nebulastation/nebulastation_cryo.dmm
@@ -1,0 +1,464 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/template_noop,
+/area/template_noop)
+"b" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/obj/item/kirbyplants/random,
+/obj/machinery/light/small/directional/south,
+/obj/machinery/light_switch/directional/west,
+/turf/open/floor/wood/tile,
+/area/station/commons/cryopods)
+"c" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 9
+	},
+/obj/structure/railing/corner/end{
+	dir = 4;
+	pixel_x = 0;
+	pixel_y = -4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/iron/white/textured_corner,
+/area/station/commons/cryopods)
+"d" = (
+/turf/closed/wall,
+/area/station/maintenance/port/fore)
+"f" = (
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/chair/sofa/bench/left{
+	dir = 4
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/dark/small,
+/area/station/commons/cryopods)
+"g" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/white/textured_half,
+/area/station/commons/cryopods)
+"h" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/wood/tile,
+/area/station/commons/cryopods)
+"i" = (
+/obj/effect/turf_decal/trimline/green/filled/warning,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/iron/white/textured_half,
+/area/station/commons/cryopods)
+"j" = (
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/bush/flowers_pp/style_3,
+/turf/open/floor/grass,
+/area/station/commons/cryopods)
+"k" = (
+/obj/machinery/cryopod,
+/obj/effect/turf_decal/trimline/green/filled/warning,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/commons/cryopods)
+"l" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/flora/bush/sparsegrass/style_3,
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/bush/grassy/style_2,
+/obj/structure/flora/bush/flowers_yw/style_2,
+/turf/open/floor/grass,
+/area/station/commons/cryopods)
+"m" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/green/filled/warning,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/iron/white/textured_half,
+/area/station/commons/cryopods)
+"n" = (
+/obj/machinery/firealarm/directional/west,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood/tile,
+/area/station/commons/cryopods)
+"r" = (
+/turf/closed/wall,
+/area/station/commons/cryopods)
+"s" = (
+/obj/effect/turf_decal/trimline/green/filled/warning,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/iron/white/textured_corner{
+	dir = 1
+	},
+/area/station/commons/cryopods)
+"t" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/time_clock/directional/east,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/wood/tile,
+/area/station/commons/cryopods)
+"u" = (
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/flora/grass/jungle/b/style_random,
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/grassy/style_random,
+/obj/structure/flora/bush/generic/style_random,
+/obj/structure/window/reinforced/spawner/directional/north,
+/turf/open/floor/grass,
+/area/station/commons/cryopods)
+"v" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/flora/bush/ferny/style_random,
+/obj/structure/flora/bush/leavy/style_3,
+/obj/structure/flora/bush/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/window/reinforced/spawner/directional/south,
+/turf/open/floor/grass,
+/area/station/commons/cryopods)
+"w" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/turf/open/floor/wood/tile,
+/area/station/commons/cryopods)
+"x" = (
+/turf/open/floor/wood/tile,
+/area/station/commons/cryopods)
+"y" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/sign/poster/timeclock_psa/directional/east,
+/turf/open/floor/wood/tile,
+/area/station/commons/cryopods)
+"B" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/station/commons/cryopods)
+"C" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/white/textured_half,
+/area/station/commons/cryopods)
+"D" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/green/filled/warning,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/iron/white/textured_half,
+/area/station/commons/cryopods)
+"E" = (
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/flora/grass/jungle/a/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/structure/window/reinforced/spawner/directional/south,
+/turf/open/floor/grass,
+/area/station/commons/cryopods)
+"F" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/bush/lavendergrass/style_4,
+/obj/structure/flora/bush/flowers_br/style_2,
+/obj/structure/window/reinforced/spawner/directional/west,
+/turf/open/floor/grass,
+/area/station/commons/cryopods)
+"G" = (
+/obj/machinery/cryopod{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/white/smooth_large,
+/area/station/commons/cryopods)
+"H" = (
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/chair/sofa/bench/right{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/small,
+/area/station/commons/cryopods)
+"I" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/flora/bush/sparsegrass/style_3,
+/obj/structure/flora/bush/fullgrass/style_3,
+/obj/structure/flora/bush/sunny/style_random,
+/obj/structure/marker_beacon/lime,
+/turf/open/floor/grass,
+/area/station/commons/cryopods)
+"J" = (
+/obj/machinery/door/airlock{
+	name = "Restroom"
+	},
+/obj/effect/turf_decal/tile/dark_blue/diagonal_edge,
+/obj/effect/turf_decal/tile/green/diagonal_centre,
+/obj/effect/turf_decal/tile/blue/diagonal_centre,
+/turf/open/floor/iron/white/diagonal,
+/area/station/commons/cryopods)
+"K" = (
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/white/textured_half,
+/area/station/commons/cryopods)
+"L" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood/tile,
+/area/station/commons/cryopods)
+"M" = (
+/obj/structure/toilet/greyscale{
+	pixel_y = 14
+	},
+/obj/structure/sink/directional/east,
+/obj/structure/mirror/directional/west,
+/obj/machinery/light/small/directional/south,
+/obj/effect/turf_decal/tile/dark_blue/diagonal_edge,
+/obj/effect/turf_decal/tile/green/diagonal_centre,
+/obj/effect/turf_decal/tile/blue/diagonal_centre,
+/turf/open/floor/iron/white/diagonal,
+/area/station/commons/cryopods)
+"O" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/navigate_destination{
+	location = "Cryopods"
+	},
+/turf/open/floor/iron/dark/herringbone,
+/area/station/commons/cryopods)
+"P" = (
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/white/textured_corner{
+	dir = 8
+	},
+/area/station/commons/cryopods)
+"Q" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/item/radio/intercom/directional/north,
+/obj/structure/table/wood,
+/turf/open/floor/wood/tile,
+/area/station/commons/cryopods)
+"R" = (
+/turf/closed/wall,
+/area/station/security/checkpoint/customs)
+"T" = (
+/obj/machinery/door/airlock/multi_tile/public/glass{
+	name = "Mini-Bar"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark/herringbone,
+/area/station/commons/cryopods)
+"U" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/newscaster/directional/west,
+/obj/machinery/vending/snack/green,
+/turf/open/floor/wood/tile,
+/area/station/commons/cryopods)
+"X" = (
+/obj/machinery/digital_clock/directional/north,
+/obj/machinery/light/directional/north,
+/obj/machinery/cryopod,
+/obj/effect/turf_decal/trimline/green/filled/warning,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/commons/cryopods)
+"Y" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/camera/autoname/directional/north,
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/wood/tile,
+/area/station/commons/cryopods)
+"Z" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/iron/white/textured_corner{
+	dir = 4
+	},
+/area/station/commons/cryopods)
+
+(1,1,1) = {"
+a
+a
+d
+d
+R
+a
+a
+"}
+(2,1,1) = {"
+a
+a
+d
+M
+R
+a
+a
+"}
+(3,1,1) = {"
+a
+d
+d
+J
+r
+R
+a
+"}
+(4,1,1) = {"
+a
+d
+U
+w
+b
+r
+R
+"}
+(5,1,1) = {"
+a
+d
+Q
+x
+L
+n
+T
+"}
+(6,1,1) = {"
+d
+d
+Y
+h
+t
+y
+O
+"}
+(7,1,1) = {"
+d
+v
+c
+Z
+r
+B
+r
+"}
+(8,1,1) = {"
+d
+k
+g
+i
+G
+F
+a
+"}
+(9,1,1) = {"
+d
+X
+K
+m
+G
+I
+a
+"}
+(10,1,1) = {"
+d
+k
+C
+D
+G
+l
+a
+"}
+(11,1,1) = {"
+d
+k
+P
+s
+G
+j
+a
+"}
+(12,1,1) = {"
+d
+E
+f
+H
+u
+r
+a
+"}

--- a/_maps/doppler/automapper/templates/nebulastation/nebulastation_cryo.dmm
+++ b/_maps/doppler/automapper/templates/nebulastation/nebulastation_cryo.dmm
@@ -8,7 +8,7 @@
 	},
 /obj/item/kirbyplants/random,
 /obj/machinery/light/small/directional/south,
-/obj/machinery/light_switch/directional/west,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/wood/tile,
 /area/station/commons/cryopods)
 "c" = (
@@ -131,10 +131,10 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/time_clock/directional/east,
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
+/obj/machinery/computer/cryopod/directional/east,
 /turf/open/floor/wood/tile,
 /area/station/commons/cryopods)
 "u" = (
@@ -179,7 +179,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/sign/poster/timeclock_psa/directional/east,
+/obj/machinery/time_clock/directional/east,
 /turf/open/floor/wood/tile,
 /area/station/commons/cryopods)
 "z" = (
@@ -339,9 +339,9 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
-/obj/machinery/airalarm/directional/north,
 /obj/machinery/newscaster/directional/west,
 /obj/machinery/vending/snack/green,
+/obj/structure/sign/poster/timeclock_psa/directional/north,
 /turf/open/floor/wood/tile,
 /area/station/commons/cryopods)
 "X" = (

--- a/_maps/doppler/automapper/templates/nebulastation/nebulastation_cryo.dmm
+++ b/_maps/doppler/automapper/templates/nebulastation/nebulastation_cryo.dmm
@@ -30,6 +30,13 @@
 "d" = (
 /turf/closed/wall,
 /area/station/maintenance/port/fore)
+"e" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/chair/sofa/bench,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "f" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/chair/sofa/bench/left{
@@ -101,6 +108,13 @@
 	},
 /turf/open/floor/wood/tile,
 /area/station/commons/cryopods)
+"p" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/chair/sofa/bench/right,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "r" = (
 /turf/closed/wall,
 /area/station/commons/cryopods)
@@ -168,6 +182,13 @@
 /obj/structure/sign/poster/timeclock_psa/directional/east,
 /turf/open/floor/wood/tile,
 /area/station/commons/cryopods)
+"z" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/chair/sofa/bench/left,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "B" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
@@ -308,10 +329,10 @@
 /turf/closed/wall,
 /area/station/security/checkpoint/customs)
 "T" = (
-/obj/machinery/door/airlock/multi_tile/public/glass{
-	name = "Mini-Bar"
-	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/multi_tile/public/glass{
+	name = "Cryogenic Storage"
+	},
 /turf/open/floor/iron/dark/herringbone,
 /area/station/commons/cryopods)
 "U" = (
@@ -424,7 +445,7 @@ g
 i
 G
 F
-a
+p
 "}
 (9,1,1) = {"
 d
@@ -433,7 +454,7 @@ K
 m
 G
 I
-a
+e
 "}
 (10,1,1) = {"
 d
@@ -442,7 +463,7 @@ C
 D
 G
 l
-a
+e
 "}
 (11,1,1) = {"
 d
@@ -451,7 +472,7 @@ P
 s
 G
 j
-a
+z
 "}
 (12,1,1) = {"
 d


### PR DESCRIPTION

## About The Pull Request
Title. 
![image](https://github.com/user-attachments/assets/0ee53a6c-57bb-4a5b-9f1e-b538692204e4)


## Why It's Good For The Game
crayonpod goode?

## Changelog

:cl:
map: The Port Authority Engineering Guild has installed a cryogenics area into Nebula model stations. It is directly north of arrivals.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
