### PR TITLE
Makes Health Analyzers Work 4 The Blind

### DIFF
--- a/code/game/objects/items/devices/scanners/gas_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/gas_analyzer.dm
@@ -136,13 +136,13 @@
 	return list("gasmixes" = last_gasmix_data)
 
 /obj/item/analyzer/attack_self(mob/user, modifiers)
-	if(user.stat != CONSCIOUS || !user.can_read(src) || user.is_blind())
+	if(user.stat != CONSCIOUS || !user.can_read(src)) //DOPPLER EDIT: Blind People Can Analyze Again
 		return
 	atmos_scan(user=user, target=get_turf(src), silent=FALSE)
 	on_analyze(source=src, target=get_turf(src))
 
 /obj/item/analyzer/attack_self_secondary(mob/user, modifiers)
-	if(user.stat != CONSCIOUS || !user.can_read(src) || user.is_blind())
+	if(user.stat != CONSCIOUS || !user.can_read(src)) //DOPPLER EDIT: Blind People Can Analyze Again
 		return
 
 	ui_interact(user)

--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -47,7 +47,7 @@
 	return BRUTELOSS
 
 /obj/item/healthanalyzer/attack_self(mob/user)
-	if(!user.can_read(src) || user.is_blind())
+	if(!user.can_read(src)) //DOPPLER EDIT: Blind People Can Analyze Again
 		return
 
 	scanmode = (scanmode + 1) % SCANMODE_COUNT
@@ -80,7 +80,7 @@
 		floor_text += "<span class='alert ml-1'>Subject lacks a brain.</span><br>"
 		floor_text += "<span class='info ml-1'>Body temperature: [scan_turf?.return_air()?.return_temperature() || "???"]</span><br>"
 
-		if(user.can_read(src) && !user.is_blind())
+		if(!user.can_read(src)) //DOPPLER EDIT: Blind People Can Analyze Again
 			to_chat(user, examine_block(floor_text))
 		last_scan_text = floor_text
 		return
@@ -93,7 +93,7 @@
 	balloon_alert(user, "analyzing vitals")
 	playsound(user.loc, 'sound/items/healthanalyzer.ogg', 50)
 
-	var/readability_check = user.can_read(src) && !user.is_blind()
+	var/readability_check = user.can_read(src) //DOPPLER EDIT - Blind People Can Analyze Again
 	switch (scanmode)
 		if (SCANMODE_HEALTH)
 			last_scan_text = healthscan(user, M, mode, advanced, tochat = readability_check)
@@ -106,7 +106,7 @@
 /obj/item/healthanalyzer/interact_with_atom_secondary(atom/interacting_with, mob/living/user, list/modifiers)
 	if(!isliving(interacting_with))
 		return NONE
-	if(user.can_read(src) && !user.is_blind())
+	if(user.can_read(src)) //DOPPLER EDIT - Blind People can Analyze Again
 		chemscan(user, interacting_with)
 	return ITEM_INTERACT_SUCCESS
 
@@ -626,7 +626,7 @@
 /obj/item/healthanalyzer/simple/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
 	if(!isliving(interacting_with))
 		return NONE
-	if(!user.can_read(src) || user.is_blind())
+	if(!user.can_read(src)) //DOPPLER EDIT - Blind People Can Analyze Again
 		return ITEM_INTERACT_BLOCKING
 
 	add_fingerprint(user)

--- a/code/game/objects/items/devices/scanners/slime_scanner.dm
+++ b/code/game/objects/items/devices/scanners/slime_scanner.dm
@@ -16,7 +16,7 @@
 /obj/item/slime_scanner/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
 	if(!isliving(interacting_with))
 		return NONE
-	if(!user.can_read(src) || user.is_blind())
+	if(!user.can_read(src)) //DOPPLER EDIT - Blind People Can Analyze Again
 		return ITEM_INTERACT_BLOCKING
 	if (!isslime(interacting_with))
 		to_chat(user, span_warning("This device can only scan slimes!"))


### PR DESCRIPTION
## About The Pull Request
This PR allows blind people the use of gas, health, and slime scanners. It also puts the white canes in the loadout.
This is the 'how the fuck' section.
Alright, so.
There's two easy surface-level possible methods in which these devices could easily work.
Method one simply being https://youtu.be/pQO4S1t2uiA, well, screen readers. This is a technology we have in 2024 our current year that can easily read text back to blind people at EXTREMELY quick speeds, this video's one of the slowest screen readers I've seen. With the addition of alt text (the text you get when you mouse over images on accessibility-friendly website) it'd be rather easy to navigate the UIs we're presented.

Method two would simply be refreshable braille displays. 
![image](https://user-images.githubusercontent.com/12636964/177015585-6a17519e-2431-4273-bf82-213d841c20dd.png)
These traditionally use a system of round-tipped pins raised through holes in a flat surface, though functionality is being designed for https://www.youtube.com/watch?v=0fIg4rI4cDw microfluidic displays that can do not only full pages, but can generate new text on the fly. See: https://en.wikipedia.org/wiki/Braille_e-book
I don't think these would be very hard at all to make in the year 2562, especially given we have nanomanipulators and such. We, also, have several technologies in the game which use either hardlight or nanomachines, and these devices can be paired with speech synthesizers as well.

Before you ask about blind surgeons, https://www.9news.com/article/news/blind-student-earns-md-things-are-only-impossible-until-theyre-done/73-344742218 technology could be developed for that and _has been already._

Alright, here's the 'why.'
I don't think any of this stuff is necessary. This was nearly removed on /tg/ as well in PR 58134. Being blind is a horrific downside no matter how you slice it, given that you can only see a very small amount of tiles and the little FOV cues outside of that radius are cues that do not give you visual information about what's going on or who's going on. It's, also, wildly inconsistent that blind people can use _every other device including PDAs,_ but somehow analyzers (a basic part of several jobs) are not devices with accessibility. For some reason. C'mon, even 2024 smartphones have screen readers, and they're a hell of a lot less complex.

## Changelog
:cl:
balance: Blind people can use analyzers now.
/:cl: