### PR TITLE
Polishes up the Mining Base

### DIFF
--- a/_maps/map_files/Mining/Iceland.dmm
+++ b/_maps/map_files/Mining/Iceland.dmm
@@ -118,13 +118,6 @@
 	},
 /turf/open/floor/iron/checker,
 /area/mine/laborcamp)
-"aR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/iron/colony,
-/area/mine/lounge)
 "aV" = (
 /obj/structure/marker_beacon/teal,
 /obj/effect/turf_decal/stripes/corner{
@@ -350,11 +343,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/mine/maintenance/service)
-"ct" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/railing,
-/turf/open/openspace/icemoon/keep_below,
-/area/icemoon/surface/outdoors/nospawn)
+"cs" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/colony_fabricator,
+/area/mine/laborcamp/security/maintenance)
 "cw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -730,10 +726,12 @@
 /area/mine/cafeteria)
 "eP" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/camera/autoname/directional/north,
-/turf/open/misc/asteroid/snow/icemoon,
+/obj/structure/cable,
+/obj/machinery/power/rtg/old_station,
+/obj/structure/railing{
+	dir = 6
+	},
+/turf/open/openspace/icemoon/keep_below,
 /area/icemoon/surface/outdoors/nospawn)
 "eQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -755,6 +753,14 @@
 /obj/structure/sign/poster/official/work_for_a_future/directional/west,
 /turf/open/floor/iron/smooth,
 /area/mine/laborcamp/quarters)
+"eV" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/obj/structure/railing{
+	dir = 5
+	},
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "eW" = (
 /obj/structure/cable,
 /obj/machinery/power/terminal,
@@ -831,9 +837,6 @@
 /area/mine/laborcamp)
 "fv" = (
 /obj/machinery/vending/dinnerware,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
-	},
 /turf/open/floor/iron/colony,
 /area/mine/cafeteria)
 "fw" = (
@@ -930,6 +933,13 @@
 /obj/effect/spawner/random/structure/steam_vent,
 /turf/open/floor/catwalk_floor/colony_fabricator,
 /area/mine/maintenance/living/north)
+"gb" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/railing,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "gd" = (
 /obj/structure/marker_beacon/yellow,
 /obj/effect/turf_decal/stripes/corner,
@@ -1001,15 +1011,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
 /area/mine/laborcamp/quarters)
-"gt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/structure/closet_empty/crate/with_loot,
-/turf/open/floor/plating,
-/area/mine/storage)
 "gx" = (
 /obj/structure/lattice/catwalk,
-/obj/structure/cable,
-/turf/open/openspace/icemoon/keep_below,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "gz" = (
 /obj/machinery/light/small/directional/east,
@@ -1128,19 +1134,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/mine/laborcamp/security)
-"hg" = (
-/obj/machinery/door/airlock/external/glass{
-	name = "Labor Camp External Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "lavaland_gulag_east"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/any/security/brig,
-/turf/open/floor/catwalk_floor/colony_fabricator,
-/area/mine/maintenance/labor)
 "hi" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -1211,9 +1204,6 @@
 /area/mine/medical)
 "hD" = (
 /obj/structure/disposalpipe/junction{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/bar/opposingcorners{
 	dir = 1
 	},
 /turf/open/floor/iron/colony,
@@ -1374,9 +1364,6 @@
 /turf/open/floor/iron/colony,
 /area/mine/storage/public)
 "iH" = (
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
-	},
 /obj/structure/table/greyscale,
 /obj/effect/spawner/random/food_or_drink/dinner,
 /turf/open/floor/iron/colony,
@@ -1543,9 +1530,6 @@
 /area/mine/production/middle)
 "jS" = (
 /obj/item/radio/intercom/directional/west,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
-	},
 /obj/structure/chair/plastic,
 /turf/open/floor/iron/colony,
 /area/mine/cafeteria)
@@ -1573,11 +1557,15 @@
 	},
 /turf/open/floor/iron/dark/smooth_edge,
 /area/mine/production/middle)
+"jZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/colony,
+/area/mine/lounge)
 "ka" = (
 /obj/machinery/newscaster/directional/north,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
-	},
 /obj/structure/table/greyscale,
 /obj/effect/spawner/random/food_or_drink/refreshing_beverage,
 /turf/open/floor/iron/colony,
@@ -1640,10 +1628,8 @@
 "kE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /turf/open/floor/catwalk_floor/colony_fabricator,
-/area/mine/maintenance/labor)
+/area/mine/laborcamp/security/maintenance)
 "kF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply,
 /turf/open/floor/plating,
@@ -1697,16 +1683,7 @@
 	},
 /turf/open/floor/iron/colony,
 /area/mine/cafeteria)
-"kQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/mine/maintenance/public/south)
 "kR" = (
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
-	},
 /obj/machinery/mining_weather_monitor/directional/west,
 /obj/structure/chair/plastic,
 /turf/open/floor/iron/colony,
@@ -1721,6 +1698,15 @@
 "kY" = (
 /turf/closed/wall/prefab_plastic,
 /area/mine/cafeteria)
+"kZ" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/obj/machinery/power/rtg/old_station,
+/obj/structure/railing{
+	dir = 9
+	},
+/turf/open/openspace/icemoon/keep_below,
+/area/icemoon/surface/outdoors/nospawn)
 "la" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/colony/white/texture,
@@ -1917,6 +1903,11 @@
 	},
 /turf/open/floor/iron/colony/white,
 /area/mine/lounge)
+"mx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/mine/maintenance/service)
 "my" = (
 /obj/machinery/door/airlock/colony_prefab{
 	name = "Maintenance"
@@ -2213,10 +2204,8 @@
 /area/icemoon/surface/outdoors/nospawn)
 "om" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/railing,
-/turf/open/misc/asteroid/snow/icemoon,
+/turf/open/openspace/icemoon/keep_below,
 /area/icemoon/surface/outdoors/nospawn)
 "op" = (
 /obj/machinery/camera/autoname/directional/south{
@@ -2349,9 +2338,12 @@
 /area/mine/laborcamp/production)
 "ps" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/misc/asteroid/snow/icemoon,
+/obj/structure/cable,
+/obj/machinery/power/rtg/old_station,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/openspace/icemoon/keep_below,
 /area/icemoon/surface/outdoors/nospawn)
 "pu" = (
 /obj/item/chair/stool{
@@ -2495,9 +2487,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
-	},
 /turf/open/floor/iron/colony,
 /area/mine/cafeteria)
 "qh" = (
@@ -2551,6 +2540,13 @@
 /obj/structure/railing/corner,
 /turf/open/openspace/icemoon/keep_below,
 /area/icemoon/surface/outdoors/nospawn)
+"qt" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 6
+	},
+/obj/machinery/space_heater,
+/turf/open/floor/iron/colony,
+/area/mine/production)
 "qw" = (
 /obj/structure/bed,
 /obj/effect/decal/cleanable/dirt,
@@ -2612,14 +2608,7 @@
 /area/mine/cafeteria)
 "qU" = (
 /obj/structure/lattice/catwalk,
-/obj/structure/cable,
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/misc/asteroid/snow/icemoon,
+/turf/open/openspace/icemoon/keep_below,
 /area/icemoon/surface/outdoors/nospawn)
 "qV" = (
 /obj/structure/table/greyscale,
@@ -2673,6 +2662,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/mine/production)
+"rr" = (
+/obj/machinery/camera/autoname/directional/west,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "rv" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron/colony,
@@ -2918,6 +2911,10 @@
 	},
 /turf/closed/wall/prefab_plastic,
 /area/mine/production/lower)
+"tk" = (
+/obj/machinery/camera/autoname/directional/east,
+/turf/open/openspace/icemoon/keep_below,
+/area/icemoon/surface/outdoors/nospawn)
 "tr" = (
 /obj/structure/closet/secure_closet/brig,
 /obj/effect/decal/cleanable/dirt,
@@ -2978,14 +2975,6 @@
 /obj/machinery/vending/assist,
 /turf/open/floor/iron/colony,
 /area/mine/living_quarters)
-"tR" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable,
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "tT" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/structure/table/greyscale,
@@ -3027,9 +3016,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/bar/opposingcorners{
 	dir = 1
 	},
 /turf/open/floor/iron/colony,
@@ -3103,11 +3089,14 @@
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "uI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/lattice/catwalk,
 /obj/structure/cable,
-/turf/open/floor/catwalk_floor/colony_fabricator,
-/area/mine/maintenance/labor)
+/obj/machinery/power/rtg/old_station,
+/obj/structure/railing{
+	dir = 10
+	},
+/turf/open/openspace/icemoon/keep_below,
+/area/icemoon/surface/outdoors/nospawn)
 "uM" = (
 /obj/structure/fence{
 	dir = 8
@@ -3178,13 +3167,12 @@
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "ve" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/colony_fabricator,
-/area/mine/laborcamp/security/maintenance)
+/area/mine/maintenance/labor)
 "vf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -3321,10 +3309,16 @@
 /turf/open/floor/iron/dark,
 /area/mine/laborcamp)
 "vQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
-/area/mine/maintenance/service)
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "vS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -3402,11 +3396,9 @@
 /turf/open/floor/iron/colony/white,
 /area/mine/lounge)
 "wq" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
+/obj/machinery/power/smes/full,
+/turf/open/floor/plating,
+/area/mine/laborcamp/security/maintenance)
 "wr" = (
 /obj/item/seeds/plump,
 /obj/machinery/hydroponics/soil,
@@ -3429,9 +3421,11 @@
 /turf/open/floor/iron/dark,
 /area/mine/laborcamp)
 "wv" = (
-/obj/machinery/camera/autoname/directional/west,
-/turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/mine/maintenance/public/south)
 "wA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -3452,11 +3446,6 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/mine/production/middle)
-"wH" = (
-/obj/structure/flora/grass/both/style_random,
-/obj/machinery/camera/autoname/directional/west,
-/turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "wJ" = (
 /obj/machinery/airalarm/directional/east,
 /obj/structure/table/greyscale,
@@ -3602,9 +3591,6 @@
 /obj/machinery/chem_master/condimaster,
 /obj/machinery/camera/autoname/directional/east{
 	network = list("mine")
-	},
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
 	},
 /turf/open/floor/iron/colony,
 /area/mine/cafeteria)
@@ -3763,9 +3749,6 @@
 "yN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
-	},
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
 	},
 /turf/open/floor/iron/colony,
 /area/mine/cafeteria)
@@ -4131,14 +4114,6 @@
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor/colony_fabricator,
 /area/mine/living_quarters)
-"Bw" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable,
-/obj/structure/railing{
-	dir = 5
-	},
-/turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "By" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "labor";
@@ -4205,6 +4180,11 @@
 /obj/structure/sign/poster/official/report_crimes/directional/west,
 /turf/open/floor/iron/smooth,
 /area/mine/laborcamp)
+"BX" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/turf/open/openspace/icemoon/keep_below,
+/area/icemoon/surface/outdoors/nospawn)
 "BY" = (
 /obj/structure/railing{
 	dir = 6
@@ -4281,14 +4261,11 @@
 /turf/open/floor/iron/colony/white/texture,
 /area/mine/living_quarters)
 "CD" = (
-/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/power/rtg/old_station,
-/obj/structure/railing{
-	dir = 9
-	},
-/turf/open/openspace/icemoon/keep_below,
-/area/icemoon/surface/outdoors/nospawn)
+/turf/open/floor/catwalk_floor/colony_fabricator,
+/area/mine/maintenance/labor)
 "CE" = (
 /obj/structure/table/greyscale,
 /obj/item/mecha_parts/mecha_equipment/drill{
@@ -4491,15 +4468,6 @@
 	},
 /turf/open/openspace/icemoon/keep_below,
 /area/icemoon/surface/outdoors/nospawn)
-"Eb" = (
-/obj/machinery/door/airlock/colony_prefab{
-	name = "Shuttle Lounge"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/catwalk_floor/colony_fabricator,
-/area/mine/lounge)
 "Ec" = (
 /obj/docking_port/stationary{
 	dir = 2;
@@ -4513,6 +4481,11 @@
 /area/icemoon/surface/outdoors/nospawn)
 "Ee" = (
 /obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/obj/machinery/power/rtg/old_station,
+/obj/structure/railing{
+	dir = 5
+	},
 /turf/open/openspace/icemoon/keep_below,
 /area/icemoon/surface/outdoors/nospawn)
 "Eg" = (
@@ -4652,9 +4625,6 @@
 /turf/open/floor/iron/colony,
 /area/mine/production)
 "Fd" = (
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
-	},
 /obj/structure/chair/plastic,
 /turf/open/floor/iron/colony,
 /area/mine/cafeteria)
@@ -4696,6 +4666,13 @@
 	},
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
+"Fy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/steam_vent,
+/turf/open/floor/plating,
+/area/mine/maintenance/public/south)
 "FD" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/iron/colony/white,
@@ -4734,6 +4711,10 @@
 /obj/structure/window/fulltile/colony_fabricator,
 /turf/open/floor/plating,
 /area/mine/maintenance/production)
+"FZ" = (
+/obj/machinery/camera/autoname/directional/south,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "Gb" = (
 /obj/structure/lattice/catwalk/mining,
 /obj/structure/railing{
@@ -4791,13 +4772,6 @@
 /obj/structure/railing,
 /turf/open/openspace/icemoon/keep_below,
 /area/icemoon/surface/outdoors/nospawn)
-"Go" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/structure/steam_vent,
-/turf/open/floor/plating,
-/area/mine/maintenance/public/south)
 "Gr" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/iron/dark,
@@ -4909,8 +4883,10 @@
 /turf/open/floor/plating,
 /area/mine/maintenance/public/north)
 "Hl" = (
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/closet_empty/crate/with_loot,
+/turf/open/floor/plating,
+/area/mine/storage)
 "Hp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -4990,12 +4966,11 @@
 /turf/closed/wall/prefab_plastic,
 /area/mine/production/lower)
 "HG" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 6
-	},
-/obj/machinery/space_heater,
-/turf/open/floor/iron/colony,
-/area/mine/production)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/lattice/catwalk,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "HI" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -5103,8 +5078,14 @@
 /turf/open/floor/carpet/royalblue,
 /area/mine/living_quarters)
 "Is" = (
-/obj/machinery/power/smes/full,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor/colony_fabricator,
 /area/mine/laborcamp/security/maintenance)
 "It" = (
 /obj/structure/window/fulltile/colony_fabricator,
@@ -5540,9 +5521,6 @@
 /turf/open/floor/iron/colony/white,
 /area/mine/lounge)
 "KL" = (
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
-	},
 /turf/open/floor/iron/colony,
 /area/mine/cafeteria)
 "KV" = (
@@ -5670,7 +5648,7 @@
 /obj/structure/cable,
 /obj/machinery/power/rtg/old_station,
 /obj/structure/railing{
-	dir = 4
+	dir = 8
 	},
 /turf/open/openspace/icemoon/keep_below,
 /area/icemoon/surface/outdoors/nospawn)
@@ -5882,9 +5860,6 @@
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/east,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
-	},
 /turf/open/floor/iron/colony,
 /area/mine/cafeteria)
 "MM" = (
@@ -6033,9 +6008,6 @@
 /area/mine/maintenance/public/south)
 "Nw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
-	},
 /turf/open/floor/iron/colony,
 /area/mine/cafeteria)
 "Nz" = (
@@ -6084,15 +6056,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/mine/laborcamp/security/maintenance)
-"NQ" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable,
-/obj/machinery/power/rtg/old_station,
-/obj/structure/railing{
-	dir = 6
-	},
-/turf/open/openspace/icemoon/keep_below,
-/area/icemoon/surface/outdoors/nospawn)
 "NR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -6165,9 +6128,6 @@
 /area/mine/laborcamp/security)
 "Oj" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
-	},
 /obj/structure/closet/secure_closet/freezer/fridge/all_access,
 /obj/effect/spawner/random/food_or_drink/cake_ingredients,
 /turf/open/floor/iron/colony,
@@ -6281,8 +6241,10 @@
 /turf/open/floor/catwalk_floor/colony_fabricator,
 /area/mine/mechbay)
 "Pc" = (
-/obj/machinery/camera/autoname/directional/south,
-/turf/open/misc/asteroid/snow/icemoon,
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "Pd" = (
 /obj/structure/marker_beacon/teal,
@@ -6530,16 +6492,6 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
-"QE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/catwalk_floor/colony_fabricator,
-/area/mine/laborcamp/security/maintenance)
 "QG" = (
 /obj/machinery/door/airlock/colony_prefab{
 	name = "Prisoner Bunk"
@@ -6566,19 +6518,14 @@
 /turf/open/floor/iron/colony,
 /area/mine/production)
 "QN" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable,
-/obj/machinery/power/rtg/old_station,
-/obj/structure/railing{
-	dir = 5
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/openspace/icemoon/keep_below,
-/area/icemoon/surface/outdoors/nospawn)
-"QO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor/colony_fabricator,
-/area/mine/laborcamp/security/maintenance)
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron/colony,
+/area/mine/lounge)
 "QP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -6633,9 +6580,6 @@
 /area/mine/living_quarters)
 "Re" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
-	},
 /turf/open/floor/iron/colony,
 /area/mine/cafeteria)
 "Rf" = (
@@ -6716,14 +6660,8 @@
 /turf/open/openspace/icemoon/keep_below,
 /area/icemoon/surface/outdoors/nospawn)
 "RD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/turf/open/floor/iron/colony,
-/area/mine/lounge)
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "RF" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -6900,14 +6838,18 @@
 /turf/open/floor/iron/smooth_large,
 /area/mine/laborcamp)
 "SN" = (
-/obj/machinery/door/airlock/colony_prefab{
-	name = "Bunk A"
+/obj/machinery/door/airlock/external/glass{
+	name = "Labor Camp External Airlock"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "lavaland_gulag_east"
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/turf/open/floor/iron/colony/white/texture,
-/area/mine/living_quarters)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/any/security/brig,
+/turf/open/floor/catwalk_floor/colony_fabricator,
+/area/mine/maintenance/labor)
 "SO" = (
 /obj/structure/marker_beacon/burgundy,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -6995,8 +6937,8 @@
 /area/mine/maintenance/living/north)
 "TA" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/railing,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
@@ -7071,12 +7013,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/mine/laborcamp/security/maintenance)
-"TY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/lattice/catwalk,
-/turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "Ua" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -7142,6 +7078,13 @@
 	},
 /turf/open/floor/iron/colony/texture,
 /area/mine/production)
+"Ur" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/camera/autoname/directional/north,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "Us" = (
 /obj/machinery/shower/directional/south,
 /turf/open/floor/iron/dark/textured_edge,
@@ -7189,9 +7132,6 @@
 /turf/open/floor/iron/colony,
 /area/mine/laborcamp/security)
 "US" = (
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
-	},
 /obj/structure/table/greyscale,
 /obj/effect/spawner/random/food_or_drink/any_snack_or_beverage,
 /turf/open/floor/iron/colony,
@@ -7305,9 +7245,13 @@
 /obj/effect/mapping_helpers/airlock/access/any/security/brig,
 /turf/open/floor/plating,
 /area/mine/maintenance/labor)
-"Vr" = (
-/obj/machinery/camera/autoname/directional/east,
-/turf/open/openspace/icemoon/keep_below,
+"Vs" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "Vt" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -7725,6 +7669,15 @@
 /mob/living/basic/mining/ice_whelp,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
+"XT" = (
+/obj/machinery/door/airlock/colony_prefab{
+	name = "Shuttle Lounge"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor/colony_fabricator,
+/area/mine/lounge)
 "XV" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/stripes/line{
@@ -7923,26 +7876,20 @@
 /turf/open/floor/iron/smooth,
 /area/mine/laborcamp/production)
 "Zb" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable,
-/obj/machinery/power/rtg/old_station,
-/obj/structure/railing{
-	dir = 10
+/obj/machinery/door/airlock/colony_prefab{
+	name = "Bunk A"
 	},
-/turf/open/openspace/icemoon/keep_below,
-/area/icemoon/surface/outdoors/nospawn)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/colony/white/texture,
+/area/mine/living_quarters)
 "Zh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
-	},
 /turf/open/floor/iron/colony,
 /area/mine/cafeteria)
 "Zj" = (
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
-	},
 /obj/machinery/light/small/directional/north,
 /obj/structure/table/greyscale,
 /obj/effect/spawner/random/food_or_drink/any_snack_or_beverage,
@@ -7977,13 +7924,9 @@
 /turf/open/floor/iron/smooth,
 /area/mine/laborcamp/production)
 "Zt" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable,
-/obj/machinery/power/rtg/old_station,
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/open/openspace/icemoon/keep_below,
+/obj/structure/flora/grass/both/style_random,
+/obj/machinery/camera/autoname/directional/west,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "Zv" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
@@ -158388,7 +158331,7 @@ hr
 hr
 Je
 hx
-uI
+CD
 Mr
 rF
 Dv
@@ -158645,7 +158588,7 @@ Gz
 rz
 kg
 If
-kE
+ve
 Mr
 rF
 Dv
@@ -158902,7 +158845,7 @@ kg
 kg
 kg
 YJ
-kE
+ve
 rF
 rF
 Dv
@@ -159414,8 +159357,8 @@ yG
 kg
 xQ
 kg
-uI
-hg
+CD
+SN
 Ha
 rF
 Dv
@@ -162757,7 +162700,7 @@ ZH
 Ya
 kt
 wA
-ve
+cs
 UV
 zh
 eX
@@ -163014,11 +162957,11 @@ aN
 Pi
 kt
 Zp
-QO
+kE
 vD
 vD
 vD
-eP
+Ur
 aK
 aK
 aK
@@ -163270,8 +163213,8 @@ he
 qy
 qA
 kt
+wq
 Is
-QE
 NM
 dJ
 dJ
@@ -163530,7 +163473,7 @@ kt
 kt
 AI
 kt
-TY
+HG
 aK
 aK
 aK
@@ -163787,7 +163730,7 @@ py
 Ji
 HD
 jc
-TY
+HG
 aK
 aK
 aK
@@ -163796,10 +163739,10 @@ aK
 aD
 aK
 aK
-CD
-Zt
-Zt
-Zb
+kZ
+Ly
+Ly
+uI
 eb
 eb
 eb
@@ -164044,19 +163987,19 @@ Ys
 kt
 HO
 jc
-TY
+HG
 aK
 eb
 eb
 aK
 aK
-Bw
-tR
+eV
+Vs
+vQ
+BX
 qU
-gx
-Ee
-Ee
-ct
+qU
+om
 eb
 eb
 eb
@@ -164310,10 +164253,10 @@ aK
 aK
 aK
 eb
-QN
-Ly
-Ly
-NQ
+Ee
+ps
+ps
+eP
 eb
 eb
 eb
@@ -167392,7 +167335,7 @@ fP
 aK
 aK
 Kk
-om
+TA
 fP
 fP
 eb
@@ -167639,7 +167582,7 @@ ol
 eb
 eb
 eb
-Pc
+FZ
 Ym
 SP
 SP
@@ -167649,7 +167592,7 @@ SP
 SP
 SP
 Ym
-om
+TA
 aK
 fP
 eb
@@ -167865,8 +167808,8 @@ aK
 Qz
 ON
 rw
-vQ
-vQ
+mx
+mx
 vA
 ON
 ON
@@ -168677,7 +168620,7 @@ Zz
 FT
 Qa
 SP
-ps
+gx
 Tc
 eb
 eb
@@ -168935,7 +168878,7 @@ yl
 Ym
 Ym
 Ym
-om
+TA
 eb
 eb
 eb
@@ -169188,11 +169131,11 @@ Sz
 xr
 yX
 PV
-RD
+QN
 Ym
 cX
 cX
-om
+TA
 aK
 eb
 eb
@@ -169449,7 +169392,7 @@ eH
 Ym
 cX
 cX
-ps
+gx
 Tc
 eb
 eb
@@ -169707,7 +169650,7 @@ rU
 rU
 rU
 rU
-om
+TA
 eb
 eb
 eb
@@ -169964,7 +169907,7 @@ rU
 Og
 Ko
 cE
-om
+TA
 eb
 eb
 eb
@@ -170221,7 +170164,7 @@ cE
 hV
 xU
 cE
-om
+TA
 eb
 eb
 eb
@@ -170478,7 +170421,7 @@ qo
 IV
 iD
 cE
-TA
+gb
 aK
 eb
 eb
@@ -170703,7 +170646,7 @@ eb
 eb
 eb
 eb
-Vr
+tk
 aK
 cW
 cW
@@ -170735,7 +170678,7 @@ cE
 hi
 tT
 cE
-om
+TA
 fP
 eb
 eb
@@ -170953,7 +170896,7 @@ kV
 kV
 ON
 Ae
-wH
+Zt
 fP
 eb
 eb
@@ -170987,12 +170930,12 @@ Sq
 cy
 It
 yf
-aR
+jZ
 cE
 aq
 ij
 cE
-ps
+gx
 Tc
 eb
 eb
@@ -171225,7 +171168,7 @@ kv
 iu
 hE
 gz
-SN
+Zb
 Uf
 lq
 iu
@@ -171250,7 +171193,7 @@ rU
 rU
 rU
 eA
-ps
+gx
 Nl
 eb
 eb
@@ -171731,7 +171674,7 @@ eb
 eb
 eb
 eb
-wv
+rr
 aK
 cW
 cW
@@ -171761,8 +171704,8 @@ yf
 NT
 zc
 ou
-Go
-kQ
+Fy
+wv
 Nv
 BS
 eA
@@ -172015,7 +171958,7 @@ Ym
 Ym
 Ym
 df
-Eb
+XT
 Ym
 pg
 Ce
@@ -173530,8 +173473,8 @@ eb
 eb
 eb
 eb
-Hl
-Hl
+RD
+RD
 cW
 cW
 cW
@@ -173788,9 +173731,9 @@ eb
 eb
 eb
 eb
-Hl
-Hl
-Hl
+RD
+RD
+RD
 OW
 zg
 oy
@@ -176101,7 +176044,7 @@ aK
 xe
 oA
 Ey
-gt
+Hl
 WU
 QX
 sX
@@ -177634,7 +177577,7 @@ aK
 aK
 aK
 aK
-wq
+Pc
 aa
 Gb
 cU
@@ -178147,7 +178090,7 @@ aK
 aK
 aK
 SO
-Hl
+RD
 aK
 eb
 eb
@@ -179189,7 +179132,7 @@ rH
 fV
 dQ
 Cg
-HG
+qt
 pK
 Ob
 IL
@@ -180216,7 +180159,7 @@ aK
 aK
 hG
 aK
-Hl
+RD
 hT
 dY
 eb

--- a/_maps/map_files/Mining/Iceland.dmm
+++ b/_maps/map_files/Mining/Iceland.dmm
@@ -472,6 +472,7 @@
 	dir = 6
 	},
 /obj/machinery/seed_extractor,
+/obj/structure/cable,
 /turf/open/floor/iron/colony,
 /area/mine/lounge)
 "da" = (
@@ -895,6 +896,7 @@
 	dir = 4
 	},
 /obj/machinery/biogenerator,
+/obj/structure/cable,
 /turf/open/floor/iron/colony,
 /area/mine/lounge)
 "fL" = (

--- a/_maps/map_files/Mining/Iceland.dmm
+++ b/_maps/map_files/Mining/Iceland.dmm
@@ -400,13 +400,11 @@
 /turf/open/floor/catwalk_floor/colony_fabricator,
 /area/mine/production)
 "cK" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 1
-	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/effect/turf_decal/siding/red{
 	dir = 1
 	},
+/obj/machinery/biogenerator/food_replicator,
 /turf/open/floor/iron/colony/white,
 /area/mine/lounge)
 "cM" = (
@@ -469,7 +467,12 @@
 /turf/closed/wall/prefab_plastic,
 /area/mine/maintenance/living/north)
 "cX" = (
-/turf/open/floor/plating/snowed/icemoon,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/obj/machinery/seed_extractor,
+/turf/open/floor/iron/colony,
 /area/mine/lounge)
 "da" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -600,6 +603,18 @@
 /obj/structure/window/fulltile/colony_fabricator,
 /turf/open/floor/plating,
 /area/mine/eva)
+"dN" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/obj/structure/table/greyscale,
+/obj/item/reagent_containers/cup/bottle/nutrient/ez,
+/obj/item/cultivator,
+/obj/item/shovel/spade,
+/obj/item/secateurs,
+/obj/item/reagent_containers/cup/watering_can,
+/turf/open/floor/iron/colony,
+/area/mine/lounge)
 "dP" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -703,9 +718,7 @@
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 1
 	},
-/obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/colony,
 /area/mine/lounge)
 "eI" = (
@@ -877,6 +890,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/mine/maintenance/service)
+"fJ" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/machinery/biogenerator,
+/turf/open/floor/iron/colony,
+/area/mine/lounge)
 "fL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1223,7 +1243,6 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "hK" = (
-/obj/machinery/seed_extractor,
 /obj/machinery/camera/autoname/directional/east{
 	network = list("mine")
 	},
@@ -1231,6 +1250,16 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/structure/closet/crate/hydroponics,
+/obj/item/seeds/korta_nut,
+/obj/item/seeds/potato,
+/obj/item/seeds/lavaland/fireblossom,
+/obj/item/seeds/lavaland/inocybe,
+/obj/item/seeds/lavaland/polypore,
+/obj/item/seeds/lavaland/porcini,
+/obj/item/seeds/lavaland/seraka,
+/obj/item/seeds/lavaland/cactus,
+/obj/item/seeds/soya,
 /turf/open/floor/iron/colony,
 /area/mine/hydroponics)
 "hR" = (
@@ -1848,6 +1877,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/mine/maintenance/living/south)
 "lO" = (
@@ -2381,10 +2411,10 @@
 /turf/open/floor/iron/colony,
 /area/mine/laborcamp/security)
 "pB" = (
-/obj/machinery/biogenerator,
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 5
 	},
+/obj/machinery/hydroponics/constructable,
 /turf/open/floor/iron/colony,
 /area/mine/hydroponics)
 "pE" = (
@@ -2890,7 +2920,7 @@
 	name = "Air Tanks"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/aux_base,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /turf/open/floor/plating,
 /area/mine/maintenance/service)
 "th" = (
@@ -3074,6 +3104,12 @@
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/colony/white/texture,
 /area/mine/living_quarters)
+"uA" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/colony,
+/area/mine/lounge)
 "uC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/wideplating_new{
@@ -3104,13 +3140,13 @@
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
 "uN" = (
-/obj/structure/chair/sofa/corp{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/red{
+	dir = 4
+	},
+/obj/structure/chair/sofa/corp/left{
 	dir = 4
 	},
 /turf/open/floor/iron/colony/white,
@@ -3156,7 +3192,7 @@
 	name = "Power"
 	},
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/aux_base,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/mine/maintenance/service)
@@ -3370,11 +3406,11 @@
 	},
 /area/mine/production/middle)
 "wg" = (
-/obj/structure/chair/sofa/corp{
-	dir = 1
-	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/effect/turf_decal/siding/red{
+	dir = 1
+	},
+/obj/structure/chair/sofa/corp/right{
 	dir = 1
 	},
 /turf/open/floor/iron/colony/white,
@@ -3397,6 +3433,7 @@
 /area/mine/lounge)
 "wq" = (
 /obj/machinery/power/smes/full,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/mine/laborcamp/security/maintenance)
 "wr" = (
@@ -3501,7 +3538,6 @@
 /area/mine/cafeteria)
 "xr" = (
 /obj/structure/sink/directional/east,
-/obj/item/reagent_containers/cup/bucket,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
@@ -3781,6 +3817,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/mine/maintenance/public/south)
 "zd" = (
@@ -5706,18 +5743,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/mine/maintenance/public/north)
 "LM" = (
-/obj/structure/chair/sofa/corp/left{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/red{
 	dir = 4
 	},
+/obj/structure/table/greyscale,
 /turf/open/floor/iron/colony/white,
 /area/mine/lounge)
 "LO" = (
@@ -6194,13 +6232,12 @@
 /turf/open/floor/iron/smooth,
 /area/mine/laborcamp)
 "OM" = (
-/obj/structure/table/greyscale,
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
 	},
-/obj/machinery/biogenerator/foodricator,
+/obj/machinery/hydroponics/constructable,
 /turf/open/floor/iron/colony,
 /area/mine/hydroponics)
 "ON" = (
@@ -6426,7 +6463,8 @@
 /obj/effect/turf_decal/siding/red/corner{
 	dir = 1
 	},
-/obj/machinery/biogenerator/food_replicator,
+/obj/structure/table/greyscale,
+/obj/machinery/biogenerator/foodricator,
 /turf/open/floor/iron/colony/white,
 /area/mine/lounge)
 "Qb" = (
@@ -6520,9 +6558,6 @@
 "QN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
 	},
 /turf/open/floor/iron/colony,
 /area/mine/lounge)
@@ -6902,7 +6937,6 @@
 /area/mine/cafeteria)
 "Tp" = (
 /obj/effect/spawner/random/structure/closet_empty/crate/with_loot,
-/obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/mine/storage)
 "Tr" = (
@@ -6998,7 +7032,7 @@
 /obj/machinery/door/airlock/colony_prefab{
 	name = "Utility Storage"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/aux_base,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /turf/open/floor/plating,
 /area/mine/maintenance/service)
 "TW" = (
@@ -169132,9 +169166,9 @@ xr
 yX
 PV
 QN
+uA
+dN
 Ym
-cX
-cX
 TA
 aK
 eb
@@ -169389,9 +169423,9 @@ Pl
 ie
 fL
 eH
+fJ
+cX
 Ym
-cX
-cX
 gx
 Tc
 eb

--- a/_maps/map_files/Mining/Iceland.dmm
+++ b/_maps/map_files/Mining/Iceland.dmm
@@ -71,7 +71,6 @@
 /area/icemoon/underground/explored)
 "aB" = (
 /obj/machinery/shower/directional/east,
-/obj/machinery/space_heater/wall_mounted/directional/north,
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 4
 	},
@@ -110,7 +109,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/iron/dark/smooth_edge,
+/turf/open/floor/iron/colony,
 /area/mine/laborcamp/security)
 "aO" = (
 /obj/effect/decal/cleanable/dirt,
@@ -119,6 +118,13 @@
 	},
 /turf/open/floor/iron/checker,
 /area/mine/laborcamp)
+"aR" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/colony,
+/area/mine/lounge)
 "aV" = (
 /obj/structure/marker_beacon/teal,
 /obj/effect/turf_decal/stripes/corner{
@@ -285,6 +291,7 @@
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/mine/maintenance/public/south)
 "ci" = (
@@ -308,9 +315,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/light/floor,
-/turf/open/floor/iron/dark/smooth_edge{
-	dir = 1
-	},
+/turf/open/floor/iron/colony,
 /area/mine/laborcamp/security)
 "ck" = (
 /obj/structure/table/greyscale,
@@ -345,6 +350,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/mine/maintenance/service)
+"ct" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing,
+/turf/open/openspace/icemoon/keep_below,
+/area/icemoon/surface/outdoors/nospawn)
 "cw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -384,7 +394,9 @@
 /turf/open/floor/iron/colony/white,
 /area/mine/lounge)
 "cJ" = (
-/obj/machinery/door/airlock/colony_prefab,
+/obj/machinery/door/airlock/colony_prefab{
+	name = "Station Stairs"
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -481,7 +493,9 @@
 /turf/open/floor/iron/colony/white/bolts,
 /area/mine/cafeteria)
 "df" = (
-/obj/machinery/door/airlock/colony_prefab,
+/obj/machinery/door/airlock/colony_prefab{
+	name = "Shuttle Lounge"
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/colony_fabricator,
@@ -510,7 +524,9 @@
 /turf/open/floor/plating,
 /area/mine/production/lower)
 "dr" = (
-/obj/machinery/door/airlock/colony_prefab,
+/obj/machinery/door/airlock/colony_prefab{
+	name = "Enrichment Center"
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/smooth,
@@ -574,6 +590,7 @@
 	dir = 1
 	},
 /obj/structure/lattice/catwalk/mining,
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/openspace/icemoon/keep_below,
 /area/icemoon/surface/outdoors/nospawn)
 "dJ" = (
@@ -637,7 +654,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/machinery/space_heater/wall_mounted/directional/north,
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor/colony_fabricator,
 /area/mine/living_quarters)
@@ -694,7 +710,7 @@
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/catwalk_floor/colony_fabricator,
+/turf/open/floor/iron/colony,
 /area/mine/lounge)
 "eI" = (
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -713,12 +729,12 @@
 /turf/open/floor/iron/colony/white,
 /area/mine/cafeteria)
 "eP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/power/floodlight,
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/camera/autoname/directional/north,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "eQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -790,7 +806,9 @@
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "fk" = (
-/obj/machinery/door/airlock/colony_prefab,
+/obj/machinery/door/airlock/colony_prefab{
+	name = "Mineral Processing"
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
@@ -841,7 +859,7 @@
 "fD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/structure/railing,
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "fH" = (
@@ -890,10 +908,9 @@
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "fS" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line,
 /mob/living/simple_animal/bot/secbot/beepsky/ofitser,
-/turf/open/floor/catwalk_floor/colony_fabricator,
+/turf/open/floor/iron/colony,
 /area/mine/laborcamp/security)
 "fU" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -974,8 +991,8 @@
 /area/mine/lounge)
 "gq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/machinery/power/smes/battery_pack/precharged,
 /obj/structure/cable,
+/obj/machinery/power/smes/battery_pack/large/precharged,
 /turf/open/floor/plating,
 /area/mine/maintenance/service)
 "gs" = (
@@ -984,17 +1001,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
 /area/mine/laborcamp/quarters)
+"gt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/closet_empty/crate/with_loot,
+/turf/open/floor/plating,
+/area/mine/storage)
 "gx" = (
-/obj/machinery/door/airlock/external/glass{
-	name = "Mining External Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "lavaland_mining_north"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/supply/mining_station,
+/obj/structure/lattice/catwalk,
 /obj/structure/cable,
-/turf/open/floor/iron/dark/textured_large,
-/area/mine/production)
+/turf/open/openspace/icemoon/keep_below,
+/area/icemoon/surface/outdoors/nospawn)
 "gz" = (
 /obj/machinery/light/small/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -1092,13 +1108,14 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/catwalk_floor/colony_fabricator,
+/turf/open/floor/iron/colony,
 /area/mine/laborcamp/security)
 "hd" = (
-/obj/machinery/door/airlock/colony_prefab,
+/obj/machinery/door/airlock/colony_prefab{
+	name = "Labor Camp Shuttle Guard Airlock"
+	},
 /obj/effect/mapping_helpers/airlock/access/any/security/brig,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -1111,6 +1128,19 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/mine/laborcamp/security)
+"hg" = (
+/obj/machinery/door/airlock/external/glass{
+	name = "Labor Camp External Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "lavaland_gulag_east"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/any/security/brig,
+/turf/open/floor/catwalk_floor/colony_fabricator,
+/area/mine/maintenance/labor)
 "hi" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -1160,7 +1190,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/catwalk_floor/colony_fabricator,
 /area/mine/maintenance/labor)
 "hy" = (
 /obj/structure/disposaloutlet,
@@ -1190,7 +1220,6 @@
 /area/mine/cafeteria)
 "hE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/machinery/space_heater/wall_mounted/directional/north,
 /turf/open/floor/iron/colony/white,
 /area/mine/living_quarters)
 "hF" = (
@@ -1246,13 +1275,17 @@
 /turf/open/floor/iron/checker,
 /area/mine/laborcamp)
 "hY" = (
-/obj/machinery/door/airlock/colony_prefab,
+/obj/machinery/door/airlock/colony_prefab{
+	name = "Prisoner Bunk"
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth,
 /area/mine/laborcamp/quarters)
 "ia" = (
-/obj/machinery/door/airlock/colony_prefab,
+/obj/machinery/door/airlock/colony_prefab{
+	name = "Emergency Clinic"
+	},
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white/side{
 	dir = 1
@@ -1262,7 +1295,9 @@
 /turf/open/floor/iron/colony/white,
 /area/mine/lounge)
 "ie" = (
-/obj/machinery/door/airlock/colony_prefab,
+/obj/machinery/door/airlock/colony_prefab{
+	name = "Native Hydroponics"
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -1293,7 +1328,6 @@
 /turf/open/floor/iron/colony,
 /area/mine/storage/public)
 "io" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/red/filled/line,
@@ -1412,15 +1446,19 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/colony,
 /area/mine/laborcamp/security)
 "jj" = (
-/obj/machinery/door/airlock/colony_prefab,
+/obj/machinery/door/airlock/colony_prefab{
+	name = "Maintenance"
+	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /turf/open/floor/plating,
 /area/mine/maintenance/public/north)
 "jm" = (
-/obj/machinery/door/airlock/colony_prefab,
+/obj/machinery/door/airlock/colony_prefab{
+	name = "Showers"
+	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1439,7 +1477,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/colony,
 /area/mine/laborcamp/security)
 "jr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1513,8 +1551,7 @@
 /area/mine/cafeteria)
 "jT" = (
 /obj/structure/railing/corner,
-/obj/structure/cable,
-/turf/open/misc/asteroid/snow/icemoon,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "jU" = (
 /obj/machinery/conveyor{
@@ -1534,7 +1571,6 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
-/obj/machinery/space_heater/wall_mounted/directional/north,
 /turf/open/floor/iron/dark/smooth_edge,
 /area/mine/production/middle)
 "ka" = (
@@ -1574,7 +1610,6 @@
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/railing{
 	dir = 5
 	},
@@ -1606,7 +1641,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor/colony_fabricator,
 /area/mine/maintenance/labor)
 "kF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply,
@@ -1650,7 +1686,9 @@
 /turf/open/floor/iron/colony/white,
 /area/mine/lounge)
 "kL" = (
-/obj/machinery/door/airlock/colony_prefab,
+/obj/machinery/door/airlock/colony_prefab{
+	name = "Cafeteria-Bunks"
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -1659,12 +1697,17 @@
 	},
 /turf/open/floor/iron/colony,
 /area/mine/cafeteria)
+"kQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/mine/maintenance/public/south)
 "kR" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners{
 	dir = 1
 	},
 /obj/machinery/mining_weather_monitor/directional/west,
-/obj/machinery/space_heater/wall_mounted/directional/north,
 /obj/structure/chair/plastic,
 /turf/open/floor/iron/colony,
 /area/mine/cafeteria)
@@ -1765,11 +1808,6 @@
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "lx" = (
-/obj/machinery/button/door/directional/east{
-	id = "labor";
-	name = "Labor Camp Lockdown";
-	req_access = list("brig")
-	},
 /obj/machinery/light/small/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/colony/texture,
@@ -1796,7 +1834,9 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/underground/explored)
 "lJ" = (
-/obj/machinery/door/airlock/colony_prefab,
+/obj/machinery/door/airlock/colony_prefab{
+	name = "Security Supply"
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/any/security/brig,
@@ -1815,7 +1855,9 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/mine/production)
 "lN" = (
-/obj/machinery/door/airlock/colony_prefab,
+/obj/machinery/door/airlock/colony_prefab{
+	name = "Maintenance"
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -1845,11 +1887,10 @@
 /turf/open/floor/iron/colony/white,
 /area/mine/lounge)
 "lV" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
 	},
-/turf/open/floor/catwalk_floor/colony_fabricator,
+/turf/open/floor/iron/colony,
 /area/mine/laborcamp/security)
 "lX" = (
 /obj/structure/sink/directional/east,
@@ -1877,7 +1918,9 @@
 /turf/open/floor/iron/colony/white,
 /area/mine/lounge)
 "my" = (
-/obj/machinery/door/airlock/colony_prefab,
+/obj/machinery/door/airlock/colony_prefab{
+	name = "Maintenance"
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -1899,6 +1942,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/colony_fabricator,
 /area/mine/laborcamp/security)
 "mF" = (
@@ -1934,7 +1978,6 @@
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/railing{
 	dir = 4
 	},
@@ -1972,7 +2015,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
 	},
-/turf/open/floor/catwalk_floor/colony_fabricator,
+/turf/open/floor/iron/colony,
 /area/mine/lounge)
 "mT" = (
 /obj/structure/table/greyscale,
@@ -1999,9 +2042,9 @@
 /turf/open/floor/iron/smooth,
 /area/mine/laborcamp/production)
 "ni" = (
-/obj/structure/cable,
 /obj/structure/rack,
 /obj/item/stack/sheet/mineral/plasma/five,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/mine/maintenance/service)
 "nk" = (
@@ -2023,7 +2066,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
 	},
-/turf/open/floor/catwalk_floor/colony_fabricator,
+/turf/open/floor/iron/colony,
 /area/mine/laborcamp/security)
 "nv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -2039,7 +2082,7 @@
 	dir = 10
 	},
 /obj/machinery/mining_weather_monitor/directional/south,
-/turf/open/floor/catwalk_floor/colony_fabricator,
+/turf/open/floor/iron/colony,
 /area/mine/laborcamp/security)
 "nA" = (
 /obj/effect/turf_decal/bot,
@@ -2116,12 +2159,12 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/iron/dark/smooth_edge{
-	dir = 1
-	},
+/turf/open/floor/iron/colony,
 /area/mine/laborcamp/security)
 "ob" = (
-/obj/machinery/door/airlock/colony_prefab,
+/obj/machinery/door/airlock/colony_prefab{
+	name = "Cafeteria"
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/bar/opposingcorners{
@@ -2169,9 +2212,12 @@
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "om" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/mine/laborcamp)
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/railing,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "op" = (
 /obj/machinery/camera/autoname/directional/south{
 	network = list("mine")
@@ -2302,10 +2348,11 @@
 /turf/open/floor/iron/white,
 /area/mine/laborcamp/production)
 "ps" = (
-/obj/machinery/power/terminal,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/mine/maintenance/service)
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "pu" = (
 /obj/item/chair/stool{
 	pixel_x = -2;
@@ -2333,14 +2380,13 @@
 /turf/open/floor/iron/colony/white/texture,
 /area/mine/cafeteria)
 "py" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/airalarm/directional/west,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/colony,
 /area/mine/laborcamp/security)
 "pB" = (
 /obj/machinery/biogenerator,
@@ -2471,7 +2517,9 @@
 /turf/open/floor/plating,
 /area/mine/production/middle)
 "qo" = (
-/obj/machinery/door/airlock/colony_prefab,
+/obj/machinery/door/airlock/colony_prefab{
+	name = "Expedition Supplies"
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -2482,7 +2530,9 @@
 /turf/open/floor/iron/colony,
 /area/mine/storage/public)
 "qp" = (
-/obj/machinery/door/airlock/colony_prefab,
+/obj/machinery/door/airlock/colony_prefab{
+	name = "Cafeteria-Bunks"
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/bar/opposingcorners{
@@ -2522,7 +2572,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/colony,
 /area/mine/laborcamp/security)
 "qA" = (
 /obj/structure/table/greyscale,
@@ -2530,15 +2580,16 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
 	},
-/obj/machinery/space_heater/wall_mounted/directional/south,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/colony,
 /area/mine/laborcamp/security)
 "qE" = (
 /obj/structure/fence/door,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/underground/explored)
 "qH" = (
-/obj/machinery/door/airlock/colony_prefab,
+/obj/machinery/door/airlock/colony_prefab{
+	name = "Private Shower"
+	},
 /obj/effect/turf_decal/siding/white{
 	dir = 8
 	},
@@ -2560,7 +2611,14 @@
 /turf/open/floor/iron/colony/white/bolts,
 /area/mine/cafeteria)
 "qU" = (
+/obj/structure/lattice/catwalk,
 /obj/structure/cable,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 4
+	},
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "qV" = (
@@ -2679,7 +2737,7 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/effect/turf_decal/trimline/brown/filled/warning,
-/turf/open/floor/catwalk_floor/colony_fabricator,
+/turf/open/floor/iron/colony,
 /area/mine/lounge)
 "rZ" = (
 /obj/structure/cable,
@@ -2755,15 +2813,12 @@
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "sx" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/small/directional/west,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
-/turf/open/floor/iron/dark/smooth_edge{
-	dir = 4
-	},
+/turf/open/floor/iron/colony,
 /area/mine/laborcamp/security)
 "sy" = (
 /obj/structure/bonfire,
@@ -2774,6 +2829,7 @@
 /obj/structure/sign/departments/medbay/alt/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/north,
+/obj/machinery/space_heater,
 /turf/open/floor/iron/smooth_edge,
 /area/mine/laborcamp/production)
 "sI" = (
@@ -2837,7 +2893,9 @@
 /area/mine/cafeteria)
 "tg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/colony_prefab,
+/obj/machinery/door/airlock/colony_prefab{
+	name = "Air Tanks"
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/aux_base,
 /turf/open/floor/plating,
@@ -2907,8 +2965,10 @@
 /area/icemoon/underground/explored)
 "tG" = (
 /obj/machinery/light/small/directional/west,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor/colony_fabricator,
 /area/mine/laborcamp/security/maintenance)
 "tL" = (
 /obj/machinery/light/small/directional/east,
@@ -2918,6 +2978,14 @@
 /obj/machinery/vending/assist,
 /turf/open/floor/iron/colony,
 /area/mine/living_quarters)
+"tR" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "tT" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/structure/table/greyscale,
@@ -2972,7 +3040,9 @@
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "uk" = (
-/obj/machinery/door/airlock/colony_prefab,
+/obj/machinery/door/airlock/colony_prefab{
+	name = "Lounge"
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/bar/opposingcorners{
@@ -3010,7 +3080,9 @@
 /turf/open/floor/iron/colony/white/bolts,
 /area/mine/cafeteria)
 "ux" = (
-/obj/machinery/door/airlock/colony_prefab,
+/obj/machinery/door/airlock/colony_prefab{
+	name = "Bunk B"
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/blue/fourcorners,
@@ -3033,7 +3105,8 @@
 "uI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor/colony_fabricator,
 /area/mine/maintenance/labor)
 "uM" = (
 /obj/structure/fence{
@@ -3062,7 +3135,6 @@
 "uR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/lattice/catwalk/mining,
 /obj/structure/railing,
 /turf/open/openspace/icemoon/keep_below,
@@ -3091,7 +3163,9 @@
 /turf/open/floor/iron/colony/white,
 /area/mine/medical)
 "vc" = (
-/obj/machinery/door/airlock/colony_prefab,
+/obj/machinery/door/airlock/colony_prefab{
+	name = "Power"
+	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/aux_base,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -3105,14 +3179,12 @@
 /area/icemoon/surface/outdoors/nospawn)
 "ve" = (
 /obj/structure/cable,
-/obj/machinery/power/terminal{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/mine/maintenance/labor)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/colony_fabricator,
+/area/mine/laborcamp/security/maintenance)
 "vf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -3124,7 +3196,9 @@
 /turf/open/floor/plating,
 /area/mine/maintenance/service)
 "vh" = (
-/obj/machinery/door/airlock/colony_prefab,
+/obj/machinery/door/airlock/colony_prefab{
+	name = "Sleeping Quarters"
+	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -3159,7 +3233,7 @@
 	dir = 9
 	},
 /obj/machinery/mining_weather_monitor/directional/north,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/colony,
 /area/mine/laborcamp/security)
 "vp" = (
 /obj/structure/window/fulltile/colony_fabricator,
@@ -3179,7 +3253,7 @@
 "vA" = (
 /obj/machinery/light/small/directional/west,
 /obj/structure/rack,
-/obj/item/flatpacked_machine/thermomachine,
+/obj/effect/spawner/random/engineering/toolbox,
 /turf/open/floor/plating,
 /area/mine/maintenance/service)
 "vB" = (
@@ -3197,7 +3271,9 @@
 /turf/closed/wall/prefab_plastic,
 /area/mine/laborcamp/security/maintenance)
 "vF" = (
-/obj/machinery/door/airlock/colony_prefab,
+/obj/machinery/door/airlock/colony_prefab{
+	name = "Mining Maintenance"
+	},
 /obj/effect/mapping_helpers/airlock/access/all/supply/mining_station,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/open/floor/plating,
@@ -3233,7 +3309,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/colony,
 /area/mine/laborcamp/security)
 "vO" = (
 /obj/effect/decal/cleanable/dirt,
@@ -3245,9 +3321,10 @@
 /turf/open/floor/iron/dark,
 /area/mine/laborcamp)
 "vQ" = (
-/obj/structure/cable,
-/turf/open/floor/iron/colony/texture,
-/area/mine/production)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/mine/maintenance/service)
 "vS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -3257,7 +3334,7 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/newscaster/directional/south,
-/turf/open/floor/catwalk_floor/colony_fabricator,
+/turf/open/floor/iron/colony,
 /area/mine/lounge)
 "vU" = (
 /obj/structure/ore_box,
@@ -3325,13 +3402,11 @@
 /turf/open/floor/iron/colony/white,
 /area/mine/lounge)
 "wq" = (
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
+/obj/structure/railing/corner{
+	dir = 8
 	},
-/obj/structure/chair/plastic,
-/obj/machinery/space_heater/wall_mounted/directional/east,
-/turf/open/floor/iron/colony,
-/area/mine/cafeteria)
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "wr" = (
 /obj/item/seeds/plump,
 /obj/machinery/hydroponics/soil,
@@ -3354,22 +3429,17 @@
 /turf/open/floor/iron/dark,
 /area/mine/laborcamp)
 "wv" = (
-/obj/structure/lattice/catwalk/mining,
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/openspace/icemoon/keep_below,
+/obj/machinery/camera/autoname/directional/west,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "wA" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/turf/open/floor/catwalk_floor/colony_fabricator,
+/obj/structure/cable,
+/obj/structure/closet/radiation,
+/turf/open/floor/plating,
 /area/mine/laborcamp/security/maintenance)
 "wE" = (
 /obj/item/chair/wood,
@@ -3382,6 +3452,11 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/mine/production/middle)
+"wH" = (
+/obj/structure/flora/grass/both/style_random,
+/obj/machinery/camera/autoname/directional/west,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "wJ" = (
 /obj/machinery/airalarm/directional/east,
 /obj/structure/table/greyscale,
@@ -3502,7 +3577,9 @@
 "xI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/colony_prefab,
+/obj/machinery/door/airlock/colony_prefab{
+	name = "Telecommunications Relay"
+	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
 /turf/open/floor/plating,
@@ -3609,7 +3686,9 @@
 /turf/closed/wall/prefab_plastic,
 /area/mine/hydroponics)
 "yl" = (
-/obj/machinery/door/airlock/colony_prefab,
+/obj/machinery/door/airlock/colony_prefab{
+	name = "Expedition Lounge"
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -3695,13 +3774,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/colony_fabricator,
 /area/mine/laborcamp/security/maintenance)
 "yT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/space_heater/wall_mounted/directional/north,
 /turf/open/floor/iron/smooth,
 /area/mine/laborcamp/production)
 "yV" = (
@@ -3712,7 +3791,9 @@
 /turf/open/floor/plating,
 /area/mine/hydroponics)
 "zc" = (
-/obj/machinery/door/airlock/colony_prefab,
+/obj/machinery/door/airlock/colony_prefab{
+	name = "Maintenance"
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -3725,7 +3806,9 @@
 /turf/open/floor/plating,
 /area/mine/maintenance/service)
 "zf" = (
-/obj/machinery/door/airlock/colony_prefab,
+/obj/machinery/door/airlock/colony_prefab{
+	name = "Community Showers"
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/siding/white,
@@ -3748,6 +3831,7 @@
 /area/mine/laborcamp/security/maintenance)
 "zi" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/firecloset/full,
 /turf/open/floor/plating,
 /area/mine/laborcamp/security/maintenance)
 "zj" = (
@@ -3944,7 +4028,6 @@
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/railing,
 /obj/structure/railing{
 	dir = 1
@@ -3976,11 +4059,12 @@
 /turf/open/floor/iron/smooth,
 /area/mine/laborcamp)
 "AI" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/colony_prefab,
+/obj/machinery/door/airlock/colony_prefab{
+	name = "Security Post Power"
+	},
 /obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/open/floor/catwalk_floor/colony_fabricator,
@@ -3996,7 +4080,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/colony,
 /area/mine/laborcamp/security)
 "AN" = (
 /obj/effect/decal/cleanable/dirt,
@@ -4014,6 +4098,7 @@
 /turf/open/floor/iron/colony/white/bolts,
 /area/mine/cafeteria)
 "AX" = (
+/obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/mine/laborcamp/security/maintenance)
 "Bb" = (
@@ -4023,7 +4108,6 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 5
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/colony,
 /area/mine/production)
 "Bd" = (
@@ -4047,13 +4131,20 @@
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor/colony_fabricator,
 /area/mine/living_quarters)
+"Bw" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/obj/structure/railing{
+	dir = 5
+	},
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "By" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "labor";
 	name = "Labor Camp Blast Door"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/space_heater/wall_mounted/directional/east,
 /turf/open/floor/iron/smooth,
 /area/mine/laborcamp)
 "BA" = (
@@ -4088,7 +4179,6 @@
 "BS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/mine/maintenance/public/south)
 "BT" = (
@@ -4142,7 +4232,9 @@
 /turf/open/floor/iron/colony/bolts,
 /area/mine/production)
 "Cm" = (
-/obj/machinery/door/airlock/colony_prefab,
+/obj/machinery/door/airlock/colony_prefab{
+	name = "Cafeteria"
+	},
 /obj/effect/turf_decal/tile/bar/opposingcorners{
 	dir = 1
 	},
@@ -4158,7 +4250,9 @@
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
 "Cz" = (
-/obj/machinery/door/airlock/colony_prefab,
+/obj/machinery/door/airlock/colony_prefab{
+	name = "Prisoner Clinic"
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
@@ -4187,11 +4281,14 @@
 /turf/open/floor/iron/colony/white/texture,
 /area/mine/living_quarters)
 "CD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/lattice/catwalk,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/mine/maintenance/labor)
+/obj/machinery/power/rtg/old_station,
+/obj/structure/railing{
+	dir = 9
+	},
+/turf/open/openspace/icemoon/keep_below,
+/area/icemoon/surface/outdoors/nospawn)
 "CE" = (
 /obj/structure/table/greyscale,
 /obj/item/mecha_parts/mecha_equipment/drill{
@@ -4233,7 +4330,9 @@
 /turf/open/floor/iron/colony,
 /area/mine/mechbay)
 "CS" = (
-/obj/machinery/door/airlock/colony_prefab,
+/obj/machinery/door/airlock/colony_prefab{
+	name = "Emergency Clinic Maintenance"
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -4295,7 +4394,9 @@
 /turf/open/floor/iron/smooth_large,
 /area/mine/laborcamp)
 "Dl" = (
-/obj/machinery/door/airlock/colony_prefab,
+/obj/machinery/door/airlock/colony_prefab{
+	name = "Labor Camp Shuttle Guard Airlock"
+	},
 /obj/effect/mapping_helpers/airlock/access/any/security/brig,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/effect/decal/cleanable/dirt,
@@ -4383,7 +4484,6 @@
 "DZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/lattice/catwalk/mining,
 /obj/structure/railing,
 /obj/structure/railing{
@@ -4391,6 +4491,15 @@
 	},
 /turf/open/openspace/icemoon/keep_below,
 /area/icemoon/surface/outdoors/nospawn)
+"Eb" = (
+/obj/machinery/door/airlock/colony_prefab{
+	name = "Shuttle Lounge"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor/colony_fabricator,
+/area/mine/lounge)
 "Ec" = (
 /obj/docking_port/stationary{
 	dir = 2;
@@ -4403,10 +4512,9 @@
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "Ee" = (
-/obj/machinery/power/smes/full,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/mine/maintenance/labor)
+/obj/structure/lattice/catwalk,
+/turf/open/openspace/icemoon/keep_below,
+/area/icemoon/surface/outdoors/nospawn)
 "Eg" = (
 /obj/structure/window/fulltile/colony_fabricator,
 /obj/structure/disposalpipe/segment,
@@ -4442,7 +4550,9 @@
 /turf/open/floor/circuit,
 /area/mine/maintenance/service/comms)
 "Ex" = (
-/obj/machinery/door/airlock/colony_prefab,
+/obj/machinery/door/airlock/colony_prefab{
+	name = "Bathroom"
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/white{
 	dir = 8
@@ -4451,7 +4561,7 @@
 /area/mine/laborcamp/quarters)
 "Ey" = (
 /obj/structure/closet/crate,
-/obj/effect/spawner/random/maintenance/two,
+/obj/effect/spawner/random/structure/closet_empty/crate/with_loot,
 /turf/open/floor/plating,
 /area/mine/storage)
 "Ez" = (
@@ -4561,8 +4671,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
 	},
-/obj/machinery/space_heater/wall_mounted/directional/north,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/colony,
 /area/mine/laborcamp/security)
 "Fs" = (
 /obj/effect/spawner/random/maintenance/two,
@@ -4592,6 +4701,7 @@
 /turf/open/floor/iron/colony/white,
 /area/mine/lounge)
 "FH" = (
+/obj/structure/sign/warning/radiation,
 /turf/closed/wall/ice,
 /area/icemoon/surface/outdoors/nospawn)
 "FL" = (
@@ -4667,6 +4777,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/colony_fabricator,
 /area/mine/laborcamp/security)
 "Gn" = (
@@ -4680,6 +4791,13 @@
 /obj/structure/railing,
 /turf/open/openspace/icemoon/keep_below,
 /area/icemoon/surface/outdoors/nospawn)
+"Go" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/steam_vent,
+/turf/open/floor/plating,
+/area/mine/maintenance/public/south)
 "Gr" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/iron/dark,
@@ -4725,7 +4843,9 @@
 /turf/open/floor/catwalk_floor/colony_fabricator,
 /area/mine/production)
 "GH" = (
-/obj/machinery/door/airlock/colony_prefab,
+/obj/machinery/door/airlock/colony_prefab{
+	name = "Expedition Lounge"
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/blue/fourcorners,
@@ -4744,7 +4864,7 @@
 /obj/structure/chair/office{
 	dir = 1
 	},
-/turf/open/floor/iron/dark/textured_large,
+/turf/open/floor/iron/colony/bolts,
 /area/mine/laborcamp/security)
 "GZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -4758,7 +4878,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/catwalk_floor/colony_fabricator,
 /area/mine/maintenance/labor)
 "Hb" = (
 /obj/structure/cable,
@@ -4766,7 +4886,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/structure/steam_vent,
-/turf/open/floor/plating,
+/turf/open/floor/catwalk_floor/colony_fabricator,
 /area/mine/maintenance/labor)
 "Hc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -4789,9 +4909,7 @@
 /turf/open/floor/plating,
 /area/mine/maintenance/public/north)
 "Hl" = (
-/obj/machinery/power/floodlight,
-/obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "Hp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -4825,7 +4943,6 @@
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/railing{
 	dir = 8
 	},
@@ -4859,13 +4976,12 @@
 	},
 /area/mine/production/lower)
 "HD" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/red/filled/end{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/colony,
 /area/mine/laborcamp/security)
 "HF" = (
 /obj/structure/railing/corner{
@@ -4874,13 +4990,12 @@
 /turf/closed/wall/prefab_plastic,
 /area/mine/production/lower)
 "HG" = (
-/obj/structure/railing{
-	dir = 4
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 6
 	},
-/obj/structure/lattice/catwalk/mining,
-/obj/structure/cable,
-/turf/open/openspace/icemoon/keep_below,
-/area/icemoon/surface/outdoors/nospawn)
+/obj/machinery/space_heater,
+/turf/open/floor/iron/colony,
+/area/mine/production)
 "HI" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -4891,7 +5006,8 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/north,
-/turf/open/floor/iron/dark,
+/obj/machinery/space_heater,
+/turf/open/floor/iron/colony,
 /area/mine/laborcamp/security)
 "HP" = (
 /obj/machinery/computer/mech_bay_power_console{
@@ -4964,7 +5080,6 @@
 /turf/closed/wall/prefab_plastic,
 /area/mine/maintenance/service)
 "If" = (
-/obj/structure/cable,
 /obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -4988,11 +5103,8 @@
 /turf/open/floor/carpet/royalblue,
 /area/mine/living_quarters)
 "Is" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/catwalk_floor/colony_fabricator,
+/obj/machinery/power/smes/full,
+/turf/open/floor/plating,
 /area/mine/laborcamp/security/maintenance)
 "It" = (
 /obj/structure/window/fulltile/colony_fabricator,
@@ -5012,7 +5124,6 @@
 /turf/open/floor/iron/white,
 /area/mine/laborcamp/production)
 "IA" = (
-/obj/structure/cable,
 /obj/structure/closet,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -5061,9 +5172,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/iron/dark/smooth_edge{
-	dir = 1
-	},
+/turf/open/floor/iron/colony,
 /area/mine/laborcamp/security)
 "IV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -5117,13 +5226,14 @@
 /turf/open/floor/plating,
 /area/mine/maintenance/service)
 "Ji" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/colony_prefab,
+/obj/machinery/door/airlock/colony_prefab{
+	name = "Storage and Power"
+	},
 /obj/effect/mapping_helpers/airlock/access/any/security/brig,
 /obj/effect/turf_decal/tile/red/fourcorners,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/colony,
 /area/mine/laborcamp/security)
 "Jl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -5135,13 +5245,13 @@
 /turf/open/floor/catwalk_floor/colony_fabricator,
 /area/mine/production)
 "Jn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/catwalk_floor/colony_fabricator,
 /area/mine/laborcamp/security/maintenance)
 "Jp" = (
@@ -5221,7 +5331,9 @@
 /turf/open/floor/plating,
 /area/mine/maintenance/labor)
 "JF" = (
-/obj/machinery/door/airlock/colony_prefab,
+/obj/machinery/door/airlock/colony_prefab{
+	name = "Public Supply Hall"
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -5273,11 +5385,14 @@
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "JN" = (
-/obj/machinery/door/airlock/colony_prefab,
+/obj/machinery/door/airlock/colony_prefab{
+	name = "Security Post Power"
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/colony_fabricator,
 /area/mine/laborcamp/security/maintenance)
 "JP" = (
@@ -5404,7 +5519,6 @@
 /obj/effect/turf_decal/siding/yellow{
 	dir = 1
 	},
-/obj/machinery/space_heater/wall_mounted/directional/north,
 /turf/open/floor/carpet/royalblue,
 /area/mine/living_quarters)
 "KI" = (
@@ -5552,11 +5666,12 @@
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "Ly" = (
-/obj/structure/lattice/catwalk/mining,
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/obj/machinery/power/rtg/old_station,
 /obj/structure/railing{
-	dir = 8
+	dir = 4
 	},
-/obj/structure/railing,
 /turf/open/openspace/icemoon/keep_below,
 /area/icemoon/surface/outdoors/nospawn)
 "Lz" = (
@@ -5606,7 +5721,9 @@
 	},
 /area/mine/laborcamp/quarters)
 "LK" = (
-/obj/machinery/door/airlock/colony_prefab,
+/obj/machinery/door/airlock/colony_prefab{
+	name = "Maintenance"
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -5709,7 +5826,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
 	},
-/turf/open/floor/catwalk_floor/colony_fabricator,
+/turf/open/floor/iron/colony,
 /area/mine/laborcamp/security)
 "My" = (
 /obj/machinery/light/small/directional/east,
@@ -5856,7 +5973,6 @@
 /obj/effect/turf_decal/trimline/red/filled/mid_joiner{
 	dir = 8
 	},
-/obj/machinery/space_heater/wall_mounted/directional/west,
 /turf/open/floor/iron/colony/bolts,
 /area/mine/production)
 "Ni" = (
@@ -5912,7 +6028,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /turf/open/floor/plating,
 /area/mine/maintenance/public/south)
@@ -5946,7 +6061,9 @@
 "NE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/colony_prefab,
+/obj/machinery/door/airlock/colony_prefab{
+	name = "Bunk C"
+	},
 /obj/effect/mapping_helpers/airlock/access/any/supply/mining_station,
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/colony/white/texture,
@@ -5964,8 +6081,18 @@
 /area/icemoon/underground/explored)
 "NM" = (
 /obj/structure/window/fulltile/colony_fabricator,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/mine/laborcamp/security/maintenance)
+"NQ" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/obj/machinery/power/rtg/old_station,
+/obj/structure/railing{
+	dir = 6
+	},
+/turf/open/openspace/icemoon/keep_below,
+/area/icemoon/surface/outdoors/nospawn)
 "NR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -6034,7 +6161,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/turf/open/floor/iron/dark/smooth_edge,
+/turf/open/floor/iron/colony,
 /area/mine/laborcamp/security)
 "Oj" = (
 /obj/structure/disposalpipe/segment,
@@ -6079,15 +6206,12 @@
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
 	},
-/turf/open/floor/iron/dark/smooth_corner{
-	dir = 4
-	},
+/turf/open/floor/iron/colony/bolts,
 /area/mine/laborcamp/security)
 "OD" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/railing,
 /obj/structure/railing{
 	dir = 10
@@ -6144,12 +6268,8 @@
 "OW" = (
 /obj/structure/lattice/catwalk/mining,
 /obj/structure/railing{
-	dir = 4
+	dir = 5
 	},
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/cable,
 /turf/open/openspace/icemoon/keep_below,
 /area/icemoon/surface/outdoors/nospawn)
 "OZ" = (
@@ -6161,7 +6281,7 @@
 /turf/open/floor/catwalk_floor/colony_fabricator,
 /area/mine/mechbay)
 "Pc" = (
-/obj/structure/closet/crate/grave,
+/obj/machinery/camera/autoname/directional/south,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "Pd" = (
@@ -6172,9 +6292,8 @@
 "Ph" = (
 /obj/structure/lattice/catwalk/mining,
 /obj/structure/railing{
-	dir = 4
+	dir = 6
 	},
-/obj/structure/railing,
 /turf/open/openspace/icemoon/keep_below,
 /area/icemoon/surface/outdoors/nospawn)
 "Pi" = (
@@ -6183,9 +6302,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/turf/open/floor/iron/dark/smooth_edge{
-	dir = 1
-	},
+/turf/open/floor/iron/colony,
 /area/mine/laborcamp/security)
 "Pk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -6216,7 +6333,7 @@
 	dir = 10
 	},
 /obj/item/radio/intercom/directional/south,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/colony,
 /area/mine/laborcamp/security)
 "Pp" = (
 /obj/item/toy/beach_ball,
@@ -6332,7 +6449,7 @@
 	},
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/power/apc/auto_name/directional/south,
-/turf/open/floor/catwalk_floor/colony_fabricator,
+/turf/open/floor/iron/colony,
 /area/mine/laborcamp/security)
 "PY" = (
 /obj/structure/table/greyscale,
@@ -6364,7 +6481,9 @@
 /turf/open/floor/iron/smooth,
 /area/mine/laborcamp/production)
 "Qi" = (
-/obj/machinery/door/airlock/colony_prefab,
+/obj/machinery/door/airlock/colony_prefab{
+	name = "Exosuit Bay"
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/any/supply/mining_station,
@@ -6411,8 +6530,20 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
+"QE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor/colony_fabricator,
+/area/mine/laborcamp/security/maintenance)
 "QG" = (
-/obj/machinery/door/airlock/colony_prefab,
+/obj/machinery/door/airlock/colony_prefab{
+	name = "Prisoner Bunk"
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
@@ -6435,17 +6566,19 @@
 /turf/open/floor/iron/colony,
 /area/mine/production)
 "QN" = (
-/obj/machinery/door/airlock/external/glass{
-	name = "Mining External Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "lavaland_mining_north"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/supply/mining_station,
-/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/structure/lattice/catwalk,
 /obj/structure/cable,
-/turf/open/floor/iron/dark/textured_large,
-/area/mine/production)
+/obj/machinery/power/rtg/old_station,
+/obj/structure/railing{
+	dir = 5
+	},
+/turf/open/openspace/icemoon/keep_below,
+/area/icemoon/surface/outdoors/nospawn)
+"QO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/colony_fabricator,
+/area/mine/laborcamp/security/maintenance)
 "QP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -6476,7 +6609,9 @@
 /turf/closed/wall/prefab_plastic,
 /area/mine/mechbay)
 "Ra" = (
-/obj/machinery/door/airlock/colony_prefab,
+/obj/machinery/door/airlock/colony_prefab{
+	name = "Mining EVA"
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -6566,6 +6701,7 @@
 "Rw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/toolcloset,
+/obj/effect/spawner/random/engineering/flashlight,
 /turf/open/floor/plating,
 /area/mine/maintenance/service)
 "Ry" = (
@@ -6580,9 +6716,14 @@
 /turf/open/openspace/icemoon/keep_below,
 /area/icemoon/surface/outdoors/nospawn)
 "RD" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/icemoon/surface/outdoors/nospawn)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron/colony,
+/area/mine/lounge)
 "RF" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -6699,7 +6840,6 @@
 /area/mine/medical)
 "Sr" = (
 /obj/item/cigbutt,
-/obj/machinery/space_heater/wall_mounted/directional/east,
 /turf/open/floor/iron/smooth,
 /area/mine/laborcamp)
 "Ss" = (
@@ -6708,12 +6848,11 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/effect/turf_decal/trimline/brown/filled/warning,
-/turf/open/floor/catwalk_floor/colony_fabricator,
+/turf/open/floor/iron/colony,
 /area/mine/lounge)
 "St" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/catwalk_floor/colony_fabricator,
+/turf/open/floor/iron/colony,
 /area/mine/laborcamp/security)
 "Sz" = (
 /obj/machinery/hydroponics/constructable,
@@ -6724,7 +6863,9 @@
 /turf/open/floor/iron/colony,
 /area/mine/hydroponics)
 "SA" = (
-/obj/machinery/door/airlock/colony_prefab,
+/obj/machinery/door/airlock/colony_prefab{
+	name = "Public Supply Hall"
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -6739,6 +6880,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/colony_fabricator,
 /area/mine/laborcamp/security)
 "SG" = (
@@ -6758,12 +6900,14 @@
 /turf/open/floor/iron/smooth_large,
 /area/mine/laborcamp)
 "SN" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/door/airlock/colony_prefab{
+	name = "Bunk A"
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/colony/texture,
-/area/mine/production)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/colony/white/texture,
+/area/mine/living_quarters)
 "SO" = (
 /obj/structure/marker_beacon/burgundy,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -6783,8 +6927,9 @@
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/railing,
+/obj/structure/railing{
+	dir = 10
+	},
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "Te" = (
@@ -6798,13 +6943,11 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
-/obj/machinery/space_heater/wall_mounted/directional/north,
 /turf/open/floor/iron/colony,
 /area/mine/eva)
 "Ti" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/structure/table/greyscale,
-/obj/item/paper/fluff/stations/lavaland/orm_notice,
+/obj/structure/closet/xenoarch,
 /turf/open/floor/iron/colony,
 /area/mine/production)
 "To" = (
@@ -6816,7 +6959,7 @@
 /turf/open/floor/iron/colony/white/bolts,
 /area/mine/cafeteria)
 "Tp" = (
-/obj/structure/closet/crate,
+/obj/effect/spawner/random/structure/closet_empty/crate/with_loot,
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/mine/storage)
@@ -6851,15 +6994,12 @@
 /turf/open/floor/plating,
 /area/mine/maintenance/living/north)
 "TA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 8
-	},
-/obj/machinery/space_heater/wall_mounted/directional/west,
-/obj/structure/cable,
-/turf/open/floor/catwalk_floor/colony_fabricator,
-/area/mine/production)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/railing,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "TD" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 1
@@ -6909,22 +7049,34 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/colony_fabricator,
 /area/mine/laborcamp/security)
 "TV" = (
-/obj/machinery/door/airlock/colony_prefab,
+/obj/machinery/door/airlock/colony_prefab{
+	name = "Utility Storage"
+	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/aux_base,
 /turf/open/floor/plating,
 /area/mine/maintenance/service)
 "TW" = (
-/obj/machinery/door/airlock/colony_prefab,
+/obj/machinery/door/airlock/colony_prefab{
+	name = "Power and Storage"
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/mine/laborcamp/security/maintenance)
+"TY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/lattice/catwalk,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "Ua" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -7001,8 +7153,9 @@
 /turf/open/floor/iron/smooth_edge,
 /area/mine/laborcamp)
 "Uu" = (
-/obj/machinery/door/airlock/colony_prefab,
-/obj/structure/cable,
+/obj/machinery/door/airlock/colony_prefab{
+	name = "Break Lounge"
+	},
 /obj/effect/mapping_helpers/airlock/access/any/security/brig,
 /obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/iron/dark,
@@ -7028,13 +7181,12 @@
 /turf/open/floor/iron/smooth,
 /area/mine/laborcamp/quarters)
 "UQ" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
 	},
 /obj/machinery/newscaster/directional/west,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/colony,
 /area/mine/laborcamp/security)
 "US" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners{
@@ -7153,6 +7305,10 @@
 /obj/effect/mapping_helpers/airlock/access/any/security/brig,
 /turf/open/floor/plating,
 /area/mine/maintenance/labor)
+"Vr" = (
+/obj/machinery/camera/autoname/directional/east,
+/turf/open/openspace/icemoon/keep_below,
+/area/icemoon/surface/outdoors/nospawn)
 "Vt" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
@@ -7197,7 +7353,6 @@
 /turf/open/floor/iron/checker,
 /area/mine/laborcamp)
 "VJ" = (
-/obj/structure/closet/crate,
 /obj/item/food/mint,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -7255,12 +7410,12 @@
 "We" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/mine/storage)
 "Wg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/machinery/airalarm/directional/south,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/mine/maintenance/service)
 "Wl" = (
@@ -7278,9 +7433,7 @@
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
 	},
-/turf/open/floor/iron/dark/smooth_corner{
-	dir = 1
-	},
+/turf/open/floor/iron/colony/bolts,
 /area/mine/laborcamp/security)
 "Wn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -7307,6 +7460,7 @@
 "Wx" = (
 /obj/structure/table/greyscale,
 /obj/effect/spawner/random/entertainment/lighter,
+/obj/machinery/light/small/blacklight/directional/west,
 /turf/open/floor/iron/colony/bolts,
 /area/mine/cafeteria)
 "Wy" = (
@@ -7396,7 +7550,9 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/underground/explored)
 "WX" = (
-/obj/machinery/door/airlock/colony_prefab,
+/obj/machinery/door/airlock/colony_prefab{
+	name = "Mining Station Production Storage"
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -7479,9 +7635,10 @@
 "Xt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/colony_prefab,
+/obj/machinery/door/airlock/colony_prefab{
+	name = "Security Post Maintenance"
+	},
 /obj/effect/mapping_helpers/airlock/access/any/security/brig,
 /turf/open/floor/plating,
 /area/mine/laborcamp/security)
@@ -7538,7 +7695,7 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/light/directional/south,
-/turf/open/floor/catwalk_floor/colony_fabricator,
+/turf/open/floor/iron/colony,
 /area/mine/lounge)
 "XH" = (
 /obj/structure/disposalpipe/segment{
@@ -7592,9 +7749,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/turf/open/floor/iron/dark/smooth_edge{
-	dir = 8
-	},
+/turf/open/floor/iron/colony,
 /area/mine/laborcamp/security)
 "Ya" = (
 /obj/machinery/vending/security{
@@ -7603,7 +7758,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/colony,
 /area/mine/laborcamp/security)
 "Yb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -7629,14 +7784,12 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/colony,
 /area/mine/production)
 "Yf" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/railing{
 	dir = 1
 	},
@@ -7698,7 +7851,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/colony,
 /area/mine/laborcamp/security)
 "Yv" = (
 /obj/structure/table/greyscale,
@@ -7770,10 +7923,14 @@
 /turf/open/floor/iron/smooth,
 /area/mine/laborcamp/production)
 "Zb" = (
-/obj/machinery/power/floodlight,
+/obj/structure/lattice/catwalk,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/obj/machinery/power/rtg/old_station,
+/obj/structure/railing{
+	dir = 10
+	},
+/turf/open/openspace/icemoon/keep_below,
+/area/icemoon/surface/outdoors/nospawn)
 "Zh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -7808,10 +7965,7 @@
 /area/mine/cafeteria)
 "Zp" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/spawner/random/structure/steam_vent,
-/turf/open/floor/catwalk_floor/colony_fabricator,
+/turf/open/floor/plating,
 /area/mine/laborcamp/security/maintenance)
 "Zq" = (
 /turf/closed/wall,
@@ -7823,9 +7977,13 @@
 /turf/open/floor/iron/smooth,
 /area/mine/laborcamp/production)
 "Zt" = (
+/obj/structure/lattice/catwalk,
 /obj/structure/cable,
-/obj/machinery/power/floodlight,
-/turf/open/floor/plating,
+/obj/machinery/power/rtg/old_station,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/openspace/icemoon/keep_below,
 /area/icemoon/surface/outdoors/nospawn)
 "Zv" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
@@ -7850,8 +8008,7 @@
 /area/icemoon/surface/outdoors/nospawn)
 "Zy" = (
 /obj/structure/cable,
-/obj/machinery/power/floodlight,
-/turf/open/floor/plating,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/underground/explored)
 "Zz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -7871,7 +8028,7 @@
 	dir = 9
 	},
 /obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/colony,
 /area/mine/laborcamp/security)
 "ZM" = (
 /turf/open/lava/plasma/ice_moon,
@@ -7884,6 +8041,7 @@
 	pixel_y = 24
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/mine/maintenance/living/north)
 "ZT" = (
@@ -50262,7 +50420,7 @@ pU
 pU
 qE
 ge
-Zb
+ge
 uM
 pU
 pU
@@ -115798,7 +115956,7 @@ pU
 pU
 yE
 DO
-eP
+WW
 ge
 yV
 ql
@@ -155905,7 +156063,7 @@ eb
 eb
 kg
 kg
-om
+rX
 RG
 fk
 gh
@@ -158743,8 +158901,8 @@ kg
 kg
 kg
 kg
-Ee
-ve
+YJ
+kE
 rF
 rF
 Dv
@@ -159256,8 +159414,8 @@ yG
 kg
 xQ
 kg
-CD
-Vq
+uI
+hg
 Ha
 rF
 Dv
@@ -162076,7 +162234,7 @@ fP
 aK
 aK
 aK
-Zt
+aK
 jc
 SB
 mD
@@ -162349,7 +162507,7 @@ vD
 dJ
 aK
 aK
-Pc
+aK
 aK
 eb
 eb
@@ -162599,7 +162757,7 @@ ZH
 Ya
 kt
 wA
-zh
+ve
 UV
 zh
 eX
@@ -162856,13 +163014,13 @@ aN
 Pi
 kt
 Zp
+QO
 vD
 vD
 vD
-vD
-dJ
+eP
 aK
-Pc
+aK
 aK
 aK
 fP
@@ -163113,15 +163271,15 @@ qy
 qA
 kt
 Is
-Is
+QE
 NM
 dJ
 dJ
 dJ
-aK
-aK
-aK
-aK
+aD
+aD
+aD
+aD
 aK
 aK
 eb
@@ -163372,14 +163530,14 @@ kt
 kt
 AI
 kt
-Ae
+TY
 aK
 aK
-Pc
 aK
-Pc
 aK
-Pc
+aK
+aD
+aK
 aK
 eb
 eb
@@ -163629,19 +163787,19 @@ py
 Ji
 HD
 jc
-Ae
+TY
 aK
 aK
 aK
 fP
 aK
+aD
 aK
 aK
-aK
-eb
-eb
-eb
-eb
+CD
+Zt
+Zt
+Zb
 eb
 eb
 eb
@@ -163886,19 +164044,19 @@ Ys
 kt
 HO
 jc
-Ae
+TY
 aK
 eb
 eb
 aK
-Pc
 aK
-aK
-aK
-eb
-eb
-eb
-eb
+Bw
+tR
+qU
+gx
+Ee
+Ee
+ct
 eb
 eb
 eb
@@ -164132,7 +164290,7 @@ eb
 aK
 aK
 aK
-Zt
+aK
 jc
 SG
 SG
@@ -164152,10 +164310,10 @@ aK
 aK
 aK
 eb
-eb
-eb
-eb
-eb
+QN
+Ly
+Ly
+NQ
 eb
 eb
 eb
@@ -164407,7 +164565,7 @@ aK
 eb
 eb
 aK
-aK
+FH
 eb
 eb
 eb
@@ -167234,7 +167392,7 @@ fP
 aK
 aK
 Kk
-Tc
+om
 fP
 fP
 eb
@@ -167481,7 +167639,7 @@ ol
 eb
 eb
 eb
-aK
+Pc
 Ym
 SP
 SP
@@ -167491,7 +167649,7 @@ SP
 SP
 SP
 Ym
-Tc
+om
 aK
 fP
 eb
@@ -167707,8 +167865,8 @@ aK
 Qz
 ON
 rw
-Hs
-Hs
+vQ
+vQ
 vA
 ON
 ON
@@ -168519,7 +168677,7 @@ Zz
 FT
 Qa
 SP
-dJ
+ps
 Tc
 eb
 eb
@@ -168777,7 +168935,7 @@ yl
 Ym
 Ym
 Ym
-Tc
+om
 eb
 eb
 eb
@@ -168985,12 +169143,12 @@ ZY
 aK
 aK
 aK
-Hl
+aK
 Ue
 AA
 gB
 og
-ps
+eW
 gq
 ER
 vc
@@ -169030,11 +169188,11 @@ Sz
 xr
 yX
 PV
-Gx
+RD
 Ym
 cX
 cX
-Tc
+om
 aK
 eb
 eb
@@ -169291,7 +169449,7 @@ eH
 Ym
 cX
 cX
-dJ
+ps
 Tc
 eb
 eb
@@ -169549,7 +169707,7 @@ rU
 rU
 rU
 rU
-Tc
+om
 eb
 eb
 eb
@@ -169782,7 +169940,7 @@ kY
 kY
 kY
 Fd
-wq
+Fd
 DW
 qg
 kY
@@ -169791,7 +169949,7 @@ kY
 kY
 gg
 gg
-Ly
+EU
 eb
 eb
 eb
@@ -169806,7 +169964,7 @@ rU
 Og
 Ko
 cE
-Tc
+om
 eb
 eb
 eb
@@ -170063,7 +170221,7 @@ cE
 hV
 xU
 cE
-Tc
+om
 eb
 eb
 eb
@@ -170320,7 +170478,7 @@ qo
 IV
 iD
 cE
-zU
+TA
 aK
 eb
 eb
@@ -170545,7 +170703,7 @@ eb
 eb
 eb
 eb
-eb
+Vr
 aK
 cW
 cW
@@ -170577,7 +170735,7 @@ cE
 hi
 tT
 cE
-dJ
+om
 fP
 eb
 eb
@@ -170795,7 +170953,7 @@ kV
 kV
 ON
 Ae
-fP
+wH
 fP
 eb
 eb
@@ -170829,12 +170987,12 @@ Sq
 cy
 It
 yf
-os
+aR
 cE
 aq
 ij
 cE
-dJ
+ps
 Tc
 eb
 eb
@@ -171067,7 +171225,7 @@ kv
 iu
 hE
 gz
-ux
+SN
 Uf
 lq
 iu
@@ -171092,7 +171250,7 @@ rU
 rU
 rU
 eA
-dJ
+ps
 Nl
 eb
 eb
@@ -171573,7 +171731,7 @@ eb
 eb
 eb
 eb
-aK
+wv
 aK
 cW
 cW
@@ -171603,8 +171761,8 @@ yf
 NT
 zc
 ou
-ou
-ou
+Go
+kQ
 Nv
 BS
 eA
@@ -171857,7 +172015,7 @@ Ym
 Ym
 Ym
 df
-SA
+Eb
 Ym
 pg
 Ce
@@ -173372,8 +173530,8 @@ eb
 eb
 eb
 eb
-Zt
-RD
+Hl
+Hl
 cW
 cW
 cW
@@ -173630,11 +173788,11 @@ eb
 eb
 eb
 eb
-RD
-RD
-RD
+Hl
+Hl
+Hl
 OW
-wv
+zg
 oy
 HR
 zg
@@ -174405,7 +174563,7 @@ eb
 eb
 eb
 eb
-RY
+Yq
 oy
 Wn
 Gb
@@ -175943,7 +176101,7 @@ aK
 xe
 oA
 Ey
-tV
+gt
 WU
 QX
 sX
@@ -177476,7 +177634,7 @@ aK
 aK
 aK
 aK
-Aw
+wq
 aa
 Gb
 cU
@@ -177491,7 +177649,7 @@ GL
 GL
 GL
 GL
-TA
+GL
 GL
 Jl
 rv
@@ -177734,14 +177892,14 @@ aK
 aK
 aK
 jT
-HG
-HG
-HG
-HG
-gx
-SN
-vQ
-QN
+pq
+pq
+pq
+pq
+Ki
+Uq
+cc
+ov
 Bb
 Ye
 GF
@@ -177990,7 +178148,7 @@ aK
 aK
 SO
 Hl
-qU
+aK
 eb
 eb
 eb
@@ -179031,7 +179189,7 @@ rH
 fV
 dQ
 Cg
-lb
+HG
 pK
 Ob
 IL


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Names all the doors! Finally, you can read what the door means to lead you to. Imagine. Readability.

Separates the Gulag and Security Post into their own - horrible - powernet.

Adds some (Horrible) RTGs to power this new much smaller power net.

## Why It's Good For The Game

Keeping the lights on at the mining base for at least 45 minutes to an hour without player intervention is Good.

## Changelog

:cl:
Removed The wall-mounted space heaters. A few have been placed in maints to compensate.
Added a new powernet for the gulag. Not that we use it, but the SMES unit was draining 50 KWs from the Actually-In-Use portion of the mining base.
![Screenshot 2024-11-21 201131](https://github.com/user-attachments/assets/e02dd95e-493f-499f-a6db-4db10d36bfb3)
![Screenshot 2024-11-21 201151](https://github.com/user-attachments/assets/0a83be3c-a08e-43fa-8e72-716a45f6caba)

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
