### PR TITLE
Bowtie 4 Loadout

### DIFF
--- a/code/modules/loadout/categories/neck.dm
+++ b/code/modules/loadout/categories/neck.dm
@@ -34,3 +34,7 @@
 /datum/loadout_item/neck/necktie_loose
 	name = "Necktie (Loose)"
 	item_path = /obj/item/clothing/neck/tie/detective
+
+/datum/loadout_item/neck/bowtie
+	name = "Bowtie (Colorable)"
+	item_path = /obj/item/clothing/neck/bowtie


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This adds the recolorable bowtie to the loadout, as the regular necktie cannot be converted into one despite having the icon state.

![image](https://github.com/user-attachments/assets/0093106d-b33a-4b20-ad03-fcf3502ea84b)

## Why It's Good For The Game

More options good. 😼

## Changelog

:cl:
add: Added a recolorable bowtie to loadout.
:cl:
