### PR TITLE
An Extremely Small Tweak To Honorbound

### DIFF
--- a/code/modules/religion/honorbound/honorbound_trauma.dm
+++ b/code/modules/religion/honorbound/honorbound_trauma.dm
@@ -273,13 +273,14 @@
 		to_chat(owner, span_warning("Followers of [GLOB.deity] cannot be evil!"))
 		return FALSE
 
-	/* cannot declare security as evil //DOPPLER EDIT CHANGE - You can, but they're good on a normal basis.
+	// cannot declare security as evil
+	/* //DOPPLER EDIT CHANGE START - Commented out. You can, but they're good on a normal basis.
 	if(living_cast_on.mind.assigned_role.departments_bitflags & DEPARTMENT_BITFLAG_SECURITY)
 		to_chat(owner, span_warning("Members of security are uncorruptable! You cannot declare one evil!"))
 		return FALSE
 
 	return TRUE
-	*/
+	*/ //DOPPLER EDIT CHANGE END
 /datum/action/cooldown/spell/pointed/declare_evil/before_cast(mob/living/cast_on)
 	. = ..()
 	if(. & SPELL_CANCEL_CAST)

--- a/code/modules/religion/honorbound/honorbound_trauma.dm
+++ b/code/modules/religion/honorbound/honorbound_trauma.dm
@@ -135,7 +135,7 @@
 		var/datum/job/job = target_human.mind?.assigned_role
 		var/is_holy = target_human.mind?.holy_role
 		if(is_holy || (job?.departments_bitflags & DEPARTMENT_BITFLAG_SECURITY))
-			to_chat(honorbound_human, span_warning("There is nothing righteous in attacking the <b>just</b>."))
+			to_chat(honorbound_human, span_warning("The <b>just</b> and fair guards? If you truly think they are not <b>innocent</b>, declare them guilty.")) //DOPPLER EDIT CHANGE - ORIGINAL: to_chat(honorbound_human, span_warning("There is nothing righteous in attacking the <b>just</b>."))
 			return FALSE
 		if(job?.departments_bitflags & DEPARTMENT_BITFLAG_MEDICAL && !is_guilty)
 			to_chat(honorbound_human, span_warning("If you truly think this healer is not <b>innocent</b>, declare them guilty."))
@@ -273,13 +273,13 @@
 		to_chat(owner, span_warning("Followers of [GLOB.deity] cannot be evil!"))
 		return FALSE
 
-	// cannot declare security as evil
+	/* cannot declare security as evil //DOPPLER EDIT CHANGE - You can, but they're good on a normal basis.
 	if(living_cast_on.mind.assigned_role.departments_bitflags & DEPARTMENT_BITFLAG_SECURITY)
 		to_chat(owner, span_warning("Members of security are uncorruptable! You cannot declare one evil!"))
 		return FALSE
 
 	return TRUE
-
+	*/
 /datum/action/cooldown/spell/pointed/declare_evil/before_cast(mob/living/cast_on)
 	. = ..()
 	if(. & SPELL_CANCEL_CAST)


### PR DESCRIPTION
## About The Pull Request
Sec are now just good by default, you can declare them evil manually.

## Why It's Good For The Game
There's going to be many cases in which you'll probably have an honorbound guy's TTRPG party running into conflict with Security, and it'd make sense if you could declare them evil manually.

## Changelog
:cl:
add: Honorbound Chaplains can now find it in them to betray the town guard.
/:cl:
