### PR TITLE
lets the modsuit pda app be linked to worn modsuits (with consent) (for entombed users) (fetishcoding)

### DIFF
--- a/modular_doppler/modsuit_pda_app/tap_to_control.dm
+++ b/modular_doppler/modsuit_pda_app/tap_to_control.dm
@@ -1,0 +1,23 @@
+/datum/computer_file/program/maintenance/modsuit_control/tap(atom/tapped_atom, mob/living/user, params)
+	. = ..()
+
+	if(!ishuman(tapped_atom))
+		return
+	var/mob/living/carbon/human/john_modsuit = tapped_atom
+	for(var/obj/item/mod/control/target_suit in john_modsuit.contents)
+		if(!do_after(user, 5 SECONDS, john_modsuit))
+			return
+		var/response = tgui_alert(
+			john_modsuit,
+			"[user] is attempting to link their PDA to your MOD, [target_suit]. This gives them TOTAL control of your suit, do you let them?",
+			"Connection Attempt",
+			list(
+				"Connect",
+				"Refuse",
+			),
+		)
+		if(response == "Connect")
+			sync_modsuit(target_suit, user)
+			playsound(target_suit, 'sound/effects/industrial_scan/industrial_scan2.ogg', 50, TRUE)
+		else
+			return

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6842,6 +6842,7 @@
 #include "modular_doppler\lore\overrides\station_traits\neutral_traits.dm"
 #include "modular_doppler\lore\overrides\station_traits\positive_traits.dm"
 #include "modular_doppler\loud_asay\code\loud_asay.dm"
+#include "modular_doppler\modsuit_pda_app\tap_to_control.dm"
 #include "modular_doppler\modular_antagonists\_dynamic_rulesets.dm"
 #include "modular_doppler\modular_antagonists\changeling\changeling.dm"
 #include "modular_doppler\modular_antagonists\datums\antag_recipes.dm"


### PR DESCRIPTION
## About The Pull Request

You can right click scan people with the modsuit control app open, which will ask the wearer if they accept you linking their pda to your suit. Has a warning that you are handing over total control of your space suit to someone's pda, to be fair. Also has a 5 sec delay before it asks you, so people can't be annoying by spamming you with it.

## Why It's Good For The Game

What if you wanted 2 scene but entombed means you can't take your suit off to link to the pda app

## Changelog

:cl:
add: The modsuit control pda app can be linked to other people's suit on their body with consent
/:cl:
