### PR TITLE
Adds The Elite MODsuit To Entombed

### DIFF
--- a/modular_doppler/modular_quirks/entombed/code/entombed.dm
+++ b/modular_doppler/modular_quirks/entombed/code/entombed.dm
@@ -176,6 +176,7 @@
 		"Mining",
 		"Prototype",
 		"Security",
+		"Elite",
 	)
 
 /datum/preference/choiced/entombed_skin/create_default_value()


### PR DESCRIPTION
## About The Pull Request
Just for aesthetics. Designed mostly so I can pair it with https://github.com/tgstation/tgstation/pull/88369 for plasmaman characters.

## Why It's Good For The Game
It uh. It looks really cool. It doesn't have the yellow visor normally so you probably won't get fooled into thinking it's an actual nukie.

## Changelog
:cl:
image: You can have the Elite MODsuit as a cosmetic-only skin for Entombed.
/:cl:
