### PR TITLE
makes the starter ore vent have a little bit of everything

### DIFF
--- a/modular_doppler/starter_resources/ore_vent.dm
+++ b/modular_doppler/starter_resources/ore_vent.dm
@@ -1,0 +1,13 @@
+/obj/structure/ore_vent/starter_resources
+	mineral_breakdown = list(
+		/datum/material/iron = 2,
+		/datum/material/glass = 2,
+		/datum/material/plasma = 1,
+		/datum/material/titanium = 1,
+		/datum/material/silver = 1,
+		/datum/material/gold = 1,
+		/datum/material/diamond = 1,
+		/datum/material/uranium = 1,
+		/datum/material/bluespace = 1,
+		/datum/material/plastic = 1,
+	)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7220,6 +7220,7 @@
 #include "modular_doppler\religion\code\religious_sects.dm"
 #include "modular_doppler\research\designs\limbgrower_designs.dm"
 #include "modular_doppler\sprite_swaps\code\bigclosets.dm"
+#include "modular_doppler\starter_resources\ore_vent.dm"
 #include "modular_doppler\stone\code\ore_veins.dm"
 #include "modular_doppler\stone\code\stone.dm"
 #include "modular_doppler\super_glasses\code\glasses_stats_thief.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

the starting ore vent will have a little bit of every resource, though it comes from small boulders so it will still be much faster to just go mining yourself

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

100 years mining coal mines just so people can play the game on lowpop

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: the starter ore vent has a little bit of everything, favoring iron and glass, now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
