### PR TITLE
evilcoding: makes death more difficult to achieve, and damage numbers no longer the one responsible

### DIFF
--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -98,10 +98,10 @@
 				Unconscious(rand(1 SECONDS, 2 SECONDS))
 				to_chat(src, span_userdanger("You black out for a moment!"))
 		// Instantly die upon this threshold
-		if(-INFINITY to BLOOD_VOLUME_SURVIVE)
+		/* if(-INFINITY to BLOOD_VOLUME_SURVIVE) // DOPPLER EDIT REMOVAL
 			if(!HAS_TRAIT(src, TRAIT_NODEATH))
 				investigate_log("has died of bloodloss.", INVESTIGATE_DEATHS)
-				death()
+				death() */
 
 	// Blood ratio! if you have 280 blood, this equals 0.5 as that's half of the current value, 560.
 	var/effective_blood_ratio = blood_volume / BLOOD_VOLUME_NORMAL

--- a/modular_doppler/modular_species/species_types/android/android.dm
+++ b/modular_doppler/modular_species/species_types/android/android.dm
@@ -93,9 +93,10 @@
 		return
 	if(core_energy > 0)
 		core_energy -= ENERGY_DRAIN_AMT
-	// alerts end, death begins
+		remove_movespeed_modifier(/datum/movespeed_modifier/android_nocharge)
+	// Once out of power, you begin to move terribly slowly
 	if(core_energy <= 0)
-		target.death() // You can do a lot in a day.
+		add_movespeed_modifier(/datum/movespeed_modifier/android_nocharge)
 
 /datum/species/android/proc/handle_hud(mob/living/carbon/human/target)
 	// update it
@@ -135,6 +136,10 @@
 	return list(
 		"Androids are a synthetic species created by the Port Authority as an intermediary between humans and cyborgs."
 	)
+
+/datum/movespeed_modifier/android_nocharge
+	multiplicative_slowdown = CRAWLING_ADD_SLOWDOWN
+	flags = IGNORE_NOSLOW
 
 #undef ENERGY_START_AMT
 #undef ENERGY_DRAIN_AMT

--- a/modular_doppler/most_evil_health_rework/code/carbon_health.dm
+++ b/modular_doppler/most_evil_health_rework/code/carbon_health.dm
@@ -1,0 +1,48 @@
+/mob/living/carbon/update_stat()
+	if(HAS_TRAIT(src, TRAIT_GODMODE))
+		return
+	if(stat != DEAD)
+		// if(health <= HEALTH_THRESHOLD_DEAD && !HAS_TRAIT(src, TRAIT_NODEATH))
+			// death()
+			// return
+		if(HAS_TRAIT_FROM(src, TRAIT_DISSECTED, AUTOPSY_TRAIT))
+			REMOVE_TRAIT(src, TRAIT_DISSECTED, AUTOPSY_TRAIT)
+		if(health <= hardcrit_threshold && !HAS_TRAIT(src, TRAIT_NOHARDCRIT))
+			set_stat(HARD_CRIT)
+		else if(HAS_TRAIT(src, TRAIT_KNOCKEDOUT))
+			set_stat(UNCONSCIOUS)
+		else if(health <= crit_threshold && !HAS_TRAIT(src, TRAIT_NOSOFTCRIT))
+			set_stat(SOFT_CRIT)
+		else
+			set_stat(CONSCIOUS)
+	update_damage_hud()
+	update_health_hud()
+	update_stamina_hud()
+	med_hud_set_status()
+
+/// Brain damage is how you die, the real question is how you get it
+/obj/item/organ/brain/on_life(seconds_per_tick, times_fired)
+	if(damage >= BRAIN_DAMAGE_DEATH)
+		achieve_death()
+	// If you don't have enough blood, your brain starts to go
+	if((owner.blood_volume < BLOOD_VOLUME_SURVIVE) && !HAS_TRAIT(owner, TRAIT_NOBLOOD))
+		var/rounded_brain_damage = round(0.01 * (BLOOD_VOLUME_NORMAL - owner.blood_volume), 0.25) * seconds_per_tick
+		apply_organ_damage(rounded_brain_damage)
+	// If you are past the point of passing out and not breathing, then you start to go as well
+	if((owner.oxyloss >= OXYLOSS_PASSOUT_THRESHOLD) && owner.failed_last_breath && !HAS_TRAIT(owner, TRAIT_NOBREATH))
+		apply_organ_damage(0.1 * seconds_per_tick)
+
+/// Synths need to do something different, as they don't breathe
+/obj/item/organ/brain/cybernetic/on_life(seconds_per_tick, times_fired)
+	if(damage >= BRAIN_DAMAGE_DEATH)
+		achieve_death()
+	if(owner.stat == HARD_CRIT)
+		apply_organ_damage(0.1 * seconds_per_tick)
+
+/// Kills the owner of the brain when called, logging the reason given to it
+/obj/item/organ/brain/proc/achieve_death(reason)
+	if(!reason)
+		reason = "has been killed by brain damage."
+	to_chat(owner, span_userdanger("The last spark of life in your brain fizzles out..."))
+	owner.investigate_log(reason, INVESTIGATE_DEATHS)
+	owner.death()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7186,6 +7186,7 @@
 #include "modular_doppler\modular_weapons\company_and_or_faction_based\carwo_defense_systems\gunsets.dm"
 #include "modular_doppler\modular_weapons\manufacturer_examine\code\gun_company_additions.dm"
 #include "modular_doppler\modular_weapons\manufacturer_examine\code\manufacturer_element.dm"
+#include "modular_doppler\most_evil_health_rework\code\carbon_health.dm"
 #include "modular_doppler\ntnrc_for_all\code\common_chat.dm"
 #include "modular_doppler\ntnrc_for_all\code\ntnrc_client_edits.dm"
 #include "modular_doppler\ntnrc_for_all\code\pda_prefs_edits.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

evil fucked up coder makes it so damage doesn't kill you outright anymore

instead, a variety of not so good for you factors can contribute to your demise, that being a lack of blood or a lack of breathing. both of these damage your brain which results in your end once it's gone

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

how else am i supposed to have a dramatic death bleeding out when i instantly die on tg code

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Death is no longer dependent directly on how much damage you have taken
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
