### PR TITLE
Welding shield eyes added to cybernetic quirk list

### DIFF
--- a/modular_doppler/modular_quirks/permitted_cybernetic/permitted_cybernetic.dm
+++ b/modular_doppler/modular_quirks/permitted_cybernetic/permitted_cybernetic.dm
@@ -6,6 +6,7 @@ GLOBAL_LIST_INIT(possible_quirk_implants, list(
 	"Razorclaw Arm" = /obj/item/organ/cyberimp/arm/razor_claws,
 	"Excavator Arm" = /obj/item/organ/cyberimp/arm/mining_drill,
 	"Nutriment Pump Implant" = /obj/item/organ/cyberimp/chest/nutriment,
+	"Flash Shielded Eyes" = /obj/item/organ/eyes/robotic/shield,
 ))
 
 /datum/quirk/permitted_cybernetic


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

It say it in the title.

## Why It's Good For The Game

Something for engineers to pick that isn't a toolarm. Useful for security too, or anyone looking to mess with them.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Adds the choice to select welding shield eyes as part of the permitted cybernetics quirk
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
