### PR TITLE
Grants beep2 to Androids and Cyborgs

### DIFF
--- a/modular_doppler/emotes/code/added_emotes/robot_sounds.dm
+++ b/modular_doppler/emotes/code/added_emotes/robot_sounds.dm
@@ -6,7 +6,7 @@
 	sound = 'modular_doppler/emotes/sound/twobeep.ogg'
 	mob_type_allowed_typecache = list(/mob/living) //Beep already exists on brains and silicons
 
-/datum/emote/living/beep2
+/datum/emote/silicon/beep2
 	key = "beep2"
 	message = "beeps sharply."
 	emote_type = EMOTE_AUDIBLE

--- a/modular_doppler/emotes/code/added_emotes/robot_sounds.dm
+++ b/modular_doppler/emotes/code/added_emotes/robot_sounds.dm
@@ -5,3 +5,10 @@
 	vary = TRUE
 	sound = 'modular_doppler/emotes/sound/twobeep.ogg'
 	mob_type_allowed_typecache = list(/mob/living) //Beep already exists on brains and silicons
+
+/datum/emote/living/beep2
+	key = "beep2"
+	message = "beeps sharply."
+	emote_type = EMOTE_AUDIBLE
+	vary = TRUE
+	sound = 'sound/machines/beep/twobeep_high.ogg'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I added an emote to added_emotes/robot_sounds.dm

The sound file was pulled from the main TG sounds/machines/beep folder and not the modular_doppler since it's already in the game and I don't really understand why there are duplicates to begin with? (this is the case with twobeep.ogg)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This alternative beeping emote was one of my favorite features on Nova, it is a critical part of android heavy roleplay and its absence was the first thing I noted when playing.

The original beep is a harsh, slower and kinda grating sound, suitable cyborgs and when you want to beep _roughly_ at someone. It's chock-full of Kiki. 

Beep2 is far more bouba on the other hand; despite being higher pitch, it is quicker, softer, more rounded sound. A gentle beep.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Androids and Cyborgs now have an extra beep, one that's more bouba and less kiki
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
