### PR TITLE
Add spacer-swimming functionality to gravless movement in atmosphere

### DIFF
--- a/code/__DEFINES/~doppler_defines/traits.dm
+++ b/code/__DEFINES/~doppler_defines/traits.dm
@@ -41,6 +41,8 @@
 #define TRAIT_ROBOTIC_LIMBATTACHMENT "robotic_limbattachment"
 /// This person has the same taste in food as a different species
 #define TRAIT_ATYPICAL_TASTER "atypical_taster"
+/// This person is space-acclimated and can "spacer-swim" on zero gravity turfs inside light atmosphere.
+#define TRAIT_SPACER_SWIM "spacer_swim"
 
 ////
 // Jobs

--- a/modular_doppler/spacer_swimming/spacer_swim.dm
+++ b/modular_doppler/spacer_swimming/spacer_swim.dm
@@ -1,0 +1,26 @@
+// if we're a spacer and have sufficient air pressure on our turf (>50kPa)
+// attempt to "space swim" slowly to our salvation tile if all other methods have failed
+#define SPACE_SWIM_DELAY_SECONDS 1.5 SECONDS
+
+/mob/living/carbon/human/Process_Spacemove(movement_dir, continuous_move)
+	. = ..()
+	if (HAS_TRAIT(src, TRAIT_SPACER_SWIM) && movement_dir && isnull(continuous_move))
+		var/drifting = !isnull(drift_handler)
+		// need to find some way of checking if we're still doing continuous drifting motion
+		// can we just check for an active drift_handler? do they delete themselves once finished?
+		if (!. && !drifting && !has_gravity() && !incapacitated) // have we failed all previous movement paths and are not on a forced movement pattern?
+			var/turf/our_turf = get_turf(src)
+			var/datum/gas_mixture/environment = our_turf.return_air()
+			var/environment_pressure = environment.return_pressure()
+			var/turf/destination = get_step(src, movement_dir)
+			if (environment_pressure >= LAVALAND_EQUIPMENT_EFFECT_PRESSURE)
+				if (do_after(src, SPACE_SWIM_DELAY_SECONDS, target = destination, interaction_key = "space_swim", max_interact_count = 1))
+					visible_message(span_notice("[src] deftly spacer-swims towards [destination]."), span_notice("You deftly spacer-swim towards [destination]."))
+					return TRUE
+				else
+					return FALSE
+
+/datum/quirk/spacer_born
+	mob_trait = TRAIT_SPACER_SWIM
+
+#undef SPACE_SWIM_DELAY_SECONDS

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7246,6 +7246,7 @@
 #include "modular_doppler\religion\code\mind.dm"
 #include "modular_doppler\religion\code\religious_sects.dm"
 #include "modular_doppler\research\designs\limbgrower_designs.dm"
+#include "modular_doppler\spacer_swimming\spacer_swim.dm"
 #include "modular_doppler\sprite_swaps\code\bigclosets.dm"
 #include "modular_doppler\starter_resources\ore_vent.dm"
 #include "modular_doppler\stone\code\ore_veins.dm"


### PR DESCRIPTION
## About The Pull Request

We have a lot of spacer/antigrav chars now, and one of my major pet peeves when actually playing one are those moments where you somehow get isolated in the middle of a 3 tile hallway and have to throw something to newtonian move back to a wall so you can continue on your way.

It happens a *lot* on certain maps (LOOKING AT YOU, NEBULA STATION) and it is honestly aggravating to high hell if anti-grav movement is your *only* means of actually getting around.

To address this, I've added a new movement feature called "spacer swimming". At the moment, only people with the Spacer quirk get it. It is an attempt to emulate the swimming-like recovery moves astronauts learn to save themselves from similar situations aboard real life orbital space stations. Wow, realism!

- If you are **not** currently moving forward from existing newtonian movement (aka, drifting in any direction), are under the influence of antigravity, are a spacer, are still, and are within an atmosphere of any gas at least 50 kPa, you may "spacer-swim" to an adjacent tile automatically when attempting to move towards it. 
- This takes 1.5 seconds and is functionally equivalent to having thrown something in the opposite direction that you're travelling.
- The check for this fires only after every other form of non-drifting spacewalking fails. This includes pushing off objects, etc.

Hopefully, this means that you should never come across this functionality unless you actually need it. I've only done limited testing to ensure this is the case, so a testmerge may be needed.

I've also uncoupled this into a special trait, so other things beyond the spacer quirk can easily grant access to it at a later point. Might make a good skillchip!

## Why It's Good For The Game

Removes a major, non-soulful annoyance about antigrav ambulation while still keeping mechanical consequences for not navigating the system properly. 1.5 seconds per move is gruesomely slow compared to any other form of movement, especially at the speed spacers can typically go at.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: yooriss
add: Spacers are now able to "swim" to adjacent tiles when not actively drifting in certain circumstances after a short delay.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
