### PR TITLE
Move gravity harness prebuilt cells to nullspace instead of storage

### DIFF
--- a/modular_doppler/gravity_harness/gravity_harness.dm
+++ b/modular_doppler/gravity_harness/gravity_harness.dm
@@ -38,6 +38,7 @@
 	AddElement(/datum/element/update_icon_updates_onmob, ITEM_SLOT_BACK)
 	if(ispath(current_cell))
 		current_cell = new current_cell(src)
+		current_cell.moveToNullspace() // so it doesn't appear in storage
 	create_storage(max_specific_storage = max_w_class, max_total_storage = max_combined_w_class, max_slots = max_items)
 
 /obj/item/gravity_harness/Destroy()


### PR DESCRIPTION
Quick and dirty: just nullspaces the harness' innate subtype cell that I added so the power cell isn't just chilling out in its storage.