### PR TITLE
Port renamed loadout items having clickable examine links

### DIFF
--- a/code/__DEFINES/~doppler_defines/traits.dm
+++ b/code/__DEFINES/~doppler_defines/traits.dm
@@ -70,3 +70,9 @@
 ////
 /// Trait for muting only speech, but allowing emotes.
 #define TRAIT_SPEECH_ONLY_MUTE "speech_only_mute"
+
+////
+// Items
+////
+
+#define TRAIT_WORN_EXAMINE "worn_examine"

--- a/code/modules/loadout/loadout_items.dm
+++ b/code/modules/loadout/loadout_items.dm
@@ -262,6 +262,7 @@ GLOBAL_LIST_INIT(all_loadout_categories, init_loadout_categories())
 		equipped_item.desc = item_details[INFO_DESCRIBED]
 		ADD_TRAIT(equipped_item, TRAIT_WAS_RENAMED, "Loadout")
 		equipped_item.on_loadout_custom_described()
+		equipped_item.AddElement(/datum/element/examined_when_worn)
 	// DOPPLER EDIT ADDITION END
 
 	if(can_be_reskinned && item_details?[INFO_RESKIN])

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -384,6 +384,7 @@
 	return final_descriptions
 
 /// Coolects examine information about the mob's clothing and equipment
+// DOPPLER EDIT BEGIN - see altered loadout items
 /mob/living/carbon/proc/get_clothing_examine_info(mob/living/user)
 	. = list()
 	var/obscured = check_obscured_slots()
@@ -394,18 +395,18 @@
 	var/t_is = p_are()
 	//head
 	if(head && !(obscured & ITEM_SLOT_HEAD) && !(head.item_flags & EXAMINE_SKIP))
-		. += "[t_He] [t_is] wearing [head.examine_title(user)] on [t_his] head."
+		. += "[t_He] [t_is] wearing [head.examine_title_worn(user)] on [t_his] head."
 	//back
 	if(back && !(back.item_flags & EXAMINE_SKIP))
-		. += "[t_He] [t_has] [back.examine_title(user)] on [t_his] back."
+		. += "[t_He] [t_has] [back.examine_title_worn(user)] on [t_his] back."
 	//Hands
 	for(var/obj/item/held_thing in held_items)
 		if(held_thing.item_flags & (ABSTRACT|EXAMINE_SKIP|HAND_ITEM))
 			continue
-		. += "[t_He] [t_is] holding [held_thing.examine_title(user)] in [t_his] [get_held_index_name(get_held_index_of_item(held_thing))]."
+		. += "[t_He] [t_is] holding [held_thing.examine_title_worn(user)] in [t_his] [get_held_index_name(get_held_index_of_item(held_thing))]."
 	//gloves
 	if(gloves && !(obscured & ITEM_SLOT_GLOVES) && !(gloves.item_flags & EXAMINE_SKIP))
-		. += "[t_He] [t_has] [gloves.examine_title(user)] on [t_his] hands."
+		. += "[t_He] [t_has] [gloves.examine_title_worn(user)] on [t_his] hands."
 	else if(GET_ATOM_BLOOD_DNA_LENGTH(src))
 		if(num_hands)
 			. += span_warning("[t_He] [t_has] [num_hands > 1 ? "" : "a "]blood-stained hand[num_hands > 1 ? "s" : ""]!")
@@ -415,23 +416,23 @@
 		. += span_warning("[t_He] [t_is] [icon2html(handcuffed, user)] [cables_or_cuffs]!")
 	//shoes
 	if(shoes && !(obscured & ITEM_SLOT_FEET)  && !(shoes.item_flags & EXAMINE_SKIP))
-		. += "[t_He] [t_is] wearing [shoes.examine_title(user)] on [t_his] feet."
+		. += "[t_He] [t_is] wearing [shoes.examine_title_worn(user)] on [t_his] feet."
 	//mask
 	if(wear_mask && !(obscured & ITEM_SLOT_MASK)  && !(wear_mask.item_flags & EXAMINE_SKIP))
-		. += "[t_He] [t_has] [wear_mask.examine_title(user)] on [t_his] face."
+		. += "[t_He] [t_has] [wear_mask.examine_title_worn(user)] on [t_his] face."
 	if(wear_neck && !(obscured & ITEM_SLOT_NECK)  && !(wear_neck.item_flags & EXAMINE_SKIP))
-		. += "[t_He] [t_is] wearing [wear_neck.examine_title(user)] around [t_his] neck."
+		. += "[t_He] [t_is] wearing [wear_neck.examine_title_worn(user)] around [t_his] neck."
 	//eyes
 	if(!(obscured & ITEM_SLOT_EYES) )
 		if(glasses  && !(glasses.item_flags & EXAMINE_SKIP))
-			. += "[t_He] [t_has] [glasses.examine_title(user)] covering [t_his] eyes."
+			. += "[t_He] [t_has] [glasses.examine_title_worn(user)] covering [t_his] eyes."
 		else if(HAS_TRAIT(src, TRAIT_UNNATURAL_RED_GLOWY_EYES))
 			. += span_warning("<B>[t_His] eyes are glowing with an unnatural red aura!</B>")
 		else if(HAS_TRAIT(src, TRAIT_BLOODSHOT_EYES))
 			. += span_warning("<B>[t_His] eyes are bloodshot!</B>")
 	//ears
 	if(ears && !(obscured & ITEM_SLOT_EARS) && !(ears.item_flags & EXAMINE_SKIP))
-		. += "[t_He] [t_has] [ears.examine_title(user)] on [t_his] ears."
+		. += "[t_He] [t_has] [ears.examine_title_worn(user)] on [t_his] ears."
 
 // Yes there's a lot of copypasta here, we can improve this later when carbons are less dumb in general
 /mob/living/carbon/human/get_clothing_examine_info(mob/living/user)
@@ -453,36 +454,36 @@
 			if(length(accessories))
 				accessory_message = " with [english_list(accessories)] attached"
 
-		. += "[t_He] [t_is] wearing [w_uniform.examine_title(user)][accessory_message]."
+		. += "[t_He] [t_is] wearing [w_uniform.examine_title_worn(user)][accessory_message]."
 	//head
 	if(head && !(obscured & ITEM_SLOT_HEAD) && !(head.item_flags & EXAMINE_SKIP))
-		. += "[t_He] [t_is] wearing [head.examine_title(user)] on [t_his] head."
+		. += "[t_He] [t_is] wearing [head.examine_title_worn(user)] on [t_his] head."
 	//mask
 	if(wear_mask && !(obscured & ITEM_SLOT_MASK)  && !(wear_mask.item_flags & EXAMINE_SKIP))
-		. += "[t_He] [t_has] [wear_mask.examine_title(user)] on [t_his] face."
+		. += "[t_He] [t_has] [wear_mask.examine_title_worn(user)] on [t_his] face."
 	//neck
 	if(wear_neck && !(obscured & ITEM_SLOT_NECK)  && !(wear_neck.item_flags & EXAMINE_SKIP))
-		. += "[t_He] [t_is] wearing [wear_neck.examine_title(user)] around [t_his] neck."
+		. += "[t_He] [t_is] wearing [wear_neck.examine_title_worn(user)] around [t_his] neck."
 	//eyes
 	if(!(obscured & ITEM_SLOT_EYES) )
 		if(glasses  && !(glasses.item_flags & EXAMINE_SKIP))
-			. += "[t_He] [t_has] [glasses.examine_title(user)] covering [t_his] eyes."
+			. += "[t_He] [t_has] [glasses.examine_title_worn(user)] covering [t_his] eyes."
 		else if(HAS_TRAIT(src, TRAIT_UNNATURAL_RED_GLOWY_EYES))
 			. += span_warning("<B>[t_His] eyes are glowing with an unnatural red aura!</B>")
 		else if(HAS_TRAIT(src, TRAIT_BLOODSHOT_EYES))
 			. += span_warning("<B>[t_His] eyes are bloodshot!</B>")
 	//ears
 	if(ears && !(obscured & ITEM_SLOT_EARS) && !(ears.item_flags & EXAMINE_SKIP))
-		. += "[t_He] [t_has] [ears.examine_title(user)] on [t_his] ears."
+		. += "[t_He] [t_has] [ears.examine_title_worn(user)] on [t_his] ears."
 	//suit/armor
 	if(wear_suit && !(wear_suit.item_flags & EXAMINE_SKIP))
-		. += "[t_He] [t_is] wearing [wear_suit.examine_title(user)]."
+		. += "[t_He] [t_is] wearing [wear_suit.examine_title_worn(user)]."
 		//suit/armor storage
 		if(s_store && !(obscured & ITEM_SLOT_SUITSTORE) && !(s_store.item_flags & EXAMINE_SKIP))
-			. += "[t_He] [t_is] carrying [s_store.examine_title(user)] on [t_his] [wear_suit.name]."
+			. += "[t_He] [t_is] carrying [s_store.examine_title_worn(user)] on [t_his] [wear_suit.name]."
 	//back
 	if(back && !(back.item_flags & EXAMINE_SKIP))
-		. += "[t_He] [t_has] [back.examine_title(user)] on [t_his] back."
+		. += "[t_He] [t_has] [back.examine_title_worn(user)] on [t_his] back."
 	//ID
 	if(wear_id && !(wear_id.item_flags & EXAMINE_SKIP))
 		var/obj/item/card/id/id = wear_id.GetID()
@@ -491,15 +492,15 @@
 			. += "[t_He] [t_is] wearing [id_href]."
 
 		else
-			. += "[t_He] [t_is] wearing [wear_id.examine_title(user)]."
+			. += "[t_He] [t_is] wearing [wear_id.examine_title_worn(user)]."
 	//Hands
 	for(var/obj/item/held_thing in held_items)
 		if(held_thing.item_flags & (ABSTRACT|EXAMINE_SKIP|HAND_ITEM))
 			continue
-		. += "[t_He] [t_is] holding [held_thing.examine_title(user)] in [t_his] [get_held_index_name(get_held_index_of_item(held_thing))]."
+		. += "[t_He] [t_is] holding [held_thing.examine_title_worn(user)] in [t_his] [get_held_index_name(get_held_index_of_item(held_thing))]."
 	//gloves
 	if(gloves && !(obscured & ITEM_SLOT_GLOVES) && !(gloves.item_flags & EXAMINE_SKIP))
-		. += "[t_He] [t_has] [gloves.examine_title(user)] on [t_his] hands."
+		. += "[t_He] [t_has] [gloves.examine_title_worn(user)] on [t_his] hands."
 	else if(GET_ATOM_BLOOD_DNA_LENGTH(src) || blood_in_hands)
 		if(num_hands)
 			. += span_warning("[t_He] [t_has] [num_hands > 1 ? "" : "a "]blood-stained hand[num_hands > 1 ? "s" : ""]!")
@@ -509,10 +510,12 @@
 		. += span_warning("[t_He] [t_is] [icon2html(handcuffed, user)] [cables_or_cuffs]!")
 	//belt
 	if(belt && !(obscured & ITEM_SLOT_BELT) && !(belt.item_flags & EXAMINE_SKIP))
-		. += "[t_He] [t_has] [belt.examine_title(user)] about [t_his] waist."
+		. += "[t_He] [t_has] [belt.examine_title_worn(user)] about [t_his] waist."
 	//shoes
 	if(shoes && !(obscured & ITEM_SLOT_FEET)  && !(shoes.item_flags & EXAMINE_SKIP))
-		. += "[t_He] [t_is] wearing [shoes.examine_title(user)] on [t_his] feet."
+		. += "[t_He] [t_is] wearing [shoes.examine_title_worn(user)] on [t_his] feet."
+
+// DOPPLER EDIT END
 
 /// Collects info displayed about any HUDs the user has when examining src
 /mob/living/carbon/proc/get_hud_examine_info(mob/living/user)

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -514,7 +514,6 @@
 	//shoes
 	if(shoes && !(obscured & ITEM_SLOT_FEET)  && !(shoes.item_flags & EXAMINE_SKIP))
 		. += "[t_He] [t_is] wearing [shoes.examine_title_worn(user)] on [t_his] feet."
-
 // DOPPLER EDIT END
 
 /// Collects info displayed about any HUDs the user has when examining src

--- a/modular_doppler/loadout_item_examine/examine.dm
+++ b/modular_doppler/loadout_item_examine/examine.dm
@@ -1,0 +1,6 @@
+/atom/proc/examine_title_worn(mob/user)
+	var/regular_examine = src.examine_title(user)
+	if(HAS_TRAIT_FROM(src, TRAIT_WORN_EXAMINE, TRAIT_SUBTREE_REQUIRED_OPERATIONAL_DATUM)) // Uses /datum/element/examined_when_worn
+		return "<a href='?src=[REF(src)];examine_loadout=1;'>[regular_examine]</a>"
+	else
+		return regular_examine

--- a/modular_doppler/loadout_item_examine/examine_when_worn.dm
+++ b/modular_doppler/loadout_item_examine/examine_when_worn.dm
@@ -1,0 +1,17 @@
+// This is cheaper than adding to the Topic() of atom
+/datum/element/examined_when_worn
+
+/datum/element/examined_when_worn/Attach(datum/target)
+	. = ..()
+	RegisterSignal(target, COMSIG_TOPIC, PROC_REF(on_topic))
+	ADD_TRAIT(target, TRAIT_WORN_EXAMINE, TRAIT_SUBTREE_REQUIRED_OPERATIONAL_DATUM)
+
+/datum/element/examined_when_worn/proc/on_topic(atom/source, mob/user, href_list)
+	if(href_list["examine_loadout"])
+		user.run_examinate(source)
+		return
+
+/datum/element/examined_when_worn/Detach(datum/source, ...)
+	. = ..()
+	UnregisterSignal(source, COMSIG_TOPIC)
+	REMOVE_TRAIT(source, TRAIT_WORN_EXAMINE, TRAIT_SUBTREE_REQUIRED_OPERATIONAL_DATUM)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6823,6 +6823,8 @@
 #include "modular_doppler\loadout_categories\categories\shoes.dm"
 #include "modular_doppler\loadout_categories\categories\toys.dm"
 #include "modular_doppler\loadout_categories\categories\undersuit.dm"
+#include "modular_doppler\loadout_item_examine\examine.dm"
+#include "modular_doppler\loadout_item_examine\examine_when_worn.dm"
 #include "modular_doppler\lore\overrides\crab17.dm"
 #include "modular_doppler\lore\overrides\ert.dm"
 #include "modular_doppler\lore\overrides\general_memories.dm"


### PR DESCRIPTION
## About The Pull Request

Really simple: ports https://github.com/Bubberstation/Bubberstation/pull/2349 in all of its glory, allowing people who examine you to click on any loadout items that you've written custom descriptions for. No link appears if you haven't written a description.

![](https://puu.sh/Kmixx/daa6f83d1c.png)

## Why It's Good For The Game

Being able to look at people's cool shit is fun!

## Changelog

:cl: yooriss, Majkl-J
add: Ported custom-described loadout item examining from Bubberstation. Original feature courtesy of Majkl-J.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
