### PR TITLE
Add common as a choice for bilingual quirk

### DIFF
--- a/modular_doppler/common_bilingual/common_bilingual.dm
+++ b/modular_doppler/common_bilingual/common_bilingual.dm
@@ -1,0 +1,5 @@
+// Adds common to the list of choices for the bilingual quirk
+/datum/preference/choiced/language/init_possible_values()
+	. = ..()
+	var/datum/language/common/common_language = /datum/language/common
+	. += initial(common_language.name)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6655,6 +6655,7 @@
 #include "modular_doppler\colony_fabricator\code\machines\stirling_generator.dm"
 #include "modular_doppler\colony_fabricator\code\machines\thermomachine.dm"
 #include "modular_doppler\colony_fabricator\code\tools\tools.dm"
+#include "modular_doppler\common_bilingual\common_bilingual.dm"
 #include "modular_doppler\cryosleep\code\admin.dm"
 #include "modular_doppler\cryosleep\code\ai.dm"
 #include "modular_doppler\cryosleep\code\config.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Simple: adds Sol Common as a choice for the bilingual quirk.

Caveats: if picking this as a Hearthkin, you'll need to also select Aetmal as a spoken language in character preferences to be able to speak it.

## Why It's Good For The Game

Lets you play stationfaring Hearthkin and possibly other "foreign" race combinations without needing to touch their default behavior.

## Changelog

:cl: yooriss
add: Common is now a choice for the bilingual quirk.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
