### PR TITLE
Fixes boxes extending when lowering the dropdown menu on the job page

### DIFF
--- a/tgui/packages/tgui/styles/interfaces/PreferencesMenu.scss
+++ b/tgui/packages/tgui/styles/interfaces/PreferencesMenu.scss
@@ -145,8 +145,7 @@ $department_map: (
           color: black;
 
           > * {
-            height: calc(100% + 0.2em);
-            padding-bottom: 0.2em;
+            height: 100%;
           }
 
           &:first-child {


### PR DESCRIPTION
## About The Pull Request
(this PR is merging into the job titles branch)
Does what the title says, stops job title boxes from extending forever when you open their dropdown titles.
Just a one line change :p

## Why It's Good For The Game
Fixes an issue

## Changelog
Not really a player facing change
