### PR TITLE
disables some grand ritual events

### DIFF
--- a/code/modules/events/wizard/embeddies.dm
+++ b/code/modules/events/wizard/embeddies.dm
@@ -2,7 +2,7 @@
 	name = "Make Everything Embeddable"
 	weight = 2
 	typepath = /datum/round_event/wizard/embedpocalypse
-	max_occurrences = 1
+	max_occurrences = 0
 	earliest_start = 0 MINUTES
 	description = "Everything becomes pointy enough to embed in people when thrown."
 	min_wizard_trigger_potency = 3

--- a/code/modules/events/wizard/lava.dm
+++ b/code/modules/events/wizard/lava.dm
@@ -2,7 +2,7 @@
 	name = "The Floor Is LAVA!"
 	weight = 2
 	typepath = /datum/round_event/wizard/lava
-	max_occurrences = 3
+	max_occurrences = 0
 	earliest_start = 0 MINUTES
 	description = "Turns the floor into hot lava."
 	min_wizard_trigger_potency = 5

--- a/code/modules/events/wizard/race.dm
+++ b/code/modules/events/wizard/race.dm
@@ -2,7 +2,7 @@
 	name = "Race Swap"
 	weight = 2
 	typepath = /datum/round_event/wizard/race
-	max_occurrences = 5
+	max_occurrences = 0
 	earliest_start = 0 MINUTES
 	description = "Gives everyone a random race."
 

--- a/code/modules/events/wizard/shuffle.dm
+++ b/code/modules/events/wizard/shuffle.dm
@@ -5,7 +5,7 @@
 	name = "Change Places!"
 	weight = 2
 	typepath = /datum/round_event/wizard/shuffleloc
-	max_occurrences = 5
+	max_occurrences = 0
 	earliest_start = 0 MINUTES
 	description = "Shuffles everyone around on the station."
 	min_wizard_trigger_potency = 0
@@ -44,7 +44,7 @@
 	name = "Change Faces!"
 	weight = 4
 	typepath = /datum/round_event/wizard/shufflenames
-	max_occurrences = 5
+	max_occurrences = 0
 	earliest_start = 0 MINUTES
 	description = "Shuffles the names of everyone around the station."
 
@@ -79,7 +79,7 @@
 	name = "Change Minds!"
 	weight = 1
 	typepath = /datum/round_event/wizard/shuffleminds
-	max_occurrences = 3
+	max_occurrences = 0
 	earliest_start = 0 MINUTES
 	description = "Shuffles the minds of everyone around the station, except for the wizard."
 

--- a/code/modules/events/wizard/tower_of_babel.dm
+++ b/code/modules/events/wizard/tower_of_babel.dm
@@ -2,7 +2,7 @@
 	name = "Tower of Babel"
 	weight = 3
 	typepath = /datum/round_event/wizard/tower_of_babel
-	max_occurrences = 1
+	max_occurrences = 0
 	earliest_start = 0 MINUTES
 	description = "Everyone forgets their current languages and gains a randomized one"
 	min_wizard_trigger_potency = 5


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Disables some chaotic/deatchmatch wizard events

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added new mechanics or gameplay changes
add: Added more things
del: Removed old things
qol: made something easier to use
balance: rebalanced something
fix: fixed a few things
sound: added/modified/removed audio or sound effects
image: added/modified/removed some icons or images
map: added/modified/removed map content
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
