### PR TITLE
Add the ability to toggle speech accents

### DIFF
--- a/modular_doppler/accent_toggle/code/accent_toggle.dm
+++ b/modular_doppler/accent_toggle/code/accent_toggle.dm
@@ -1,0 +1,21 @@
+/mob/living
+	var/use_accent = TRUE
+
+/// Overload the speech-handling verb to seamlessly disable all tongue replacements. Magic!
+/obj/item/organ/tongue/should_modify_speech(datum/source, list/speech_args)
+	if (owner.use_accent)
+		return ..()
+
+	return FALSE
+
+/mob/living/verb/accent_toggle_verb()
+	set name = "Toggle Speech Accent"
+	set category = "IC"
+	set instant = TRUE
+
+	if (use_accent)
+		use_accent = FALSE
+		to_chat(src, span_notice("You will no longer automatically apply speech accents."))
+	else
+		use_accent = TRUE
+		to_chat(src, span_notice("You will now automatically apply speech accents."))

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6582,6 +6582,7 @@
 #include "interface\fonts\tiny_unicode.dm"
 #include "interface\fonts\vcr_osd_mono.dm"
 #include "modular_doppler\_HELPERS\preferences.dm"
+#include "modular_doppler\accent_toggle\code\accent_toggle.dm"
 #include "modular_doppler\accessable_storage\accessable_storage.dm"
 #include "modular_doppler\accessable_storage\item.dm"
 #include "modular_doppler\accessable_storage\strippable.dm"


### PR DESCRIPTION

## About The Pull Request

Really simple: adds a "Toggle Speech Accent" verb to the IC tab that lets you turn on/off any speech replacements that your tongue organ forces you to have, like lizard's ssssss, fly tongue's zzzing, etc.

This does **not** change your say_mod (says, intones, hisses, etc). That'll come later.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: yooriss
add: You can now toggle your character's coded speech accent via the "Toggle Speech Accent" verb in the IC tab. No more sssssspam (unless you want it, of course).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
