### PR TITLE
Adds clickable examine link to entombed modsuits

### DIFF
--- a/modular_doppler/modular_quirks/entombed/code/entombed.dm
+++ b/modular_doppler/modular_quirks/entombed/code/entombed.dm
@@ -111,6 +111,7 @@
 	var/modsuit_desc = client_source?.prefs.read_preference(/datum/preference/text/entombed_mod_desc)
 	if (modsuit_desc)
 		modsuit.desc = modsuit_desc
+		modsuit.AddElement(/datum/element/examined_when_worn)
 
 	var/modsuit_skin_prefix = client_source?.prefs.read_preference(/datum/preference/text/entombed_mod_prefix)
 	if (modsuit_skin_prefix)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

If a character with Entombed has a custom description for their controller, it will have a hyperlink when examining them like described loadout items. An undescribed controller remains the same.

## Why It's Good For The Game

look at my swagful armor, boy

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Entombed modsuits with a custom description can now have their description clicked when examining the wearer.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
