### PR TITLE
Added short treatment text to all Doppler wounds

### DIFF
--- a/modular_doppler/modular_medical/wounds/muscle.dm
+++ b/modular_doppler/modular_medical/wounds/muscle.dm
@@ -5,6 +5,11 @@
 
 /datum/wound/muscle
 	name = "Muscle Wound"
+
+	simple_desc = "Patient has torn something in their limb, reducing overall functionality."
+	simple_treat_text = "Applying a <b>splint or gauze wrapping</b> will assist greatly with the tear. After that, it's just <b>bed rest</b> until everything heals."
+	homemade_treat_text = "Sheets can be torn up to make <b>makeshift gauze</b>, which can be used to wrap the tear. Or, you can just <b>sleep it off</b>."
+
 	sound_effect = 'sound/effects/wounds/blood1.ogg'
 	wound_flags = (ACCEPTS_GAUZE | SPLINT_OVERLAY)
 
@@ -126,7 +131,9 @@
 /datum/wound/muscle/moderate
 	name = "Muscle Tear"
 	desc = "Patient's muscle has torn, causing serious pain and reduced limb functionality."
-	treat_text = "A tight splint on the affected limb, as well as plenty of rest and sleep."
+	treat_text = "The affected limb should have a tight splint applied. A wrapping of gauze can suffice in a pinch. \
+		Follow with plenty of rest and sleep."
+	treat_text_short = "Apply a splint or a gauze wrapping and allow the patient to rest."
 	examine_desc = "appears unnaturallly red and swollen"
 	occur_text = "swells up, its skin turning red"
 	severity = WOUND_SEVERITY_MODERATE
@@ -151,7 +158,9 @@
 	name = "Ruptured Tendon"
 	sound_effect = 'sound/effects/wounds/blood2.ogg'
 	desc = "Patient's tendon has been severed, causing significant pain and near uselessness of limb."
-	treat_text = "A tight splint on the affected limb, as well as plenty of rest and sleep."
+	treat_text = "The affected limb should have a tight splint applied. A wrapping of gauze can suffice in a pinch. \
+		Follow with plenty of rest and sleep."
+	treat_text_short = "Apply a splint or a gauze wrapping and allow the patient to rest."
 	examine_desc = "is limp and awkwardly twitching, skin swollen and red"
 	occur_text = "twists in pain and goes limp, its tendon ruptured"
 	severity = WOUND_SEVERITY_SEVERE

--- a/modular_doppler/modular_medical/wounds/synth/blunt/robotic_blunt_T1.dm
+++ b/modular_doppler/modular_medical/wounds/synth/blunt/robotic_blunt_T1.dm
@@ -3,6 +3,7 @@
 	desc = "Various semi-external fastening instruments have loosened, causing components to jostle, inhibiting limb control."
 	treat_text = "Recommend topical re-fastening of instruments with a screwdriver, though percussive maintenance via low-force bludgeoning may suffice - \
 	albeit at risk of worsening the injury."
+	treat_text_short = "Screw instruments back on. Percussive maintenance may also function."
 	examine_desc = "appears to be loosely secured"
 	occur_text = "jostles awkwardly and seems to slightly unfasten"
 	severity = WOUND_SEVERITY_MODERATE

--- a/modular_doppler/modular_medical/wounds/synth/blunt/robotic_blunt_T2.dm
+++ b/modular_doppler/modular_medical/wounds/synth/blunt/robotic_blunt_T2.dm
@@ -3,6 +3,7 @@
 	desc = "Various fastening devices are extremely loose and solder has disconnected at multiple points, causing significant jostling of internal components and \
 	noticable limb dysfunction."
 	treat_text = "Fastening of bolts and screws by a qualified technician (though bone gel may suffice in the absence of one) followed by re-soldering."
+	treat_text_short = "Re-fasten with a wrench or screwdriver, then solder with a heat source."
 	examine_desc = "jostles with every move, solder visibly broken"
 	occur_text = "visibly cracks open, solder flying everywhere"
 	severity = WOUND_SEVERITY_SEVERE

--- a/modular_doppler/modular_medical/wounds/synth/blunt/robotic_blunt_T3.dm
+++ b/modular_doppler/modular_medical/wounds/synth/blunt/robotic_blunt_T3.dm
@@ -4,6 +4,7 @@
 	treat_text = "Reforming of superstructure via either RCD or manual molding, followed by typical treatment of loosened internals. \
 				To manually mold, the limb must be aggressively grabbed and welded held to it to make it malleable (though attacking it til thermal overload may be adequate) \
 				followed by firmly grasping and molding the limb with heat-resistant gloves."
+	treat_text_short = "Reform with an RCD, then screw together and solder with a heat source. Grab strongly, apply heat, and mold with your hands if an RCD is unavailable."
 	occur_text = "caves in on itself, damaged solder and shrapnel flying out in a miniature explosion"
 	examine_desc = "has caved in, with internal components visible through gaps in the metal"
 	severity = WOUND_SEVERITY_CRITICAL

--- a/modular_doppler/modular_medical/wounds/synth/robotic_burns.dm
+++ b/modular_doppler/modular_medical/wounds/synth/robotic_burns.dm
@@ -10,12 +10,14 @@
 	return list("[BIO_METAL]")
 
 /datum/wound/burn/robotic/overheat
-	treat_text = "Introduction of a cold environment or lowering of body temperature."
+	treat_text = "Cool down the overheating metal in the patient's body. This can be done safely with cryogenics or other cold environments. \
+				For rapid cooling, spraying water or coolant directly on the metal will rapidly decrease temperatures, damaging in the process. Gauze can mitigate the shock."
+	treat_text_short = "Introduce to a cold environment, or rapidly cool with sprays after applying gauze to mitigate shock."
 
 	simple_desc = "Metals are overheated, increasing damage taken significantly and raising body temperature!"
-	simple_treat_text = "Ideally <b>cryogenics</b>, but any source of <b>low body temperature</b> can work. <b>Spraying</b> with <b>spray bottles/extinguishers/showers</b> \
-	will quickly cool the limb, but <b>cause damage</b>. <b>Hercuri</b> is <b>especially effective</b> in quick cooling. \
-	<b>Clothing</b> reduces the water/hercuri that makes it to the metal, and <b>gauze</b> binds it and <b>reduces</b> the <b>damage</b> taken."
+	simple_treat_text = "<b>Cryogenics</b> is the ideal way to cool the patient down, but any source of <b>low body temperature</b> can work. <b>Spraying</b> with <b>spray bottles, extinguishers, or showers</b> \
+	will quickly cool the limb, but will <b>cause damage</b> from thermal shock. <b>Hercuri</b> is <b>especially effective</b> in quick cooling. \
+	<b>Gauze</b> binds the metal and <b>reduces</b> the <b>damage</b> taken, but <b>clothing</b> reduces the amount of cooling that makes it to the metal."
 	homemade_treat_text = "You can also splash <b>any liquid</b> on it for a rather <b>inefficient</b> and <b>damaging</b> coolant!"
 
 	default_scar_file = METAL_SCAR_FILE
@@ -343,7 +345,10 @@
 		sustain additional wounds."
 	occur_text = "lets out a slight groan as it turns a dull shade of thermal red"
 	examine_desc = "is glowing a dull thermal red and giving off heat"
-	treat_text = "Reduction of body temperature to expedite the passive heat dissipation - or, if thermal shock is to be risked, application of a fire extinguisher/shower."
+	treat_text = "Cool down the overheating metal in the patient's body. This can be done safely with cryogenics or other cold environments. \
+				For rapid cooling, spraying water or coolant directly on the metal will rapidly decrease temperatures, inflicting moderate harm in the process. \
+				Gauze can somewhat mitigate the high risk of temperature shock."
+	treat_text_short = "Introduce to a cold environment, or rapidly cool with sprays after applying gauze to mitigate shock."
 	severity = WOUND_SEVERITY_MODERATE
 
 	damage_multiplier_penalty = 1.15 //1.15x damage taken
@@ -392,8 +397,10 @@
 	desc = "Exterior plating has surpassed critical thermal levels, causing significant failure in structural integrity and overheating of internal systems."
 	occur_text = "sizzles, the externals turning a dull shade of orange"
 	examine_desc = "appears discolored and polychromatic, parts of it glowing a dull orange"
-	treat_text = "Isolation from physical hazards, and accommodation of passive heat dissipation - active cooling may be used, but temperature differentials significantly \
-		raise the risk of thermal shock."
+	treat_text = "Cool down the near-molten metal in the patient's body. This can be done safely with cryogenics or other cold environments. \
+				In an emergency, spraying water or coolant directly on the metal will rapidly decrease temperatures, inflicting incredible harm in the process. \
+				Gauze can slightly mitigate the extreme risk of temperature shock."
+	treat_text_short = "Introduce to a cold environment. In an emergency, rapidly cool with sprays after applying gauze to mitigate shock."
 	severity = WOUND_SEVERITY_SEVERE
 
 	a_or_from = "from"
@@ -436,8 +443,9 @@
 	desc = "Carapace is beyond melting point, causing catastrophic structural integrity failure as well as massively heating up the subject."
 	occur_text = "turns a bright shade of radiant white as it sizzles and melts"
 	examine_desc = "is a blinding shade of white, almost melting from the heat"
-	treat_text = "Immediate confinement to cryogenics, as rapid overheating and physical vulnerability may occur. Active cooling is not advised, \
-		since the thermal shock may be lethal with such a temperature differential."
+	treat_text = "Immediately cool the melting superstructure of the patient, ideally via cryogenics. \
+				Coolant sprays and other rapid cooling carry an extreme risk of total collapse if used, but still function."
+	treat_text_short = "Immediately move to cryogenics if possible. Rapid cooling may cause total structural collapse."
 	severity = WOUND_SEVERITY_CRITICAL
 
 	a_or_from = "from"

--- a/modular_doppler/modular_medical/wounds/synth/robotic_muscle.dm
+++ b/modular_doppler/modular_medical/wounds/synth/robotic_muscle.dm
@@ -1,5 +1,5 @@
 /datum/wound/muscle/robotic
-	sound_effect = 'sound/effects/wounds/blood1.ogg'
+	sound_effect = 'sound/effects/servostep.ogg'
 
 /datum/wound_pregen_data/muscle/robotic
 	required_limb_biostate = (BIO_METAL)
@@ -7,7 +7,9 @@
 /datum/wound/muscle/robotic/moderate
 	name = "Overworked Servo"
 	desc = "A servo has been overworked, and will operate with reduced efficiency until rested."
-	treat_text = "A tight splint on the affected limb, as well as plenty of rest and sleep."
+	treat_text = "The affected limb should have a tight splint applied. A wrapping of gauze can suffice in a pinch. \
+		Follow with plenty of rest."
+	treat_text_short = "Apply a splint or a gauze wrapping and allow the patient to rest."
 	examine_desc = "appears to be moving sluggishly"
 	occur_text = "jitters for a moment before moving sluggishly"
 	severity = WOUND_SEVERITY_MODERATE
@@ -25,9 +27,11 @@
 
 /datum/wound/muscle/robotic/severe
 	name = "Exhausted Piston"
-	sound_effect = 'sound/effects/wounds/blood2.ogg'
+	sound_effect = 'sound/effects/stall.ogg'
 	desc = "An important hydraulic piston has been critically overused, resulting in total dysfunction until it recovers."
-	treat_text = "A tight splint on the affected limb, as well as plenty of rest and sleep."
+	treat_text = "The affected limb should have a tight splint applied. A wrapping of gauze can suffice in a pinch. \
+		Follow with plenty of rest."
+	treat_text_short = "Apply a splint or a gauze wrapping and allow the patient to rest."
 	examine_desc = "is stiffly limp, the extremities splayed out widely"
 	occur_text = "goes completely stiff, seeming to lock into position"
 	severity = WOUND_SEVERITY_SEVERE

--- a/modular_doppler/modular_medical/wounds/synth/robotic_pierce.dm
+++ b/modular_doppler/modular_medical/wounds/synth/robotic_pierce.dm
@@ -24,8 +24,9 @@
 	desc = "A major capacitor has been broken open, causing slow but noticable electrical damage."
 	occur_text = "shoots out a short stream of sparks"
 	examine_desc = "is shuddering gently, movements a little weak"
-	treat_text = "Replacing of damaged wiring, though repairs via wirecutting instruments or sutures may suffice, albeit at limited efficiency. In case of emergency, \
-				subject may be subjected to high temperatures to allow solder to reset."
+	treat_text = "Replace the damaged wiring. Repairs via wirecutting instruments or sutures may suffice, albeit at limited efficiency. \
+				In case of emergency, subject may be subjected to high temperatures to allow solder to reset."
+	treat_text_short = "Replace wiring, or repair with wirecutters or sutures. Apply heat in a pinch."
 
 	sound_effect = 'modular_doppler/modular_medical/wounds/synth/sound/robotic_slash_T1.ogg'
 
@@ -68,7 +69,9 @@
 	desc = "A major transformer has been pierced, causing slow-to-progess but eventually intense electrical damage."
 	occur_text = "sputters and goes limp for a moment as it ejects a stream of sparks"
 	examine_desc = "is shuddering significantly, its servos briefly giving way in a rythmic pattern"
-	treat_text = "Containment of damaged wiring via gauze, then application of fresh wiring/sutures, or resetting of displaced wiring via wirecutter/retractor."
+	treat_text = "Wrap the injury with gauze to contain the severed wiring, then replace it with fresh cabling, or sutures if necessary. \
+				Displaced wiring can also be reset using a wirecutter or retractor."
+	treat_text_short = "Wrap in gauze, then replace cabling or suture. Wirecutters or a retractor can also reset the wiring."
 
 	sound_effect = 'modular_doppler/modular_medical/wounds/synth/sound/robotic_slash_T2.ogg'
 
@@ -111,8 +114,9 @@
 	desc = "The local PSU of this limb has suffered a core rupture, causing a progressive power failure that will slowly intensify into massive electrical damage."
 	occur_text = "flashes with radiant blue, emitting a noise not unlike a Jacob's Ladder"
 	examine_desc = "'s PSU is visible, with a sizable hole in the center"
-	treat_text = "Immediate securing via gauze, followed by emergency cable replacement and securing via wirecutters or hemostat. \
+	treat_text = "Immediately secure the damaged area with gauze. Replace all cabling, and secure it into place via wirecutters or a retractor. \
 		If the fault has become uncontrollable, extreme heat therapy is recommended."
+	treat_text_short = "Wrap with gauze, then replace cabling and secure with wirecutters or a retractor. In an emergency, apply high heat."
 
 	severity = WOUND_SEVERITY_CRITICAL
 	wound_flags = (ACCEPTS_GAUZE|MANGLES_EXTERIOR|CAN_BE_GRASPED|SPLINT_OVERLAY)

--- a/modular_doppler/modular_medical/wounds/synth/robotic_slash.dm
+++ b/modular_doppler/modular_medical/wounds/synth/robotic_slash.dm
@@ -511,8 +511,9 @@
 	desc = "Internal wiring has suffered a slight abrasion, causing a slow electrical fault that will intensify over time."
 	occur_text = "lets out a few sparks, as a few frayed wires stick out"
 	examine_desc = "has a few frayed wires sticking out"
-	treat_text = "Replacing of damaged wiring, though repairs via wirecutting instruments or sutures may suffice, albeit at limited efficiency. In case of emergency, \
-				subject may be subjected to high temperatures to allow solder to reset."
+	treat_text = "Replace the damaged wiring. Repairs via wirecutting instruments or sutures may suffice, albeit at limited efficiency. \
+				In case of emergency, subject may be subjected to high temperatures to allow solder to reset."
+	treat_text_short = "Replace wiring, or repair with wirecutters or sutures. Apply heat in a pinch."
 
 	sound_effect = 'modular_doppler/modular_medical/wounds/synth/sound/robotic_slash_T1.ogg'
 
@@ -555,7 +556,9 @@
 	desc = "A number of wires have been completely cut, resulting in electrical faults that will intensify at a worrying rate."
 	occur_text = "sends some electrical fiber in the direction of the blow, beginning to profusely spark"
 	examine_desc = "has multiple severed wires visible to the outside"
-	treat_text = "Containment of damaged wiring via gauze, then application of fresh wiring/sutures, or resetting of displaced wiring via wirecutter/retractor."
+	treat_text = "Wrap the injury with gauze to contain the severed wiring, then replace it with fresh cabling, or sutures if necessary. \
+				Displaced wiring can also be reset using a wirecutter or retractor."
+	treat_text_short = "Wrap in gauze, then replace cabling or suture. Wirecutters or a retractor can also reset the wiring."
 
 	sound_effect = 'modular_doppler/modular_medical/wounds/synth/sound/robotic_slash_T2.ogg'
 
@@ -598,8 +601,9 @@
 	desc = "A significant portion of the power distribution network has been cut open, resulting in massive power loss and runaway electrocution."
 	occur_text = "lets out a violent \"zhwarp\" sound as angry electric arcs attack the surrounding air"
 	examine_desc = "has lots of mauled wires sticking out"
-	treat_text = "Immediate securing via gauze, followed by emergency cable replacement and securing via wirecutters or retractor. \
+	treat_text = "Immediately secure the damaged area with gauze. Replace all cabling, and secure it into place via wirecutters or a retractor. \
 		If the fault has become uncontrollable, extreme heat therapy is recommended."
+	treat_text_short = "Wrap with gauze, then replace cabling and secure with wirecutters or a retractor. In an emergency, apply high heat."
 
 	severity = WOUND_SEVERITY_CRITICAL
 	wound_flags = (ACCEPTS_GAUZE|MANGLES_EXTERIOR|CAN_BE_GRASPED|SPLINT_OVERLAY)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

All the wounds added by this codebase have had treat_text_short added, and many have had their normal treatment text shored up. Muscle wounds have additionally had their simple and first aid descriptions added.

Also, the synth muscle wounds have a different sound than the normal blood spurt thing. Because it's cooler.

Acknowledges #237 

## Why It's Good For The Game

blenderman be like collect my wound descriptions

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: All Doppler wounds now have treatment hovertext
qol: Synthetic muscle wounds have a different sound now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
