### PR TITLE
Let undersized carp genemods function as slightly more powerful wirecutters when picked up

### DIFF
--- a/code/__DEFINES/~doppler_defines/signals.dm
+++ b/code/__DEFINES/~doppler_defines/signals.dm
@@ -19,3 +19,6 @@
 #define COMSIG_PRE_BATON_FINALIZE_ATTACK "pre_baton_finalize_attack"
 // For after a user has sent a say message
 #define COMSIG_MOB_POST_SAY "mob_post_say"
+
+/// For modifying a mob holder based on what it's holding
+#define COMSIG_ADDING_MOB_HOLDER_SPECIALS "adding_mob_holder_specials"

--- a/modular_doppler/modular_quirks/undersized/held_undersized_specials.dm
+++ b/modular_doppler/modular_quirks/undersized/held_undersized_specials.dm
@@ -1,0 +1,38 @@
+
+/obj/item/clothing/head/mob_holder/Initialize(mapload, mob/living/M, worn_state, head_icon, lh_icon, rh_icon, worn_slot_flags = NONE)
+	. = ..()
+	SEND_SIGNAL(M, COMSIG_ADDING_MOB_HOLDER_SPECIALS, M, src)
+
+
+// CARP TONGUE WIRECUTTERS
+
+/obj/item/organ/tongue/carp/on_mob_insert(mob/living/carbon/tongue_owner, special, movement_flags)
+	. = ..()
+	if(!ishuman(tongue_owner))
+		return
+	RegisterSignal(tongue_owner, COMSIG_ADDING_MOB_HOLDER_SPECIALS, PROC_REF(on_adding_mob_holder_specials))
+
+/obj/item/organ/tongue/carp/on_mob_remove(mob/living/carbon/tongue_owner)
+	. = ..()
+	if(!ishuman(tongue_owner))
+		return
+	UnregisterSignal(tongue_owner, COMSIG_ADDING_MOB_HOLDER_SPECIALS)
+	
+/obj/item/organ/tongue/carp/proc/on_adding_mob_holder_specials(datum/source, mob/living/held_creature, obj/item/clothing/head/mob_holder/our_holder)
+	SIGNAL_HANDLER
+	if(!held_creature.has_quirk(/datum/quirk/undersized))
+		return
+	// Make our little carp an effective wirecutter <3
+	our_holder.tool_behaviour = TOOL_WIRECUTTER
+	our_holder.toolspeed = 1
+	our_holder.attack_verb_continuous = list("pinches", "nips")
+	our_holder.attack_verb_simple = list("pinch", "nip")
+	our_holder.hitsound = 'sound/items/tools/wirecutter.ogg'
+	our_holder.usesound = 'sound/items/tools/wirecutter.ogg'
+	our_holder.operating_sound = 'sound/items/tools/wirecutter_cut.ogg'
+	our_holder.drop_sound = 'sound/items/handling/tools/wirecutter_drop.ogg'
+	our_holder.pickup_sound = 'sound/items/handling/tools/wirecutter_pickup.ogg'
+	// And a decently effective weapon
+	our_holder.force = 10
+	our_holder.throw_speed = 3
+	our_holder.throw_range = 7

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7195,6 +7195,7 @@
 #include "modular_doppler\modular_quirks\permitted_cybernetic\code\preferences.dm"
 #include "modular_doppler\modular_quirks\system_shock\system_shock.dm"
 #include "modular_doppler\modular_quirks\undersized\gun.dm"
+#include "modular_doppler\modular_quirks\undersized\held_undersized_specials.dm"
 #include "modular_doppler\modular_quirks\undersized\inhand_holder.dm"
 #include "modular_doppler\modular_quirks\undersized\squashable.dm"
 #include "modular_doppler\modular_quirks\undersized\undersized.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Implements a signal for adding special properties to the mob holder based on the mob that's being held, which could in the future be extended to oversized crew picking up regular crew if so desired.

We then use this to implement undersized crew with the carp tongue being slightly more dangerous wirecutters when picked up, by having it set the vars on the holder item to be parallel to those on wirecutters.
There's no reason to reset these values later, as the holder item gets deleted when unused.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It's funny
snip snip snip

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Undersized people with the carp tongue can now be used as wirecutters when picked up, dealing damage in the lower range of the unarmed damage their teeth gives them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
