### PR TITLE
Lower plasmoid limb colonization chance to 1% per tick

### DIFF
--- a/code/game/turfs/open/lava.dm
+++ b/code/game/turfs/open/lava.dm
@@ -415,8 +415,8 @@
 		|| !ishuman(burn_living) \
 		|| HAS_TRAIT(burn_living, TRAIT_NODISMEMBER) \
 		|| HAS_TRAIT(burn_living, TRAIT_NO_PLASMA_TRANSFORM) \
-		|| SPT_PROB(65, seconds_per_tick) \
-	)
+		|| SPT_PROB(99, seconds_per_tick) \
+	) // DOPPLER EDIT: decrease the chance of plasmoid infection massively (original: SPT_PROB(65)
 		return
 
 	var/mob/living/carbon/human/burn_human = burn_living


### PR DESCRIPTION
## Why It's Good For The Game

two characters in the span of 2 minutes touched a single liquid plasma tile during a retrieval and ended up with plasmaman limbs.

the base chance is too high - this should get it to a point where you really don't want to be walking on liquid plasma (horrific burns aside) but corpses that fall into the lake should still end up requiring extended medical care past a point

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: yooriss
balance: Taking damage from a liquid plasma tile now only has a 1% chance to convert a random limb to a plasmoid limb, down from 35%.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
