### PR TITLE
Robotics legs no longer have meat footsteps

### DIFF
--- a/modular_doppler/modular_species/species_types/android/android_parts.dm
+++ b/modular_doppler/modular_species/species_types/android/android_parts.dm
@@ -851,6 +851,8 @@
 	icon_state = "synth_lizard_r_leg"
 	limb_id = "synth_lizard"
 
+	footstep_type = FOOTSTEP_MOB_CLAW
+
 /obj/item/bodypart/leg/left/robot/android/synth_lizard
 	bodypart_traits = list(TRAIT_HARD_SOLES)
 	bodyshape = BODYSHAPE_HUMANOID | BODYSHAPE_DIGITIGRADE
@@ -860,6 +862,8 @@
 	icon_greyscale = ANDROID_BODYPARTS_DMI
 	icon_state = "synth_lizard_r_leg"
 	limb_id = "synth_lizard"
+
+	footstep_type = FOOTSTEP_MOB_CLAW
 
 ///
 // Human-Like
@@ -906,6 +910,8 @@
 	icon_state = "human_like_r_leg"
 	limb_id = "human_like"
 
+	footstep_type = FOOTSTEP_MOB_BAREFOOT
+
 /obj/item/bodypart/leg/left/robot/android/human_like
 	should_draw_greyscale = TRUE
 	icon_static = ANDROID_BODYPARTS_DMI
@@ -913,6 +919,8 @@
 	icon_greyscale = ANDROID_BODYPARTS_DMI
 	icon_state = "human_like_r_leg"
 	limb_id = "human_like"
+
+	footstep_type = FOOTSTEP_MOB_BAREFOOT
 
 ///
 // zhenkov-light
@@ -1063,3 +1071,14 @@
 	category = list(
 		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_ADVANCED_LIMBS
 	)
+
+
+///
+// sound overwrites
+///
+
+/obj/item/bodypart/leg/right/robot
+	footstep_type = FOOTSTEP_MOB_SHOE //stop making meat noises. consider custom sounds for this later
+
+/obj/item/bodypart/leg/left/robot
+	footstep_type = FOOTSTEP_MOB_SHOE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Robotic limbs across the board have had their footstep sound set to the standard shoe one. The exceptions are the human-like legs, which retain barefoot sounds, and the synthetic lizard legs, which have the clawed footstep sounds.

## Why It's Good For The Game

i am tired of sounding like a fish sprinting around when i make the dastardly design decision to have a character's decidedly inhuman legs not have shoes

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Robotic legs no longer have organic barefoot footstep sounds. Human-like and synthetic lizard legs are exempt.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
