### PR TITLE
Adds color selection to android screens

### DIFF
--- a/modular_doppler/modular_species/species_types/android/monitor_component.dm
+++ b/modular_doppler/modular_species/species_types/android/monitor_component.dm
@@ -59,6 +59,8 @@ GLOBAL_LIST_INIT(monitor_lizard_displays, list(
 	layers = EXTERNAL_ADJACENT
 	blocks_emissive = EMISSIVE_BLOCK_NONE
 
+	draw_color = "#FFFFFF"
+
 // the component
 /datum/component/monitor_head
 	dupe_mode = COMPONENT_DUPE_UNIQUE
@@ -109,10 +111,14 @@ GLOBAL_LIST_INIT(monitor_lizard_displays, list(
 	if(!new_display)
 		return
 
+	var/new_color = sanitize_hexcolor(input(usr, "Choose your screen's color:", "Monitor Color") as null | color) // BAD
+	if(!new_color)
+		return
+
 	if(!display_overlay)
 		create_screen(wearer)
 
-	change_screen(wearer, "[head_type & MONITOR_HEAD ? GLOB.monitor_displays[new_display] : GLOB.monitor_lizard_displays[new_display]]")
+	change_screen(wearer, "[head_type & MONITOR_HEAD ? GLOB.monitor_displays[new_display] : GLOB.monitor_lizard_displays[new_display]]", new_color)
 
 /datum/action/innate/monitor_head/proc/check_emote(mob/living/carbon/wearer, datum/emote/emote)
 	SIGNAL_HANDLER
@@ -179,11 +185,19 @@ GLOBAL_LIST_INIT(monitor_lizard_displays, list(
 
 	monitor_head.add_bodypart_overlay(display_overlay)
 
-/datum/action/innate/monitor_head/proc/change_screen(mob/living/carbon/wearer, screen)
+/datum/action/innate/monitor_head/proc/change_screen(mob/living/carbon/wearer, screen, new_color = null)
 	var/obj/item/bodypart/head/robot/android/monitor_head = wearer.get_bodypart(BODY_ZONE_HEAD)
+
+	var/old_screen = display_overlay.icon_state
+	if(old_screen == screen) // EXTREMELY BAD
+		display_overlay.icon_state = "none"
+		wearer.update_body_parts()
 
 	display_overlay.icon_state = screen
 	monitor_head.monitor_state = screen
+
+	if(new_color)
+		display_overlay.draw_color = new_color
 
 	playsound(wearer, 'modular_doppler/modular_sounds/sound/mobs/humanoids/android/monitor_switch.ogg', 100, TRUE)
 	wearer.update_body_parts()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changing your screen now also gives a color selection prompt. Color will be preserved through synthlizard emotes.

This code is unpleasant and has a hacky check for allowing the color to update even if the screen icon doesn't. It's functional for now, but I'd love to change that to literally anything else.

## Why It's Good For The Game

I LIKE SHAPES AND COLORS

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Androids can now change their screen color
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
