### PR TITLE
I Am The Captain Now: Ship captain quirk

### DIFF
--- a/modular_doppler/ship_captain/code/ship_captain.dm
+++ b/modular_doppler/ship_captain/code/ship_captain.dm
@@ -1,0 +1,90 @@
+/datum/quirk/ship_captain
+	name = "Ship Captain"
+	desc = "You own or otherwise have access to a spacefaring vessel capable of docking with the station, and spawn in it at roundstart."
+	gain_text = span_info("Your trusty vessel is at hand.")
+	lose_text = span_warning("You've lost your vessel...")
+	icon = FA_ICON_SHIP
+	value = 8
+	var/datum/turf_reservation/owned_ship_reservation
+	var/datum/map_template/shuttle/personal_buyable/our_shuttle_template
+
+/datum/quirk/ship_captain/post_add()
+	. = ..()
+	// we have to post_add this otherwise it'll fire on every spawn which we really, really don't want
+
+	var/template_path_key = quirk_holder.client?.prefs.read_preference(/datum/preference/choiced/ship_captain_hull)
+	var/template_path = GLOB.purchasable_ship_hulls[template_path_key]
+	if (template_path_key)
+		our_shuttle_template = new template_path()
+
+	if (!our_shuttle_template)
+		CRASH("failed to make ship template for captain quirk at prefs read stage")
+
+	owned_ship_reservation = SSmapping.request_turf_block_reservation(
+		our_shuttle_template.width,
+		our_shuttle_template.height,
+		1,
+		reservation_type = /datum/turf_reservation/transit,
+	)
+	if (!owned_ship_reservation)
+		CRASH("failed to reserve an area for ship captain quirk shuttle template loading")
+
+	var/turf/bottom_left = owned_ship_reservation.bottom_left_turfs[1]
+	our_shuttle_template.load(bottom_left, centered = FALSE)
+
+	// need to find a safe turf and drop us there
+	var/affected_turfs = our_shuttle_template.get_affected_turfs(bottom_left, centered = TRUE)
+	var/turf/spawn_turf
+	for (var/turf/shuttle_turf in affected_turfs)
+		if (is_safe_turf(shuttle_turf))
+			spawn_turf = shuttle_turf
+			break
+
+	if (!spawn_turf)
+		CRASH("failed to find a safe turf for ship captain shuttle spawning...")
+
+	// otherwise, move us there
+	var/mob/living/carbon/human/human_holder = quirk_holder
+	human_holder.forceMove(spawn_turf)
+
+	to_chat(human_holder, span_notice("<b>OOC NOTE</b>: If you're using a larger ship (like the mothership), please try to avoid automatic docking (use the navigation computer and place your ship manually near the station and EVA across). There are also known issues with rotation screwing up some shuttle templates, and staff can't fix this for you if it happens mid round!"))
+
+// TODO: transponder prefs to rename the area?
+// TODO: announce on command comms when thing spawns nearby (is this even possible?)
+
+/datum/quirk_constant_data/ship_captain
+	associated_typepath = /datum/quirk/ship_captain
+	customization_options = list(
+		/datum/preference/choiced/ship_captain_hull,
+	)
+
+/datum/preference/choiced/ship_captain_hull
+	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
+	savefile_key = "ship_captain_hull"
+	savefile_identifier = PREFERENCE_CHARACTER
+	can_randomize = FALSE
+
+/datum/preference/choiced/ship_captain_hull/init_possible_values()
+	return assoc_to_keys(GLOB.purchasable_ship_hulls)
+
+/datum/preference/choiced/ship_captain_hull/create_default_value()
+	return "CAS Hafila"
+
+/datum/preference/choiced/ship_captain_hull/is_accessible(datum/preferences/preferences)
+	if (!..())
+		return FALSE
+
+	return "Ship Captain" in preferences.all_quirks
+
+/datum/preference/choiced/ship_captain_hull/apply_to_human(mob/living/carbon/human/target, value)
+	return // is it possible to use this to readout info on each ship type?
+
+GLOBAL_LIST_INIT(purchasable_ship_hulls, generate_purchasable_ship_hulls())
+
+/proc/generate_purchasable_ship_hulls()
+	var/list/hulls = list()
+	var/list/shuttle_types = subtypesof(/datum/map_template/shuttle/personal_buyable)
+	for(var/datum/map_template/shuttle/personal_buyable/path as anything in shuttle_types)
+		hulls["[path.name]"] = path
+
+	return hulls

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7299,6 +7299,7 @@
 #include "modular_doppler\research\designs\limbgrower_designs.dm"
 #include "modular_doppler\research\techweb\all_nodes.dm"
 #include "modular_doppler\research\techweb\roundstart_techweb_nodes.dm"
+#include "modular_doppler\ship_captain\code\ship_captain.dm"
 #include "modular_doppler\ships_r_us\code\buyable_shuttle_template.dm"
 #include "modular_doppler\ships_r_us\code\micro_reactor.dm"
 #include "modular_doppler\ships_r_us\code\order_console.dm"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/dopplershift_preferences/ship_captain.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/dopplershift_preferences/ship_captain.tsx
@@ -1,0 +1,9 @@
+import {
+  FeatureChoiced,
+} from '../base';
+import { FeatureDropdownInput } from '../dropdowns';
+
+export const ship_captain_hull: FeatureChoiced = {
+  name: 'Ship Hull',
+  component: FeatureDropdownInput,
+};


### PR DESCRIPTION
## About The Pull Request

Threw this up last night in about an hour on a whim after thinking it'd be pretty cool if people could just spawn in with a Paxil shuttle. Turns out that it is a *lot* easier to do that than expected.

Real simple: adds a quirk that lets you pick from any of the purchasable shuttles, creates one for you out in deep space and moves you to it shortly after you spawn.

I have not tested how this works with multiple people taking the quirk - it should theoretically be fine given that it's using turf reservations properly and all that jazz, but still.

I might extend this with a box of stuff like megabeacons and other useful captain goodies to give people a bit of a head start in terms of getting going.

## Why It's Good For The Game

Shiptest go brrr

## Changelog

:cl: yooriss
add: The Ship Captain quirk has been added, allowing characters to spawn with a purchasable shuttle at round start.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
