### PR TITLE
Oof Ouch Owie: Pain only causes screaming when actually felt

### DIFF
--- a/code/datums/components/tackle.dm
+++ b/code/datums/components/tackle.dm
@@ -533,7 +533,7 @@
 			playsound(user, 'sound/effects/blob/blobattack.ogg', 60, TRUE)
 			playsound(user, 'sound/effects/splat.ogg', 70, TRUE)
 			playsound(user, 'sound/effects/wounds/crack2.ogg', 70, TRUE)
-			user.emote("scream")
+			user.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 			user.gain_trauma(/datum/brain_trauma/severe/paralysis/paraplegic) // oopsie indeed!
 			shake_camera(user, 7, 7)
 			user.flash_act(1, TRUE, TRUE, length = 4.5)

--- a/code/datums/components/vision_hurting.dm
+++ b/code/datums/components/vision_hurting.dm
@@ -23,4 +23,4 @@
 		if(SPT_PROB(50, seconds_per_tick))
 			to_chat(viewer, span_userdanger("[message] [parent]!"))
 		if(SPT_PROB(20, seconds_per_tick))
-			viewer.emote("scream")
+			viewer.painful_scream() // DOPPLER EDIT: check for painkilling before screaming

--- a/code/datums/diseases/advance/symptoms/deafness.dm
+++ b/code/datums/diseases/advance/symptoms/deafness.dm
@@ -57,7 +57,7 @@
 					to_chat(infected_mob, span_userdanger("Your ears pop painfully and start bleeding!"))
 					// Just absolutely murder me man
 					ears.apply_organ_damage(ears.maxHealth)
-					infected_mob.emote("scream")
+					infected_mob.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 					ADD_TRAIT(infected_mob, TRAIT_DEAF, DISEASE_TRAIT)
 			else
 				to_chat(infected_mob, span_userdanger("Your ears pop and begin ringing loudly!"))

--- a/code/datums/diseases/advance/symptoms/fire.dm
+++ b/code/datums/diseases/advance/symptoms/fire.dm
@@ -60,7 +60,7 @@
 			if(living_mob.on_fire) //check to make sure they actually caught on fire, or if it was prevented cause they were wet.
 				living_mob.visible_message(span_warning("[living_mob] catches fire!"), ignored_mobs = living_mob)
 				to_chat(living_mob, span_userdanger((advanced_stage ? "Your skin erupts into an inferno!" : "Your skin bursts into flames!")))
-				living_mob.emote("scream")
+				living_mob.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 			else if(!suppress_warning)
 				warn_mob(living_mob)
 
@@ -139,7 +139,7 @@ Bonus
 			Alkali_fire_stage_4(M, A)
 			M.ignite_mob()
 			to_chat(M, span_userdanger("Your sweat bursts into flames!"))
-			M.emote("scream")
+			M.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 		if(5)
 			if(M.fire_stacks < 0)
 				M.visible_message(span_warning("[M]'s sweat sizzles and pops on contact with water!"))
@@ -147,7 +147,7 @@ Bonus
 			Alkali_fire_stage_5(M, A)
 			M.ignite_mob()
 			to_chat(M, span_userdanger("Your skin erupts into an inferno!"))
-			M.emote("scream")
+			M.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 
 /datum/symptom/alkali/proc/Alkali_fire_stage_4(mob/living/M, datum/disease/advance/A)
 	var/get_stacks = 6 * power

--- a/code/datums/diseases/chronic_illness.dm
+++ b/code/datums/diseases/chronic_illness.dm
@@ -63,7 +63,7 @@
 					affected_mob.AdjustSleeping(1 SECONDS)
 			if(SPT_PROB(0.5, seconds_per_tick))
 				to_chat(affected_mob, span_danger("[pick("You feel as though your atoms are accelerating in place.", "You feel like you're being torn apart!")]"))
-				affected_mob.emote("scream")
+				affected_mob.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 				need_mob_update += affected_mob.adjustBruteLoss(10, updating_health = FALSE)
 			if(need_mob_update)
 				affected_mob.updatehealth()
@@ -76,7 +76,7 @@
 					to_chat(affected_mob, span_boldwarning("There is no place for you in this timeline."))
 					affected_mob.adjustStaminaLoss(100, forced = TRUE)
 					playsound(affected_mob.loc, 'sound/effects/magic/repulse.ogg', 100, FALSE)
-					affected_mob.emote("scream")
+					affected_mob.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 					for(var/mob/living/viewers in viewers(3, affected_mob.loc))
 						viewers.flash_act()
 					new /obj/effect/decal/cleanable/plasma(affected_mob.loc)

--- a/code/datums/diseases/gastrolisis.dm
+++ b/code/datums/diseases/gastrolisis.dm
@@ -43,7 +43,7 @@
 				new_eyes.Insert(affected_mob)
 				affected_mob.visible_message(span_warning("[affected_mob]'s eyes fall out, with snail eyes taking its place!"), \
 				span_userdanger("You scream in pain as your eyes are pushed out by your new snail eyes!"))
-				affected_mob.emote("scream")
+				affected_mob.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 				return
 
 			var/obj/item/shell = affected_mob.get_item_by_slot(ITEM_SLOT_BACK)
@@ -54,7 +54,7 @@
 					affected_mob.equip_to_slot_or_del(new /obj/item/storage/backpack/snail(affected_mob), ITEM_SLOT_BACK)
 					affected_mob.visible_message(span_warning("[affected_mob] grows a grotesque shell on their back!"), \
 					span_userdanger("You scream in pain as a shell pushes itself out from under your skin!"))
-					affected_mob.emote("scream")
+					affected_mob.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 					return
 
 			var/obj/item/organ/tongue/tongue = locate(/obj/item/organ/tongue/snail) in affected_mob.organs

--- a/code/datums/elements/kneecapping.dm
+++ b/code/datums/elements/kneecapping.dm
@@ -87,7 +87,7 @@
 	var/max_wound = leg.get_wound_threshold_of_wound_type(WOUND_BLUNT, WOUND_SEVERITY_CRITICAL, return_value_if_no_wound = 50, wound_source = weapon)
 
 	target.apply_damage(weapon.force, weapon.damtype, leg, wound_bonus = rand(min_wound, max_wound + 10), attacking_item = weapon)
-	target.emote("scream")
+	target.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 	log_combat(attacker, target, "broke the kneecaps of", weapon)
 	attacker.do_attack_animation(target, used_item = weapon)
 	playsound(source = weapon, soundin = weapon.hitsound, vol = weapon.get_clamped_volume(), vary = TRUE)

--- a/code/datums/embedding.dm
+++ b/code/datums/embedding.dm
@@ -359,7 +359,7 @@
 		damagetype = STAMINA,
 	)
 
-	owner.emote("scream")
+	owner.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 
 /// The proper proc to call when you want to remove something. If a mob is passed, the item will be put in its hands - otherwise it's just dumped onto the ground
 /datum/embedding/proc/remove_embedding(mob/living/to_hands)

--- a/code/datums/martial/wrestling.dm
+++ b/code/datums/martial/wrestling.dm
@@ -162,7 +162,7 @@ If you make a derivative work from this code, you must include this notification
 	defender.visible_message(span_danger("[attacker] starts spinning around with [defender]!"), \
 					span_userdanger("You're spun around by [attacker]!"), span_hear("You hear aggressive shuffling!"), null, attacker)
 	to_chat(attacker, span_danger("You start spinning around with [defender]!"))
-	attacker.emote("scream")
+	attacker.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 
 	for (var/i in 1 to 20)
 		var/delay = 5
@@ -220,7 +220,7 @@ If you make a derivative work from this code, you must include this notification
 		var/turf/T = get_edge_target_turf(attacker, attacker.dir)
 		if (T && isturf(T))
 			if (!defender.stat)
-				defender.emote("scream")
+				defender.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 			defender.throw_at(T, 10, 4, attacker, TRUE, TRUE, callback = CALLBACK(defender, TYPE_PROC_REF(/mob/living, Paralyze), 20))
 	log_combat(attacker, defender, "has thrown with wrestling")
 	return
@@ -320,7 +320,7 @@ If you make a derivative work from this code, you must include this notification
 		to_chat(attacker, span_danger("You [fluff] [defender]!"))
 		playsound(attacker.loc, SFX_SWING_HIT, 50, TRUE)
 		if (!defender.stat)
-			defender.emote("scream")
+			defender.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 			defender.Paralyze(4 SECONDS)
 
 			switch(rand(1,3))
@@ -371,7 +371,7 @@ If you make a derivative work from this code, you must include this notification
 /datum/martial_art/wrestling/proc/kick(mob/living/attacker, mob/living/defender)
 	if(!defender)
 		return
-	attacker.emote("scream")
+	attacker.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 	attacker.emote("flip")
 	attacker.setDir(turn(attacker.dir, 90))
 
@@ -445,7 +445,7 @@ If you make a derivative work from this code, you must include this notification
 						span_userdanger("You're leg-dropped by [attacker]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), null, attacker)
 		to_chat(attacker, span_danger("You leg-drop [defender]!"))
 		playsound(attacker.loc, SFX_SWING_HIT, 50, TRUE)
-		attacker.emote("scream")
+		attacker.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 
 		if (falling == 1)
 			if (prob(33) || defender.stat)

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -106,7 +106,7 @@
 
 /datum/mutation/human/paranoia/on_life(seconds_per_tick, times_fired)
 	if(SPT_PROB(2.5, seconds_per_tick) && owner.stat == CONSCIOUS)
-		owner.emote("scream")
+		owner.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 		if(prob(25))
 			owner.adjust_hallucinations(40 SECONDS)
 

--- a/code/datums/mutations/hulk.dm
+++ b/code/datums/mutations/hulk.dm
@@ -154,8 +154,8 @@
 	yeeted_person.visible_message(span_danger("[the_hulk] starts spinning [yeeted_person] around by [yeeted_person.p_their()] tail!"), \
 					span_userdanger("[the_hulk] starts spinning you around by your tail!"), span_hear("You hear wooshing sounds!"), null, the_hulk)
 	to_chat(the_hulk, span_danger("You start spinning [yeeted_person] around by [yeeted_person.p_their()] tail!"))
-	the_hulk.emote("scream")
-	yeeted_person.emote("scream")
+	the_hulk.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
+	yeeted_person.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 	swing_loop(the_hulk, yeeted_person, 0, original_dir)
 
 /**
@@ -253,7 +253,7 @@
 	if(!isturf(T))
 		return
 	if(!yeeted_person.stat)
-		yeeted_person.emote("scream")
+		yeeted_person.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 	yeeted_person.throw_at(T, 10, 6, the_hulk, TRUE, TRUE)
 	log_combat(the_hulk, yeeted_person, "has thrown by tail")
 

--- a/code/datums/mutations/touch.dm
+++ b/code/datums/mutations/touch.dm
@@ -408,7 +408,7 @@
 	motherfucker_to_hurt.update_damage_overlays()
 
 	to_chat(motherfucker_to_hurt, span_bolddanger("[smiter] [smite_text_to_target], hurting you!"))
-	motherfucker_to_hurt.emote("scream")
+	motherfucker_to_hurt.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 	new /obj/effect/temp_visual/explosion(get_turf(motherfucker_to_hurt), evil_smite ? LIGHT_COLOR_BLOOD_MAGIC : LIGHT_COLOR_HOLY_MAGIC)
 	. = TRUE
 

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -220,7 +220,7 @@
 	if(duration + bonus_time >= exhaustion_limit)
 		duration = exhaustion_limit
 		to_chat(new_owner, span_userdanger("Your muscles are exhausted! Might be a good idea to sleep..."))
-		new_owner.emote("scream")
+		new_owner.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 		return // exhaustion_limit
 
 	return bonus_time

--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -874,7 +874,7 @@
 				if(1)
 					victim.say(pick(ant_debuff_speech), forced = /datum/status_effect/ants)
 				if(2)
-					victim.emote("scream")
+					victim.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 		if(prob(50)) // Most of the damage is done through random chance. When tested yielded an average 100 brute with 200u ants.
 			switch(rand(1,50))
 				if (1 to 8) //16% Chance

--- a/code/datums/status_effects/debuffs/phobia.dm
+++ b/code/datums/status_effects/debuffs/phobia.dm
@@ -6,7 +6,7 @@
 
 /datum/status_effect/minor_phobia_reaction/on_apply()
 	. = ..()
-	owner.emote("scream")
+	owner.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 	owner.set_jitter_if_lower(6 SECONDS)
 	owner.add_mood_event("phobia_minor", /datum/mood_event/startled)
 
@@ -46,7 +46,7 @@
 			owner.Immobilize(0.1 SECONDS * stacks)
 
 		if(2)
-			owner.emote("scream")
+			owner.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 			owner.say("AAAAH!!", forced = "phobia")
 
 			if(stacks >= 5)

--- a/code/datums/status_effects/debuffs/terrified.dm
+++ b/code/datums/status_effects/debuffs/terrified.dm
@@ -30,7 +30,7 @@
 
 /datum/status_effect/terrified/on_apply()
 	RegisterSignal(owner, COMSIG_CARBON_PRE_MISC_HELP, PROC_REF(comfort_owner))
-	owner.emote("scream")
+	owner.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 	to_chat(owner, span_alert("The darkness closes in around you, shadows dance around the corners of your vision... It feels like something is watching you!"))
 	return TRUE
 
@@ -149,7 +149,7 @@
 	terror_buildup += amount
 	owner.Knockdown(0.5 SECONDS)
 	if(prob(50))
-		owner.emote("scream")
+		owner.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 
 /// The status effect popup for the terror status effect
 /atom/movable/screen/alert/status_effect/terrified

--- a/code/datums/wounds/bones.dm
+++ b/code/datums/wounds/bones.dm
@@ -307,7 +307,7 @@
 	if(prob(65))
 		user.visible_message(span_danger("[user] snaps [victim]'s dislocated [limb.plaintext_zone] back into place!"), span_notice("You snap [victim]'s dislocated [limb.plaintext_zone] back into place!"), ignored_mobs=victim)
 		to_chat(victim, span_userdanger("[user] snaps your dislocated [limb.plaintext_zone] back into place!"))
-		victim.emote("scream")
+		victim.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 		victim.apply_damage(20, BRUTE, limb, wound_bonus = CANT_WOUND)
 		qdel(src)
 	else
@@ -326,7 +326,7 @@
 	if(prob(65))
 		user.visible_message(span_danger("[user] snaps [victim]'s dislocated [limb.plaintext_zone] with a sickening crack!"), span_danger("You snap [victim]'s dislocated [limb.plaintext_zone] with a sickening crack!"), ignored_mobs=victim)
 		to_chat(victim, span_userdanger("[user] snaps your dislocated [limb.plaintext_zone] with a sickening crack!"))
-		victim.emote("scream")
+		victim.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 		victim.apply_damage(25, BRUTE, limb, wound_bonus = 30)
 	else
 		user.visible_message(span_danger("[user] wrenches [victim]'s dislocated [limb.plaintext_zone] around painfully!"), span_danger("You wrench [victim]'s dislocated [limb.plaintext_zone] around painfully!"), ignored_mobs=victim)
@@ -356,7 +356,7 @@
 		user.visible_message(span_danger("[user] finishes resetting [victim]'s [limb.plaintext_zone]!"), span_nicegreen("You finish resetting [victim]'s [limb.plaintext_zone]!"), ignored_mobs=victim)
 		to_chat(victim, span_userdanger("[user] resets your [limb.plaintext_zone]!"))
 
-	victim.emote("scream")
+	victim.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 	qdel(src)
 	return TRUE
 
@@ -460,7 +460,7 @@
 		return TRUE
 
 	I.use(1)
-	victim.emote("scream")
+	victim.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 	if(user != victim)
 		user.visible_message(span_notice("[user] finishes applying [I] to [victim]'s [limb.plaintext_zone], emitting a fizzing noise!"), span_notice("You finish applying [I] to [victim]'s [limb.plaintext_zone]!"), ignored_mobs=victim)
 		to_chat(victim, span_userdanger("[user] finishes applying [I] to your [limb.plaintext_zone], and you can feel the bones exploding with pain as they begin melting and reforming!"))

--- a/code/datums/wounds/pierce.dm
+++ b/code/datums/wounds/pierce.dm
@@ -158,7 +158,7 @@
 	user.visible_message(span_green("[user] cauterizes some of the [bleeding_wording] on [victim]."), span_green("You cauterize some of the [bleeding_wording] on [victim]."))
 	victim.apply_damage(2 + severity, BURN, limb, wound_bonus = CANT_WOUND)
 	if(prob(30))
-		victim.emote("scream")
+		victim.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 	var/blood_cauterized = (0.6 / (self_penalty_mult * improv_penalty_mult))
 	adjust_blood_flow(-blood_cauterized)
 

--- a/code/datums/wounds/slash.dm
+++ b/code/datums/wounds/slash.dm
@@ -236,7 +236,7 @@
 	lasgun.chambered.loaded_projectile.damage *= self_penalty_mult
 	if(!lasgun.process_fire(victim, victim, TRUE, null, limb.body_zone))
 		return
-	victim.emote("scream")
+	victim.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 	adjust_blood_flow(-1 * (damage / (5 * self_penalty_mult))) // 20 / 5 = 4 bloodflow removed, p good
 	victim.visible_message(span_warning("The cuts on [victim]'s [limb.plaintext_zone] scar over!"))
 	return TRUE
@@ -265,7 +265,7 @@
 	user.visible_message(span_green("[user] cauterizes some of the [bleeding_wording] on [victim]."), span_green("You cauterize some of the [bleeding_wording] on [victim]."))
 	victim.apply_damage(2 + severity, BURN, limb, wound_bonus = CANT_WOUND)
 	if(prob(30))
-		victim.emote("scream")
+		victim.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 	var/blood_cauterized = (0.6 / (self_penalty_mult * improv_penalty_mult))
 	var/mob/victim_stored = victim
 	adjust_blood_flow(-blood_cauterized)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -577,7 +577,7 @@
 				future_pancake.Paralyze(100)
 			else if(ishuman(future_pancake)) //For humans
 				future_pancake.adjustBruteLoss(DOOR_CRUSH_DAMAGE)
-				future_pancake.emote("scream")
+				future_pancake.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 				future_pancake.Paralyze(100)
 			else //for simple_animals & borgs
 				future_pancake.adjustBruteLoss(DOOR_CRUSH_DAMAGE)

--- a/code/game/machinery/harvester.dm
+++ b/code/game/machinery/harvester.dm
@@ -123,7 +123,7 @@
 	var/turf/target = get_step(src, output_dir)
 	for(var/obj/item/bodypart/limb_to_remove as anything in operation_order) //first we do non-essential limbs
 		limb_to_remove.drop_limb()
-		carbon_occupant.emote("scream")
+		carbon_occupant.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 		if(limb_to_remove.body_zone != "chest")
 			limb_to_remove.forceMove(target)    //Move the limbs right next to it, except chest, that's a weird one
 			limb_to_remove.drop_organs()

--- a/code/game/machinery/photobooth.dm
+++ b/code/game/machinery/photobooth.dm
@@ -135,7 +135,7 @@
 				carbon_occupant.flash_act(5)
 			sleep(0.2 SECONDS)
 		if(carbon_occupant)
-			carbon_occupant.emote("scream")
+			carbon_occupant.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 		finish_taking_pictures()
 		return
 	if(!do_after(occupant, 2 SECONDS, src, timed_action_flags = IGNORE_HELD_ITEM)) //gives them time to put their hand items away.

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -498,7 +498,7 @@
 				mob_occupant.adjustFireLoss(rand(10, 16))
 			if(iscarbon(mob_occupant) && mob_occupant.stat < UNCONSCIOUS)
 				//Awake, organic and screaming
-				mob_occupant.emote("scream")
+				mob_occupant.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 		addtimer(CALLBACK(src, PROC_REF(cook)), 5 SECONDS)
 	else
 		uv_cycles = initial(uv_cycles)

--- a/code/game/machinery/transformer.dm
+++ b/code/game/machinery/transformer.dm
@@ -93,7 +93,7 @@
 	update_appearance()
 
 	playsound(src.loc, 'sound/items/tools/welder.ogg', 50, TRUE)
-	victim.emote("scream") // It is painful
+	victim.painful_scream() // DOPPLER EDIT: check for painkilling before screaming // It is painful
 	victim.adjustBruteLoss(max(0, 80 - victim.getBruteLoss())) // Hurt the human, don't try to kill them though.
 
 	// Sleep for a couple of ticks to allow the human to see the pain

--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -515,7 +515,7 @@
 		var/mob/living/M = H.pulledby
 		if(M.electrocute_act(dmg, H))
 			M.visible_message(span_danger("[M] is electrocuted by [M.p_their()] contact with [H]!"))
-			M.emote("scream")
+			M.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 
 /obj/item/shockpaddles/proc/do_disarm(mob/living/M, mob/living/user)
 	if(!DEFIB_CAN_HURT(src))
@@ -561,7 +561,7 @@
 			user.visible_message(span_bolddanger("<i>[user] shocks [H] with \the [src]!"), span_warning("You shock [H] with \the [src]!"))
 			playsound(src, 'sound/machines/defib/defib_zap.ogg', 100, TRUE, -1)
 			playsound(src, 'sound/items/weapons/egloves.ogg', 100, TRUE, -1)
-			H.emote("scream")
+			H.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 			shock_pulling(45, H)
 			if(H.can_heartattack() && !H.undergoing_cardiac_arrest())
 				if(!H.stat)

--- a/code/game/objects/items/devices/reverse_bear_trap.dm
+++ b/code/game/objects/items/devices/reverse_bear_trap.dm
@@ -125,7 +125,7 @@
 	else
 		var/mob/living/carbon/human/jill = loc
 		jill.visible_message(span_boldwarning("[src] goes off in [jill]'s mouth, ripping [jill.p_their()] head apart!"), span_userdanger("[src] goes off!"))
-		jill.emote("scream")
+		jill.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 		playsound(src, 'sound/effects/snap.ogg', 75, TRUE, frequency = 0.5)
 		playsound(src, 'sound/effects/splat.ogg', 50, TRUE, frequency = 0.5)
 		jill.apply_damage(9999, BRUTE, BODY_ZONE_HEAD)

--- a/code/game/objects/items/hand_items.dm
+++ b/code/game/objects/items/hand_items.dm
@@ -182,7 +182,7 @@
 		damage += rand(3,7)
 
 	if(damage >= 5)
-		target.emote("scream")
+		target.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 
 	log_combat(user, target, "given a noogie to", addition = "([damage] brute before armor)")
 	target.apply_damage(damage, BRUTE, BODY_ZONE_HEAD)

--- a/code/game/objects/items/his_grace.dm
+++ b/code/game/objects/items/his_grace.dm
@@ -107,7 +107,7 @@
 			if(HIS_GRACE_CONSUME_OWNER to HIS_GRACE_FALL_ASLEEP)
 				master.visible_message(span_boldwarning("[src] turns on [master]!"), "<span class='his_grace big bold'>[src] turns on you!</span>")
 				do_attack_animation(master, null, src)
-				master.emote("scream")
+				master.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 				master.remove_status_effect(/datum/status_effect/his_grace)
 				REMOVE_TRAIT(src, TRAIT_NODROP, HIS_GRACE_TRAIT)
 				master.Paralyze(60)

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -708,7 +708,7 @@
 		patient.visible_message(span_suicide("[patient] screws up like an idiot and still dies anyway!"))
 		return BRUTELOSS
 
-	patient.emote("scream")
+	patient.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 	for(var/obj/item/bodypart/bone as anything in patient.bodyparts)
 		// fine to just, use these raw, its a meme anyway
 		var/datum/wound/blunt/bone/severe/oof_ouch = new

--- a/code/game/objects/structures/guillotine.dm
+++ b/code/game/objects/structures/guillotine.dm
@@ -175,7 +175,7 @@
 			else
 				victim.apply_damage(15 * blade_sharpness, BRUTE, head, attacking_item = src)
 				log_combat(user, victim, "dropped the blade on", src, " non-fatally")
-				victim.emote("scream")
+				victim.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 
 			if (blade_sharpness > 1)
 				blade_sharpness -= 1

--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -117,7 +117,7 @@
 
 /obj/structure/kitchenspike/post_buckle_mob(mob/living/target)
 	playsound(src.loc, 'sound/effects/splat.ogg', 25, TRUE)
-	target.emote("scream")
+	target.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 	target.add_splatter_floor()
 	target.adjustBruteLoss(30)
 	target.setDir(2)

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -472,7 +472,7 @@ GLOBAL_LIST_EMPTY(crematoriums)
 			if(M.incorporeal_move) //can't cook revenants!
 				continue
 			if (M.stat != DEAD)
-				M.emote("scream")
+				M.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 			if(user)
 				log_combat(user, M, "cremated")
 			else

--- a/code/game/objects/structures/water_structures/urinal.dm
+++ b/code/game/objects/structures/water_structures/urinal.dm
@@ -36,7 +36,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/urinal, 32)
 				return
 			user.changeNext_move(CLICK_CD_MELEE)
 			user.visible_message(span_danger("[user] slams [grabbed_mob] into [src]!"), span_danger("You slam [grabbed_mob] into [src]!"))
-			grabbed_mob.emote("scream")
+			grabbed_mob.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 			grabbed_mob.adjustBruteLoss(8)
 		else
 			to_chat(user, span_warning("You need a tighter grip!"))

--- a/code/game/turfs/open/lava.dm
+++ b/code/game/turfs/open/lava.dm
@@ -434,7 +434,7 @@
 
 	if(length(transform_parts))
 		var/obj/item/bodypart/burn_limb = pick_n_take(transform_parts)
-		burn_human.emote("scream")
+		burn_human.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 		var/obj/item/bodypart/plasmalimb
 		switch(burn_limb.body_zone) //get plasmaman limb to swap in
 			if(BODY_ZONE_L_ARM)
@@ -452,7 +452,7 @@
 
 		burn_human.del_and_replace_bodypart(plasmalimb, special = TRUE)
 		burn_human.update_body_parts()
-		burn_human.emote("scream")
+		burn_human.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 		burn_human.visible_message(span_warning("[burn_human]'s [burn_limb.plaintext_zone] melts down to the bone!"), \
 			span_userdanger("You scream out in pain as your [burn_limb.plaintext_zone] melts down to the bone, held together only by strands of purple fungus!"))
 

--- a/code/modules/antagonists/blob/blobstrains/blazing_oil.dm
+++ b/code/modules/antagonists/blob/blobstrains/blazing_oil.dm
@@ -39,4 +39,4 @@
 	if(exposed_mob)
 		exposed_mob.apply_damage(0.8*reac_volume, BURN, wound_bonus=CANT_WOUND)
 	if(iscarbon(exposed_mob))
-		exposed_mob.emote("scream")
+		exposed_mob.painful_scream() // DOPPLER EDIT: check for painkilling before screaming

--- a/code/modules/antagonists/changeling/powers/defib_grasp.dm
+++ b/code/modules/antagonists/changeling/powers/defib_grasp.dm
@@ -37,7 +37,7 @@
 	changeling.buckled?.unbuckle_mob(changeling) // get us off of stasis beds please
 	changeling.set_resting(FALSE)
 	changeling.adjust_jitter(20 SECONDS)
-	changeling.emote("scream")
+	changeling.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 	playsound(changeling, 'sound/effects/magic/demon_consume.ogg', 50, TRUE)
 
 	// Mimics some real defib stuff (wish this was more generalized)
@@ -72,7 +72,7 @@
 				defibber.adjust_dizzy(1 MINUTES)
 				defibber.adjust_stutter(1 MINUTES)
 				defibber.adjust_eye_blur(10 SECONDS)
-				defibber.emote("scream")
+				defibber.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 
 				changeling.visible_message(
 					span_bolddanger("[changeling] awakens suddenly, snatching [defib] out of [defibber]'s hands while ripping off [removed_arms >= 2 ? "" : "one of "][defibber.p_their()] arms!"),

--- a/code/modules/antagonists/changeling/powers/fakedeath.dm
+++ b/code/modules/antagonists/changeling/powers/fakedeath.dm
@@ -114,7 +114,7 @@
 		span_userdanger("Your limbs regrow, making a loud, crunchy sound and giving you great pain!"),
 		span_hear("You hear organic matter ripping and tearing!"),
 	)
-	user.emote("scream")
+	user.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 	// Manually call this (outside of revive/fullheal) so we can pass our blacklist
 	user.regenerate_limbs(dont_regenerate)
 

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -77,7 +77,7 @@
 		limb_regen = user.regenerate_limb(BODY_ZONE_L_ARM, 1)
 	if(limb_regen)
 		user.visible_message(span_warning("[user]'s missing arm reforms, making a loud, grotesque sound!"), span_userdanger("Your arm regrows, making a loud, crunchy sound and giving you great pain!"), span_hear("You hear organic matter ripping and tearing!"))
-		user.emote("scream")
+		user.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 	var/obj/item/W = new weapon_type(user, silent)
 	user.put_in_hands(W)
 	if(!silent)

--- a/code/modules/antagonists/changeling/powers/regenerate.dm
+++ b/code/modules/antagonists/changeling/powers/regenerate.dm
@@ -25,6 +25,6 @@
 			span_userdanger("Your limbs regrow, making a loud, crunchy sound and giving you great pain!"),
 			span_hear("You hear organic matter ripping and tearing!"),
 		)
-		carbon_user.emote("scream")
+		carbon_user.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 
 	return TRUE

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -1395,7 +1395,7 @@ Striking a noncultist, however, will tear their flesh."}
 						L.Paralyze(20)
 						L.adjustBruteLoss(45)
 						playsound(L, 'sound/effects/hallucinations/wail.ogg', 50, TRUE)
-						L.emote("scream")
+						L.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 		user.Beam(temp_target, icon_state="blood_beam", time = 7, beam_type = /obj/effect/ebeam/blood)
 
 

--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
@@ -455,7 +455,7 @@
 	sac_target.set_jitter_if_lower(20 SECONDS)
 	sac_target.set_dizzy_if_lower(20 SECONDS)
 	sac_target.adjust_hallucinations(24 SECONDS)
-	sac_target.emote("scream")
+	sac_target.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 
 	to_chat(sac_target, span_reallybig(span_hypnophrase("The grasp of the Mansus reveal themselves to you!")))
 	to_chat(sac_target, span_hypnophrase("You feel invigorated! Fight to survive!"))

--- a/code/modules/antagonists/heretic/knowledge/starting_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/starting_lore.dm
@@ -361,7 +361,7 @@ GLOBAL_LIST_INIT(heretic_start_knowledge, initialize_starting_knowledge())
 	user.AdjustParalyzed(reward * 1 SECONDS)
 	user.playsound_local(get_turf(user), 'sound/music/antag/heretic/heretic_gain_intense.ogg', 100, FALSE, pressure_affected = FALSE, use_reverb = FALSE)
 	for(var/i in 1 to reward)
-		user.emote("scream")
+		user.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 		playsound(loc, 'sound/items/eatfood.ogg', 100, TRUE)
 		heretic_datum.knowledge_points++
 		to_chat(user, span_danger("You feel something invisible tearing away at your very essence!"))

--- a/code/modules/antagonists/heretic/magic/flesh_surgery.dm
+++ b/code/modules/antagonists/heretic/magic/flesh_surgery.dm
@@ -208,7 +208,7 @@
 	playsound(victim, 'sound/effects/dismember.ogg', 50, TRUE)
 	if(carbon_victim.stat == CONSCIOUS)
 		carbon_victim.adjust_timed_status_effect(15 SECONDS, /datum/status_effect/speech/slurring/heretic)
-		carbon_victim.emote("scream")
+		carbon_victim.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 
 	// We need to wait for the spell to actually finish casting to put the organ in their hands, hence, 1 ms timer.
 	addtimer(CALLBACK(caster, TYPE_PROC_REF(/mob, put_in_hands), picked_organ), 0.1 SECONDS)

--- a/code/modules/antagonists/heretic/magic/mansus_grasp.dm
+++ b/code/modules/antagonists/heretic/magic/mansus_grasp.dm
@@ -130,7 +130,7 @@
 			carbon_user.adjustFireLoss(20)
 			playsound(carbon_user, 'sound/effects/wounds/sizzle1.ogg', 70, vary = TRUE)
 			if(prob(50))
-				carbon_user.emote("scream")
+				carbon_user.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 				carbon_user.adjust_stutter(26 SECONDS)
 
 		source.cast_on_hand_hit(src, user, user)

--- a/code/modules/antagonists/voidwalker/voidwalker_abilities.dm
+++ b/code/modules/antagonists/voidwalker/voidwalker_abilities.dm
@@ -50,7 +50,7 @@
 	target.Paralyze(stun_time)
 	target.adjustStaminaLoss(stamina_damage)
 	target.apply_status_effect(/datum/status_effect/speech/slurring/generic)
-	target.emote("scream")
+	target.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 
 	new /obj/effect/temp_visual/circle_wave/unsettle(get_turf(owner))
 	new /obj/effect/temp_visual/circle_wave/unsettle(get_turf(target))

--- a/code/modules/antagonists/wizard/equipment/soulstone.dm
+++ b/code/modules/antagonists/wizard/equipment/soulstone.dm
@@ -160,7 +160,7 @@
 /obj/item/soulstone/proc/hot_potato(mob/living/user)
 	to_chat(user, span_userdanger("Holy magics residing in [src] burn your hand!"))
 	user.apply_damage(10, BURN, user.get_active_hand())
-	user.emote("scream")
+	user.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 	user.update_damage_overlays()
 	user.dropItemToGround(src)
 

--- a/code/modules/clothing/head/perceptomatrix.dm
+++ b/code/modules/clothing/head/perceptomatrix.dm
@@ -239,7 +239,7 @@
 		return
 
 	to_chat(cast_on, span_warning("Your brain feels like it's on fire!"))
-	cast_on.emote("scream")
+	cast_on.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 	cast_on.set_eye_blur_if_lower(eye_blur_duration)
 	cast_on.adjust_staggered(stagger_duration)
 	cast_on.apply_status_effect(/datum/status_effect/hallucination, hallucination_duration, \

--- a/code/modules/clothing/neck/_neck.dm
+++ b/code/modules/clothing/neck/_neck.dm
@@ -297,7 +297,7 @@
 				else
 					if(appendix.damage > 10 && carbon_patient.stat == CONSCIOUS)
 						render_list += "<span class='danger ml-1'>[target] screams when you lift your hand from [target.p_their()] appendix!</span>\n"//scream if their appendix is damaged and they're awake
-						target.emote("scream")
+						target.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 						appendix_okay = FALSE
 
 				if(liver_okay && appendix_okay)//if they have all their organs and have no detectable damage

--- a/code/modules/clothing/shoes/_shoes.dm
+++ b/code/modules/clothing/shoes/_shoes.dm
@@ -202,7 +202,7 @@
 		else // if one of us moved
 			user.visible_message(span_danger("[our_guy] stamps on [user]'s hand, mid-shoelace [tied ? "knotting" : "untying"]!"), span_userdanger("Ow! [our_guy] stamps on your hand!"), list(our_guy))
 			to_chat(our_guy, span_userdanger("You stamp on [user]'s hand! What the- [user.p_they()] [user.p_were()] [tied ? "knotting" : "untying"] your shoelaces!"))
-			user.emote("scream")
+			user.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 			user.apply_damage(10, BRUTE, user.get_active_hand(), wound_bonus = CANT_WOUND)
 			user.apply_damage(40, STAMINA)
 			user.Paralyze(1 SECONDS)

--- a/code/modules/events/aurora_caelus.dm
+++ b/code/modules/events/aurora_caelus.dm
@@ -51,7 +51,7 @@
 				human_blacklist += seymour
 				if(seymour.mind && istype(seymour.mind.assigned_role, /datum/job/cook))
 					seymour.say("My roast is ruined!!!", forced = "ruined roast")
-					seymour.emote("scream")
+					seymour.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 
 /datum/round_event/aurora_caelus/tick()
 	if(activeFor % 8 != 0)

--- a/code/modules/experisci/handheld_scanner.dm
+++ b/code/modules/experisci/handheld_scanner.dm
@@ -39,7 +39,7 @@
 
 	playsound(src, 'sound/effects/pope_entry.ogg', 60, TRUE)
 	playsound(src, 'sound/machines/destructive_scanner/ScanDangerous.ogg', 40)
-	user.emote("scream")
+	user.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 
 	addtimer(CALLBACK(src, PROC_REF(make_meat_toilet), user), 5 SECONDS)
 	return MANUAL_SUICIDE

--- a/code/modules/fishing/fish/types/rift.dm
+++ b/code/modules/fishing/fish/types/rift.dm
@@ -316,7 +316,7 @@
 	playsound(user, 'sound/effects/cartoon_sfx/cartoon_pop.ogg', 50, TRUE)
 	user.visible_message("[user]'s [eyes ? eyes : "eye holes"] suddenly sprout stalks and turn into [new_eyes]!")
 	ASYNC
-		user.emote("scream")
+		user.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 		eyes.throw_at(get_edge_target_turf(user, pick(GLOB.alldirs)), rand(1, 10), rand(1, 10))
 		sleep(5 SECONDS)
 		if(!QDELETED(eyes))

--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -174,7 +174,7 @@
 			fallen_mob.apply_damage(25 * levels, BRUTE, sharpness = SHARP_POINTY)
 			if(iscarbon(fallen_mob))
 				var/mob/living/carbon/fallen_carbon = fallen_mob
-				fallen_carbon.emote("scream")
+				fallen_carbon.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 				fallen_carbon.bleed(30)
 	. |= FALL_INTERCEPTED | FALL_NO_MESSAGE
 

--- a/code/modules/library/skill_learning/generic_skillchips/acrobatics.dm
+++ b/code/modules/library/skill_learning/generic_skillchips/acrobatics.dm
@@ -113,7 +113,7 @@
 					span_userdanger("Your head hurts so much, it feels like it's on fire!"),
 				)
 				ASYNC
-					bozo.emote("scream")
+					bozo.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 				if(particle_effect?.type == particle_path)
 					return
 				particle_path = /particles/smoke/steam/bad

--- a/code/modules/mapfluff/ruins/spaceruin_code/garbagetruck.dm
+++ b/code/modules/mapfluff/ruins/spaceruin_code/garbagetruck.dm
@@ -52,7 +52,7 @@
 		span_hear("You hear a sickening sound of metal piercing flesh!")
 	)
 	eyeballies.apply_organ_damage(eyeballies.maxHealth)
-	target.emote("scream")
+	target.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 	playsound(target, 'sound/effects/wounds/crackandbleed.ogg', 100)
 	log_combat(user, target, "cracked the skull of (eye snatching)", src)
 
@@ -76,7 +76,7 @@
 		source = target,
 		header = "Ouch!",
 	)
-	target.emote("scream")
+	target.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 	if(prob(20))
 		target.emote("cry")
 	used = TRUE

--- a/code/modules/mining/lavaland/tendril_loot.dm
+++ b/code/modules/mining/lavaland/tendril_loot.dm
@@ -556,7 +556,7 @@
 	wings.Insert(exposed_human)
 	playsound(exposed_human.loc, 'sound/items/poster/poster_ripped.ogg', 50, TRUE, -1)
 	exposed_human.apply_damage(20, def_zone = BODY_ZONE_CHEST, forced = TRUE, wound_bonus = CANT_WOUND)
-	exposed_human.emote("scream")
+	exposed_human.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 
 /datum/reagent/flightpotion/proc/get_wing_choice(mob/needs_wings, obj/item/bodypart/chest/chest)
 	var/list/wing_types = chest.wing_types.Copy()
@@ -861,7 +861,7 @@
 
 /obj/item/clothing/glasses/godeye/proc/pain(mob/living/victim)
 	to_chat(victim, span_userdanger("You experience blinding pain, as [src] burrows into your skull."))
-	victim.emote("scream")
+	victim.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 	victim.flash_act()
 
 /datum/action/cooldown/spell/pointed/scan

--- a/code/modules/mob/living/basic/ruin_defender/flesh.dm
+++ b/code/modules/mob/living/basic/ruin_defender/flesh.dm
@@ -130,7 +130,7 @@
 	var/target_zone = pick(zone_candidates)
 	var/obj/item/bodypart/target_part = target.get_bodypart(target_zone)
 	if(isnull(target_part))
-		target.emote("scream") // dismember already makes them scream so only do this if we aren't doing that
+		target.painful_scream() // DOPPLER EDIT: check for painkilling before screaming // dismember already makes them scream so only do this if we aren't doing that
 	else
 		target_part.dismember()
 

--- a/code/modules/mob/living/carbon/alien/organs.dm
+++ b/code/modules/mob/living/carbon/alien/organs.dm
@@ -120,7 +120,7 @@
 
 	else if(ishuman(owner)) //Humans, being more fragile, are more overwhelmed by the mental backlash.
 		to_chat(owner, span_danger("You feel a splitting pain in your head, and are struck with a wave of nausea. You cannot hear the hivemind anymore!"))
-		owner.emote("scream")
+		owner.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 		owner.Paralyze(100)
 
 	owner.adjust_jitter(1 MINUTES)

--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -404,7 +404,7 @@
 	wearer.apply_damage(5 / severity, BURN, spread_damage=TRUE)
 	to_chat(wearer, span_danger("You feel [src] heat up from the EMP, burning you slightly."))
 	if(wearer.stat < UNCONSCIOUS && prob(10))
-		wearer.emote("scream")
+		wearer.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 
 /obj/item/mod/control/on_outfit_equip(mob/living/carbon/human/outfit_wearer, visuals_only, item_slot)
 	. = ..()

--- a/code/modules/mod/modules/modules_maint.dm
+++ b/code/modules/mod/modules/modules_maint.dm
@@ -81,7 +81,7 @@
 	if(!mod.wearer) //while there is a guaranteed user when on_wearer_exposed() fires, that isn't the same case for this proc
 		return
 	mod.wearer.visible_message("[src] inside [mod.wearer]'s [mod.name] snaps shut, mutilating the user inside!", span_userdanger("*SNAP*"))
-	mod.wearer.emote("scream")
+	mod.wearer.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 	playsound(mod.wearer, 'sound/effects/snap.ogg', 75, TRUE, frequency = 0.5)
 	playsound(mod.wearer, 'sound/effects/splat.ogg', 50, TRUE, frequency = 0.5)
 	mod.wearer.client?.give_award(/datum/award/achievement/misc/springlock, mod.wearer)

--- a/code/modules/paperwork/paperplane.dm
+++ b/code/modules/paperwork/paperplane.dm
@@ -107,7 +107,7 @@
 	hit_human.adjust_eye_blur(12 SECONDS)
 	eyes?.apply_organ_damage(rand(6, 8))
 	hit_human.Paralyze(4 SECONDS)
-	hit_human.emote("scream")
+	hit_human.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 
 /obj/item/paperplane/throw_at(atom/target, range, speed, mob/thrower, spin=FALSE, diagonals_first = FALSE, datum/callback/callback, gentle, quickstart = TRUE)
 	return ..(target, range, speed, thrower, FALSE, diagonals_first, callback, quickstart = quickstart)

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -308,7 +308,7 @@
 		return ..()
 	if(process_fire(user, user, FALSE, null, BODY_ZONE_HEAD))
 		user.visible_message(span_warning("[user] somehow manages to shoot [user.p_them()]self in the face!"), span_userdanger("You somehow shoot yourself in the face! How the hell?!"))
-		user.emote("scream")
+		user.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 		user.drop_all_held_items()
 		user.Paralyze(80)
 

--- a/code/modules/projectiles/projectile/energy/stun.dm
+++ b/code/modules/projectiles/projectile/energy/stun.dm
@@ -175,7 +175,7 @@
 		owner.add_mood_event("tased", /datum/mood_event/tased)
 		owner.add_movespeed_modifier(/datum/movespeed_modifier/being_tased)
 		if(!HAS_TRAIT(owner, TRAIT_ANALGESIA))
-			owner.emote("scream")
+			owner.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 		if(HAS_TRAIT(owner, TRAIT_HULK))
 			owner.say(pick(
 				";RAAAAAAAARGH!",

--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -601,7 +601,7 @@
 		affected_mob.remove_traits(subject_traits, type)
 		to_chat(affected_mob, span_danger("You feel something rupturing inside your chest!"))
 		if(!HAS_TRAIT(affected_mob, TRAIT_ANALGESIA))
-			affected_mob.emote("scream")
+			affected_mob.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 		affected_mob.set_heartattack(TRUE)
 		volume = 0
 	if(need_mob_update)

--- a/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
@@ -261,14 +261,14 @@
 				eyes.Remove(drinker)
 				eyes.forceMove(get_turf(drinker))
 				to_chat(drinker, span_userdanger("You double over in pain as you feel your eyeballs liquify in your head!"))
-				drinker.emote("scream")
+				drinker.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 				if(drinker.adjustBruteLoss(15 * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype))
 					. = UPDATE_MOB_HEALTH
 			else
 				to_chat(drinker, span_userdanger("You scream in terror as you go blind!"))
 				if(eyes.apply_organ_damage(eyes.maxHealth))
 					. = UPDATE_MOB_HEALTH
-				drinker.emote("scream")
+				drinker.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 
 	if(SPT_PROB(1.5, seconds_per_tick) && iscarbon(drinker))
 		drinker.visible_message(span_danger("[drinker] starts having a seizure!"), span_userdanger("You have a seizure!"))
@@ -2106,7 +2106,7 @@
 		. = UPDATE_MOB_HEALTH
 		// Random chance of causing a screm if we did some damage
 		if(SPT_PROB(2, seconds_per_tick))
-			drinker.emote("scream")
+			drinker.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 
 /datum/reagent/consumable/ethanol/applejack
 	name = "Applejack"

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -191,7 +191,7 @@
 		exposed_mob.visible_message(span_warning("The boiling oil sizzles as it covers [exposed_mob]!"), \
 		span_userdanger("You're covered in boiling oil!"))
 		if(FryLoss)
-			exposed_mob.emote("scream")
+			exposed_mob.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 		playsound(exposed_mob, 'sound/machines/fryer/deep_fryer_emerge.ogg', 25, TRUE)
 		ADD_TRAIT(exposed_mob, TRAIT_OIL_FRIED, "cooking_oil_react")
 		addtimer(CALLBACK(exposed_mob, TYPE_PROC_REF(/mob/living, unfry_mob)), 0.3 SECONDS)
@@ -443,7 +443,7 @@
 		//actually handle the pepperspray effects
 		if (!victim.is_pepper_proof()) // you need both eye and mouth protection
 			if(prob(5))
-				victim.emote("scream")
+				victim.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 			victim.emote("cry")
 			victim.set_eye_blur_if_lower(10 SECONDS)
 			victim.adjust_temp_blindness(6 SECONDS)

--- a/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
@@ -905,7 +905,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 /datum/reagent/inverse/ammoniated_mercury/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
 	if(SPT_PROB(7.5, seconds_per_tick))
-		affected_mob.emote("scream")
+		affected_mob.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 		affected_mob.say(pick("AAAAAAAHHHHH!!","OOOOH NOOOOOO!!","GGGUUUUHHHHH!!","AIIIIIEEEEEE!!","HAHAHAHAHAAAAAA!!","OORRRGGGHHH!!","AAAAAAAJJJJJJJJJ!!"), forced = type)
 
 /datum/reagent/inverse/rezadone

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -462,7 +462,7 @@
 					"All that power, and you still fail?", "If you cannot scour this poison, I shall scour your meager life!")]."))
 		else if(HAS_TRAIT(affected_mob, TRAIT_EVIL) && SPT_PROB(25, seconds_per_tick)) //Congratulations, your committment to evil has now made holy water a deadly poison to you!
 			if(!IS_CULTIST(affected_mob) || affected_mob.mind?.holy_role != HOLY_ROLE_PRIEST)
-				affected_mob.emote("scream")
+				affected_mob.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 				need_mob_update += affected_mob.adjustFireLoss(3 * REM * seconds_per_tick, updating_health = FALSE)
 
 	if(data["deciseconds_metabolized"] >= (1 MINUTES)) // 24 units
@@ -2966,7 +2966,7 @@
 		else
 			victim.say(pick(ant_screams), forced = type)
 	if(SPT_PROB(15, seconds_per_tick))
-		victim.emote("scream")
+		victim.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 	if(SPT_PROB(2, seconds_per_tick)) // Stuns, but purges ants.
 		victim.vomit(VOMIT_CATEGORY_DEFAULT, lost_nutrition = rand(5,10), purge_ratio = 1)
 

--- a/code/modules/religion/burdened/psyker.dm
+++ b/code/modules/religion/burdened/psyker.dm
@@ -293,7 +293,7 @@
 		to_chat(owner, span_warning("The spell had no effect!"))
 		return FALSE
 	to_chat(cast_on, span_userdanger("Your mind gets twisted!"))
-	cast_on.emote("scream")
+	cast_on.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 	cast_on.apply_status_effect(/datum/status_effect/psychic_projection, projection_duration)
 	return TRUE
 

--- a/code/modules/religion/sparring/sparring_datum.dm
+++ b/code/modules/religion/sparring/sparring_datum.dm
@@ -216,7 +216,7 @@
 				to_chat(interfering, span_warning("[GLOB.deity] brands your flesh for interfering with [chaplain]'s sparring match!!"))
 				var/obj/item/bodypart/branded_limb = pick(branded.bodyparts)
 				branded_limb.force_wound_upwards(/datum/wound/burn/flesh/severe/brand, wound_source = "divine intervention")
-				branded.emote("scream")
+				branded.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 
 	flubs--
 	if(!flubs) //too many interferences

--- a/code/modules/spells/spell_types/jaunt/bloodcrawl.dm
+++ b/code/modules/spells/spell_types/jaunt/bloodcrawl.dm
@@ -198,7 +198,7 @@
 		return FALSE
 
 	victim.forceMove(jaunter)
-	victim.emote("scream")
+	victim.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 	jaunt_turf.visible_message(
 		span_boldwarning("[jaunter] drags [victim] into [blood]!"),
 		blind_message = span_notice("You hear a splash."),

--- a/code/modules/spells/spell_types/touch/scream_for_me.dm
+++ b/code/modules/spells/spell_types/touch/scream_for_me.dm
@@ -27,7 +27,7 @@
 	if(!ishuman(victim))
 		return
 	var/mob/living/carbon/human/human_victim = victim
-	human_victim.emote("scream")
+	human_victim.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 	for(var/obj/item/bodypart/to_wound as anything in human_victim.bodyparts)
 		human_victim.cause_wound_of_type_and_severity(WOUND_SLASH, to_wound, WOUND_SEVERITY_MODERATE, WOUND_SEVERITY_CRITICAL)
 	return TRUE

--- a/code/modules/surgery/organs/internal/eyes/_eyes.dm
+++ b/code/modules/surgery/organs/internal/eyes/_eyes.dm
@@ -605,7 +605,7 @@
 		apply_organ_damage(20 * severity)
 		to_chat(owner, span_warning("Your eyes start to fizzle in their sockets!"))
 		do_sparks(2, TRUE, owner)
-		owner.emote("scream")
+		owner.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 
 /obj/item/organ/eyes/robotic/xray
 	name = "x-ray eyes"

--- a/code/modules/surgery/organs/internal/heart/heart_anomalock.dm
+++ b/code/modules/surgery/organs/internal/heart/heart_anomalock.dm
@@ -67,7 +67,7 @@
 	user.temporarilyRemoveItemFromInventory(src, TRUE)
 	Insert(user)
 	user.apply_damage(100, BRUTE, BODY_ZONE_CHEST)
-	user.emote("scream")
+	user.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 	return TRUE
 
 /obj/item/organ/heart/cybernetic/anomalock/proc/on_emp_act(severity)

--- a/code/modules/surgery/organs/internal/liver/_liver.dm
+++ b/code/modules/surgery/organs/internal/liver/_liver.dm
@@ -152,12 +152,12 @@
 		if(4)
 			to_chat(owner, span_userdanger("Overwhelming pain knocks you out!"))
 			owner.vomit(VOMIT_CATEGORY_BLOOD, distance = rand(1,2))
-			owner.emote("Scream")
+			owner.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 			owner.AdjustUnconscious(2.5 SECONDS)
 		if(5)
 			to_chat(owner, span_userdanger("You feel as if your guts are about to melt!"))
 			owner.vomit(VOMIT_CATEGORY_BLOOD, distance = rand(1,3))
-			owner.emote("Scream")
+			owner.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 			owner.AdjustUnconscious(5 SECONDS)
 
 	switch(failure_time)

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -325,7 +325,7 @@
 				return
 			to_chat(target, span_userdanger(pain_message))
 			if(prob(30) && !mechanical_surgery)
-				target.emote("scream")
+				target.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 
 #undef SURGERY_SPEED_TRAIT_ANALGESIA
 #undef SURGERY_SPEED_DISSECTION_MODIFIER

--- a/code/modules/transport/tram/tram_doors.dm
+++ b/code/modules/transport/tram/tram_doors.dm
@@ -137,7 +137,7 @@
 			future_pancake.visible_message(span_warning("[src] beeps angrily and closes on [future_pancake]!"), span_userdanger("[src] beeps angrily and closes on you!"))
 			SEND_SIGNAL(future_pancake, COMSIG_LIVING_DOORCRUSHED, src)
 			if(ishuman(future_pancake))
-				future_pancake.emote("scream")
+				future_pancake.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 				future_pancake.adjustBruteLoss(DOOR_CRUSH_DAMAGE * 2)
 				future_pancake.Paralyze(2 SECONDS)
 

--- a/code/modules/vehicles/vehicle_actions.dm
+++ b/code/modules/vehicles/vehicle_actions.dm
@@ -388,7 +388,7 @@
 				span_danger("[rider] misses the landing and falls on [rider.p_their()] face!)"),
 				span_userdanger("You smack against the board, hard."),
 			)
-			rider.emote("scream")
+			rider.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 			rider.adjustBruteLoss(10)  // thats gonna leave a mark
 			return
 		rider.visible_message(

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -891,7 +891,7 @@ GLOBAL_LIST_EMPTY(vending_machines_to_restock)
 					living_target.apply_damage(adjusted_damage, damage_type, blocked = blocked, forced = TRUE, attack_direction = crush_dir)
 
 				living_target.Paralyze(paralyze_time)
-				living_target.emote("scream")
+				living_target.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 				playsound(living_target, 'sound/effects/blob/blobattack.ogg', 40, TRUE)
 				playsound(living_target, 'sound/effects/splat.ogg', 50, TRUE)
 				post_crush_living(living_target, was_alive)

--- a/modular_doppler/hearthkin/primitive_production/code/glassblowing.dm
+++ b/modular_doppler/hearthkin/primitive_production/code/glassblowing.dm
@@ -97,7 +97,7 @@
 /obj/item/glassblowing/molten_glass/proc/try_burn_user(mob/living/user)
 	if(!COOLDOWN_FINISHED(src, remaining_heat))
 		to_chat(user, span_warning("You burn your hands trying to pick up [src]!"))
-		user.emote("scream")
+		user.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 		user.dropItemToGround(src)
 		var/obj/item/bodypart/affecting = user.get_active_hand()
 		user.investigate_log("was burned their hand on [src] for [15] at [AREACOORD(user)]", INVESTIGATE_CRAFTING)

--- a/modular_doppler/reagent_forging/code/anvil.dm
+++ b/modular_doppler/reagent_forging/code/anvil.dm
@@ -157,7 +157,7 @@
 		span_userdanger("You are crushed by [src]!")
 	)
 	poor_target.Paralyze(5 SECONDS)
-	poor_target.emote("scream")
+	poor_target.painful_scream() // DOPPLER EDIT: check for painkilling before screaming
 	playsound(poor_target, 'sound/effects/magic/clockwork/fellowship_armory.ogg', 50, TRUE)
 	add_memory_in_range(poor_target, 7, /datum/memory/witness_vendor_crush, protagonist = poor_target, antognist = src)
 	return TRUE

--- a/modular_doppler/scream_b_gone/code/human.dm
+++ b/modular_doppler/scream_b_gone/code/human.dm
@@ -1,0 +1,6 @@
+/mob/living/carbon/human/painful_scream(force = FALSE)
+	if(HAS_TRAIT(src, TRAIT_ANALGESIA) && !force)
+		return
+	if (dna?.species == /datum/species/android) // don't scream if we're a robot, dude...
+		return
+	INVOKE_ASYNC(src, PROC_REF(emote), "scream")

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7299,6 +7299,7 @@
 #include "modular_doppler\research\designs\limbgrower_designs.dm"
 #include "modular_doppler\research\techweb\all_nodes.dm"
 #include "modular_doppler\research\techweb\roundstart_techweb_nodes.dm"
+#include "modular_doppler\scream_b_gone\code\human.dm"
 #include "modular_doppler\ships_r_us\code\buyable_shuttle_template.dm"
 #include "modular_doppler\ships_r_us\code\micro_reactor.dm"
 #include "modular_doppler\ships_r_us\code\order_console.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

A big search and replace commit (intensely not modular) that replaces ```emote("scream")``` with the ```painful_scream()``` proc that apparently exists but was used in one place for one thing only, and a human overload to check for android species beforehand as well.

What does this functionally mean? It means now that if you can't feel pain from any source that gives TRAIT_ANALGESIA (numb quirk, lidocaine, amollin, et al), you should *never* scream in painful circumstances. You also won't scream if you're an android by default, because robots don't really do pain (unless you say yours does, in which case, scream away manually!)

## Why It's Good For The Game

This has been an elephant in the room since forever.

## Changelog

:cl: yooriss
fix: You will no longer scream in most pain-related circumstances if you can't feel pain for whatever reason.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
