### PR TITLE
Undersized Examine and ID code

### DIFF
--- a/modular_doppler/modular_quirks/undersized/held_undersized_examine.dm
+++ b/modular_doppler/modular_quirks/undersized/held_undersized_examine.dm
@@ -1,0 +1,22 @@
+
+// Overrides such that examining a held undersized character shows their proper examine rather than the item examine
+
+/obj/item/clothing/head/mob_holder/get_examine_name(mob/user)
+	if(iscarbon(held_mob))
+		return held_mob.get_examine_name(user)
+	return ..()
+
+/obj/item/clothing/head/mob_holder/get_examine_icon(mob/user)
+	if(iscarbon(held_mob))
+		return held_mob.get_examine_icon(user)
+	return ..()
+
+/obj/item/clothing/head/mob_holder/examine(mob/user)
+	if(iscarbon(held_mob))
+		return held_mob.examine(user)
+	return ..()
+
+/obj/item/clothing/head/mob_holder/examine_more(mob/user)
+	if(iscarbon(held_mob))
+		return held_mob.examine_more(user)
+	return ..()

--- a/modular_doppler/modular_quirks/undersized/held_undersized_id.dm
+++ b/modular_doppler/modular_quirks/undersized/held_undersized_id.dm
@@ -1,0 +1,12 @@
+
+// Overrides such that a held undersized character counts as whatever their ID/access is
+
+/obj/item/clothing/head/mob_holder/GetAccess()
+	if(iscarbon(held_mob))
+		return held_mob.get_access()
+	return ..()
+
+/obj/item/clothing/head/mob_holder/GetID()
+	if(iscarbon(held_mob))
+		return held_mob.get_idcard()
+	return ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7180,6 +7180,8 @@
 #include "modular_doppler\modular_quirks\permitted_cybernetic\code\preferences.dm"
 #include "modular_doppler\modular_quirks\system_shock\system_shock.dm"
 #include "modular_doppler\modular_quirks\undersized\gun.dm"
+#include "modular_doppler\modular_quirks\undersized\held_undersized_examine.dm"
+#include "modular_doppler\modular_quirks\undersized\held_undersized_id.dm"
 #include "modular_doppler\modular_quirks\undersized\held_undersized_specials.dm"
 #include "modular_doppler\modular_quirks\undersized\inhand_holder.dm"
 #include "modular_doppler\modular_quirks\undersized\squashable.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This pr just adds overrides for a list of procs to the mob holder item, forwarding them to the held person's respective procs if it's a carbon so they let you do funny stuff with undersized people.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Being able to examine held undersized people and actually get their examine text is helpful, at least definitely better than the absolutely nothingburger "this is a tiny clothing item :+1:" text you get normally

Holding your pocket Medical Doctor inhand swiping them to open doors is funny
Picking up your nearest tiny coworker to pay for your lunch on a vendor is funny

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: [DOPPLER] Examining undersized people inhand shows you the proper examine for them rather than the holder item examine.
add: [DOPPLER] Undersized people inhand count as whatever ID they're wearing for all intents and purposes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
