### PR TITLE
Exposure To Heavenly Principles: Exploitables/classified records visible via BMS quirk

### DIFF
--- a/code/__DEFINES/~doppler_defines/traits.dm
+++ b/code/__DEFINES/~doppler_defines/traits.dm
@@ -43,7 +43,8 @@
 #define TRAIT_ATYPICAL_TASTER "atypical_taster"
 /// This person is space-acclimated and can "spacer-swim" on zero gravity turfs inside light atmosphere.
 #define TRAIT_SPACER_SWIM "spacer_swim"
-
+/// This person has criminal connections and is able to benefit from whatever those entail (allows viewing of exploitables upon examine)
+#define TRAIT_CRIMINAL_CONNECTIONS "criminal_connections"
 ////
 // Jobs
 ////

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -26,6 +26,8 @@
 	// DOPPLER EDIT BEGIN - flavor text
 	if (dna.features["flavor_short_desc"])
 		. += "[dna.features["flavor_short_desc"]] [get_extended_description_href("\[👁️\]")]"
+	if (HAS_TRAIT(user, TRAIT_CRIMINAL_CONNECTIONS) && dna.features["exploitables"])
+		. += " [get_exploitables_href("\[🗝️\]")]"
 	ADD_NEWLINE_IF_NECESSARY(.)
 	if (dna.features["custom_species_name"])
 		. += "[t_He] [t_is] [prefix_a_or_an(dna.features["custom_species_name"])] <em>[get_species_description_href(dna.features["custom_species_name"])]</em> of [LOWER_TEXT(dna.species.name)] physiology."

--- a/modular_doppler/flavortext_and_records/code/examine.dm
+++ b/modular_doppler/flavortext_and_records/code/examine.dm
@@ -10,6 +10,9 @@
 	// Provides a href link with the `species_info` arg, to be consumed by a Topic override (intended for species/model descriptions)
 	return "<a href='?src=[REF(src)];species_info=1;examine_time=[world.time]'>[input_text]</a>"
 
+/mob/living/proc/get_exploitables_href(input_text)
+	return "<a href='?src=[REF(src)];exploitables=1;examine_time=[world.time]'>[input_text]</a>"
+
 /mob/living/proc/compile_examined_text(short_desc, extended_desc, headshot, ooc_notes)
 	// Compiles the full examined description because I HATE code duplication
 	var/full_examine = span_slightly_larger(separator_hr("<em>[src]</em>"))
@@ -96,6 +99,14 @@
 		to_chat(viewer, boxed_message(span_info(full_examine)))
 		return
 
+	else if (href_list["exploitables"])
+		// show the vulnerable information ENCODED INTO THEIR VERY DNA!!!!
+		var/mob/viewer = usr
+
+		var/the_goss = src.dna.features["exploitables"] ? src.dna.features["exploitables"] : "Your contacts are unaware of anything involving this person."
+
+		to_chat(viewer, boxed_message(span_orange(the_goss)))
+		return
 /*
 	SILICONS (AKA HORRIBLE RUSTBUCKETS)
 */

--- a/modular_doppler/flavortext_and_records/code/records.dm
+++ b/modular_doppler/flavortext_and_records/code/records.dm
@@ -65,6 +65,8 @@
 	maximum_value_length = 4096
 
 /datum/preference/text/exploitable_records/apply_to_human(mob/living/carbon/human/target, value)
+	// lazy lazy LAZY LAZY
+	target.dna.features["exploitables"] = value
 	return
 
 /datum/preference/text/ooc_notes

--- a/modular_doppler/underworld_connections/underworld_connections_quirk.dm
+++ b/modular_doppler/underworld_connections/underworld_connections_quirk.dm
@@ -8,6 +8,7 @@
 	medical_record_text = "Patient records may have been tampered with in the past."
 	quirk_flags = QUIRK_HIDE_FROM_SCAN
 	mail_goodies = list(/obj/item/storage/briefcase/secure)
+	mob_trait = TRAIT_CRIMINAL_CONNECTIONS
 
 /datum/quirk/item_quirk/underworld_connections/add_unique(client/client_source)
 	if (ishuman(quirk_holder))


### PR DESCRIPTION

## About The Pull Request

![](https://puu.sh/KoR4D/f391a7bbbb.png)

Lets BMS quirk-havers see exploitable records since general chat promised me personally with pinky swears that this'll make people fuck each other up more.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: yooriss
add: Exploitables/classified records are now viewable upon examine by individuals with the BMS quirk, if a character has any. They're denoted by a key icon next to the eye one for examining long description.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
