### PR TITLE
Fix and improve job equipment straps.

### DIFF
--- a/modular_doppler/job_straps/code/straps.dm
+++ b/modular_doppler/job_straps/code/straps.dm
@@ -23,21 +23,33 @@
 		/obj/item/tank/internals/plasmaman,
 	)
 
+/obj/item/job_equipment_strap/Initialize(mapload)
+	. = ..()
+	register_item_context()
+
 /obj/item/job_equipment_strap/examine(mob/user)
 	. = ..()
 	. += span_notice("Using this on a <b>suit slot</b> item will add this strap's job items to the things you can wear in it's suit storage.")
 	return .
 
-/obj/item/job_equipment_strap/pre_attack(atom/attacking, mob/living/user, params)
-	if(!istype(attacking, /obj/item/clothing/suit))
-		return ..()
-	var/obj/item/clothing/suit/attacking_suit = attacking
-	attacking_suit.allowed |= things_to_allow
-	if(!do_after(user, 3 SECONDS, user))
-		return FALSE
+/obj/item/job_equipment_strap/add_item_context(obj/item/source, list/context, atom/target, mob/living/user)
+	if(!istype(target, /obj/item/clothing/suit))
+		return NONE
+	context[SCREENTIP_CONTEXT_LMB] = "Attach strap"
+	return CONTEXTUAL_SCREENTIP_SET
+
+/obj/item/job_equipment_strap/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
+	if(!istype(interacting_with, /obj/item/clothing/suit))
+		return NONE
+	if(!do_after(user, 3 SECONDS, target = interacting_with))
+		return ITEM_INTERACT_BLOCKING
+
+	var/obj/item/clothing/suit/targeted_suit = interacting_with
+	targeted_suit.allowed |= things_to_allow
 	playsound(src, 'sound/items/equip/toolbelt_equip.ogg', 50, TRUE)
 	qdel(src)
-	return TRUE
+	return ITEM_INTERACT_SUCCESS
+
 
 // Service
 /obj/item/job_equipment_strap/service


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

So job equipment straps were jank as hell, both prioritizing being put into storage and not even needing to pass the `do_after(...)` to do their job anyway.

Anyhow, this moves it from the ancient `pre_attack(...)` to `interact_with_atom(...)`, fixing the storage slots issue.
We then make it actually wait until the `do_after(...)` is over to apply its benefits, *and* make the `do_after(...)` care about the item we're targeting.
It *also* adds item interaction context, so it shows what it does in the hover tooltips up top.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fix jamnk :+1:

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: [DOPPLER] Job equipment straps can actually be used on suit items with storage slots.
fix: [DOPPLER] Job equipment straps no longer apply the benefits BEFORE the do_after, meaning you can no longer cancel the do_after and keep both the benefits and the strap.
qol: [DOPPLER] Added item interaction context.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
