### PR TITLE
Fluoride stare sucks less

### DIFF
--- a/code/datums/quirks/negative_quirks/fluoride_stare.dm
+++ b/code/datums/quirks/negative_quirks/fluoride_stare.dm
@@ -28,7 +28,7 @@
 
 /datum/quirk/item_quirk/fluoride_stare/add(client/client_source)
 	ADD_TRAIT(quirk_holder, TRAIT_NO_EYELIDS, QUIRK_TRAIT)
-	quirk_holder.AddComponent(/datum/component/manual_blinking, 1, 30 SECONDS, 10 SECONDS, FALSE)
+	quirk_holder.AddComponent(/datum/component/manual_blinking, 0.5, 300 SECONDS, 60 SECONDS, FALSE) // DOPPLER EDIT - half dmg, 30s to 5m inbetween, 10s to 60s grace
 
 /datum/quirk/item_quirk/fluoride_stare/remove()
 	REMOVE_TRAIT(quirk_holder, TRAIT_NO_EYELIDS, QUIRK_TRAIT)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adjusts the blink time from 30 seconds to 5 minutes, grace period after warning from 10 seconds to 1 minute, and halves damage rate for not blinking. 

## Why It's Good For The Game

average tg negative quirk balance. now it's just stupid and annoying and not stupid and utterly debilitating!

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Fluoride stare sucks less
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
