### PR TITLE
Chipped sucks less

### DIFF
--- a/code/datums/quirks/positive_quirks/chipped.dm
+++ b/code/datums/quirks/positive_quirks/chipped.dm
@@ -38,8 +38,8 @@
 	var/mob/living/carbon/quirk_holder_carbon = quirk_holder
 	installed_chip = new installed_chip()
 
-	RegisterSignals(installed_chip, list(COMSIG_QDELETING, COMSIG_SKILLCHIP_REMOVED), PROC_REF(remove_effect))
-	RegisterSignal(installed_chip, COMSIG_SKILLCHIP_IMPLANTED, PROC_REF(apply_effect))
+	//RegisterSignals(installed_chip, list(COMSIG_QDELETING, COMSIG_SKILLCHIP_REMOVED), PROC_REF(remove_effect))
+	//RegisterSignal(installed_chip, COMSIG_SKILLCHIP_IMPLANTED, PROC_REF(apply_effect))
 
 	quirk_holder_carbon.implant_skillchip(installed_chip, force = TRUE)
 	installed_chip.try_activate_skillchip(silent = FALSE, force = TRUE)

--- a/code/datums/quirks/positive_quirks/chipped.dm
+++ b/code/datums/quirks/positive_quirks/chipped.dm
@@ -38,8 +38,8 @@
 	var/mob/living/carbon/quirk_holder_carbon = quirk_holder
 	installed_chip = new installed_chip()
 
-	//RegisterSignals(installed_chip, list(COMSIG_QDELETING, COMSIG_SKILLCHIP_REMOVED), PROC_REF(remove_effect))
-	//RegisterSignal(installed_chip, COMSIG_SKILLCHIP_IMPLANTED, PROC_REF(apply_effect))
+	//DOPPLER REMOVAL: RegisterSignals(installed_chip, list(COMSIG_QDELETING, COMSIG_SKILLCHIP_REMOVED), PROC_REF(remove_effect))
+	//DOPPLER REMOVAL: RegisterSignal(installed_chip, COMSIG_SKILLCHIP_IMPLANTED, PROC_REF(apply_effect))
 
 	quirk_holder_carbon.implant_skillchip(installed_chip, force = TRUE)
 	installed_chip.try_activate_skillchip(silent = FALSE, force = TRUE)

--- a/code/datums/quirks/positive_quirks/chipped.dm
+++ b/code/datums/quirks/positive_quirks/chipped.dm
@@ -44,6 +44,7 @@
 	quirk_holder_carbon.implant_skillchip(installed_chip, force = TRUE)
 	installed_chip.try_activate_skillchip(silent = FALSE, force = TRUE)
 
+/* DOPPLER REMOVAL START: don't apply braindamage status with the quirk
 /datum/quirk/chipped/proc/apply_effect(datum/source, obj/item/brain_applied)
 	SIGNAL_HANDLER
 	var/mob/living/carbon/quirk_holder_carbon = quirk_holder
@@ -56,6 +57,7 @@
 	if(QDELING(source) || brain_removed == quirk_holder_carbon.get_organ_slot(ORGAN_SLOT_BRAIN))
 		quirk_holder.remove_status_effect(itchy_effect)
 		itchy_effect = null
+DOPPLER REMOVAL END */
 
 /datum/quirk/chipped/remove()
 	QDEL_NULL(installed_chip)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Chipped no longer applies its passive brain damage status effect.

If people _really_ miss the brain damage, this can be shifted to instead have a very low brain damage threshold (~10 damage) instead so it still does something but doesn't apply traumas.

## Why It's Good For The Game

negative quirk: get brain damage and get paralyzed and die
positive quirk: get brain damage and get paralyzed and Don't die

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Chipped no longer gives you brain damage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
