### PR TITLE
gives thermal pistols normal dual wield spread

### DIFF
--- a/code/modules/projectiles/guns/energy/crank_guns.dm
+++ b/code/modules/projectiles/guns/energy/crank_guns.dm
@@ -86,7 +86,7 @@
 	ammo_x_offset = 1
 	obj_flags = UNIQUE_RENAME
 	w_class = WEIGHT_CLASS_NORMAL
-	dual_wield_spread = 5 //as intended by the coders
+	//dual_wield_spread = 5 as no longer intended by the coders
 
 /obj/item/gun/energy/laser/thermal/add_bayonet_point()
 	AddComponent(/datum/component/bayonet_attachable, offset_x = 19, offset_y = 13)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Nerfs the thermal pistols by preventing them from having an insane accuracy bonus while dual wielded, making them dramatically less effective at range. Single-wielding is unchanged. Someone let me know if I should also remove the whole recharging thing.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
uh yeah so i log on to doppler for yet another day of moon viewing ceremonys in the 11 am round (my favorite) ((FUCK the 11 pm round)) and surprise surprise, this stupid fucking powergaming detective was ordering thermal pistols roundstart. AGAIN. everyone knows shes a blatant griefer and the fact that admins actually let her get away with this shit is fucking atrocious. who the fuck vouched for this moron. anyways, this detective ("SEVEN" isnt even a name its a NUMBER) comes up to me while im breaking into the vault (its my character gimmick) and just wordlessly pops combat intent, and only waits 3.9 seconds before taking out her stupid valid hunter set (((clear rule break))) and gunning me down. when i ahelped it the clearly biased admins kept telling me that i "opened fire with a 357 revolver first" and that i "wasn't even an antag" (i already told them this is my character gimmick but admins HATE roleplay) and then the admins didnt even do anything. so im nerfing her broken powergaming instead
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Thermal pistols no longer have bonus dual wielding accuracy.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
