### PR TITLE
ports lethalstation's [genemodded] quirk! allows roundstart selection of ONE (only ONE!) genetics mutation

### DIFF
--- a/modular_doppler/genemod_quirk/code/genemod_quirk.dm
+++ b/modular_doppler/genemod_quirk/code/genemod_quirk.dm
@@ -1,0 +1,60 @@
+/datum/quirk/genemodded
+	name = "Genemodded"
+	desc = "Some aspect of your physiology has been modified from your race's ordinary baseline, granting you a mutation of your choice."
+	gain_text = span_notice("Your body feels unusual...")
+	lose_text = span_notice("Normality returns in a flash.")
+	medical_record_text = "Subject has innately modified genetic information."
+	value = 10
+	icon = FA_ICON_FLASK
+	var/datum/mutation/human/added_mutation = NONE
+
+/datum/quirk/genemodded/add_unique(client/client_source)
+	var/mob/living/carbon/human/human_holder = quirk_holder
+	var/desired_mutation = client_source?.prefs.read_preference(/datum/preference/choiced/genemodded_dna)
+
+	if (desired_mutation)
+		added_mutation = GLOB.possible_genemods_for_quirk[desired_mutation]
+		if (!human_holder.dna.activate_mutation(added_mutation))
+			human_holder.dna.add_mutation(added_mutation, MUT_EXTRA)
+
+/datum/quirk/genemodded/remove()
+	if (added_mutation)
+		var/mob/living/carbon/human/human_holder = quirk_holder
+		human_holder.dna.remove_mutation(added_mutation)
+		added_mutation = null
+
+/datum/quirk_constant_data/genemodded
+	associated_typepath = /datum/quirk/genemodded
+	customization_options = list(/datum/preference/choiced/genemodded_dna)
+
+/datum/preference/choiced/genemodded_dna
+	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
+	savefile_key = "genemodded_dna"
+	savefile_identifier = PREFERENCE_CHARACTER
+	can_randomize = FALSE
+
+/proc/generate_genemod_quirk_list()
+	var/list/genemods = list()
+	for (var/datum/mutation/human/mut as anything in subtypesof(/datum/mutation/human))
+		if (!mut.locked)
+			genemods[mut.name] = mut
+
+	return genemods
+
+GLOBAL_LIST_INIT(possible_genemods_for_quirk, generate_genemod_quirk_list())
+
+/datum/preference/choiced/genemodded_dna/init_possible_values()
+	return assoc_to_keys(GLOB.possible_genemods_for_quirk)
+
+/datum/preference/choiced/genemodded_dna/create_default_value()
+	return pick(assoc_to_keys(GLOB.possible_genemods_for_quirk))
+
+/datum/preference/choiced/genemodded_dna/is_accessible(datum/preferences/preferences)
+	if (!..())
+		return FALSE
+
+	return "Genemodded" in preferences.all_quirks
+
+/datum/preference/choiced/genemodded_dna/apply_to_human(mob/living/carbon/human/target, value)
+	return
+

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6769,6 +6769,7 @@
 #include "modular_doppler\food_replicator\code\replicator_designs\replicator_clothing.dm"
 #include "modular_doppler\food_replicator\code\replicator_designs\replicator_food.dm"
 #include "modular_doppler\food_replicator\code\replicator_designs\replicator_medical.dm"
+#include "modular_doppler\genemod_quirk\code\genemod_quirk.dm"
 #include "modular_doppler\gravity_harness\gravity_harness.dm"
 #include "modular_doppler\gravity_harness\supply_packs.dm"
 #include "modular_doppler\hearthkin\primitive_cooking_additions\code\big_mortar.dm"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/doppler/genemodded.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/doppler/genemodded.tsx
@@ -1,0 +1,8 @@
+// THIS IS A DOPPLER SHIFT UI FILE
+import { FeatureChoiced } from '../../base';
+import { FeatureDropdownInput } from '../../dropdowns';
+
+export const genemodded_dna: FeatureChoiced = {
+  name: 'Mutation',
+  component: FeatureDropdownInput,
+};


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

okay so this basically does what it says on the tin. a positive quirk that lets you select ONE genetics mutation (if your species is eligible, sorry robots / plasmamen) to have by default

## Why It's Good For The Game

![image](https://github.com/user-attachments/assets/5539d52e-2425-4056-9e42-f5f5f86aa105) gigantism example for those ppl who want to be EVEN BIGGER at the cost of moving slower than a snailperson

other selectable quirks include, (but are not limited to,):

pressure adaptation! 

epilepsy!

chameleon!

thermal vision!

h.a.r.s.!

and last but not least,

chav!

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: added genemodded quirk
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
