### PR TITLE
Adds some visual-only modules to Entombed

### DIFF
--- a/modular_doppler/modular_quirks/entombed/code/entombed.dm
+++ b/modular_doppler/modular_quirks/entombed/code/entombed.dm
@@ -135,6 +135,7 @@
 				modsuit.icon = modular_icon_files[modsuit.skin]
 				modsuit.worn_icon = modular_worn_files[modsuit.skin]
 	install_racial_features()
+	install_skin_features(modsuit_skin)
 
 	//transfer as many items across from our dropped backslot as we can. do this last incase something breaks
 	if (force_dropped_items)
@@ -174,6 +175,20 @@
 	if (human_holder.get_quirk(/datum/quirk/paraplegic))
 		var/obj/item/mod/module/anomaly_locked/antigrav/entombed/ambulator = new
 		modsuit.install(ambulator, human_holder)
+
+/datum/quirk/equipping/entombed/proc/install_skin_features(modsuit_skin)
+	// adds non-functional visual equivalents of modules to skins that should have them
+	if (!modsuit)
+		return
+
+	var/mob/living/carbon/human/human_holder = quirk_holder
+
+	if (modsuit_skin == "Loader")
+		var/obj/item/mod/module/visual_dummy/hydraulic/loader = new
+		modsuit.install(loader, human_holder)
+	else if (modsuit_skin == "Elite")
+		var/obj/item/mod/module/visual_dummy/armor_booster/elite = new
+		modsuit.install(elite, human_holder)
 
 /datum/quirk_constant_data/entombed
 	associated_typepath = /datum/quirk/equipping/entombed

--- a/modular_doppler/modular_quirks/entombed/code/entombed_mod.dm
+++ b/modular_doppler/modular_quirks/entombed/code/entombed_mod.dm
@@ -155,3 +155,41 @@
 	. = ..()
 	// we do this so that in the rare event that someone gets gibbed/destroyed, their suit can be retrieved easily w/o requiring admin intervention
 	REMOVE_TRAIT(src, TRAIT_NODROP, QUIRK_TRAIT)
+
+// VISUAL MODULES
+// this is a set of integrated dummy modules to allow specific visual variants to have their characteristic equipment sprites
+
+/obj/item/mod/module/visual_dummy
+	name = "MOD dummy module"
+	desc = "You're not quite certain what this is supposed to do."
+	icon = 'icons/obj/clothing/modsuit/mod_modules.dmi'
+	icon_state = "module"
+	removable = FALSE
+	use_mod_colors = TRUE
+
+/obj/item/mod/module/visual_dummy/hydraulic
+	name = "MOD barebones auxiliary arms module"
+	desc = "A pair of questionably useful arms hooked up to central control systems. \
+		They get in the way so often that there's no practical benefit from having them, \
+		so they're most likely just installed for aesthetic purposes."
+	icon_state = "launch_loader"
+	module_type = MODULE_TOGGLE
+	overlay_state_inactive = "module_hydraulic"
+	overlay_state_active = "module_hydraulic_active"
+
+/obj/item/mod/module/visual_dummy/armor_booster
+	name = "MOD plating adjustment module"
+	desc = "A set of retractable external plates around the user's helmet. \
+		While some military suits use tech like this for armor and other combat functionality, \
+		these are just installed for aesthetic purposes."
+	icon_state = "armor_booster"
+	module_type = MODULE_TOGGLE
+	overlay_state_inactive = "module_armorbooster_off"
+	overlay_state_active = "module_armorbooster_on"
+	mask_worn_overlay = TRUE
+
+/obj/item/mod/module/visual_dummy/armor_booster/generate_worn_overlay(mutable_appearance/standing)
+	// mirrored here to allow this to properly apply visual states
+	overlay_state_inactive = "[initial(overlay_state_inactive)]-[mod.skin]"
+	overlay_state_active = "[initial(overlay_state_active)]-[mod.skin]"
+	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The Loader and Elite modsuits have visual designs that rely extremely heavily on their integrated modules. This adds some zero-functionality dummy modules to entombed suits spawning with those skins so they look as good as they're supposed to. You can toggle these like their functional versions, of course. 

![image](https://github.com/user-attachments/assets/0db0f3cd-9636-4968-ba84-ca769561f7eb)

## Why It's Good For The Game

have you SEEN the armless loader suit

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Entombed now has useless modules to make the loader and elite skins look better
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
