### PR TITLE
Actually implements abberant stuff!!!

### DIFF
--- a/code/__DEFINES/~doppler_defines/powers.dm
+++ b/code/__DEFINES/~doppler_defines/powers.dm
@@ -13,3 +13,6 @@ GLOBAL_LIST_INIT(path_core_powers, list(
 	"path_mortal" = /datum/power/tenacious
 ))
 
+// Signal define to be used to trigger resonance suppressing abilities
+#define COSMIG_RESONANCE_SUPRESSED "resonance_suppresion_signal"
+#define COSMIG_RESONANCE_UNSUPRESSED "resonance_unsuppresion_signal"

--- a/code/__DEFINES/~doppler_defines/powers.dm
+++ b/code/__DEFINES/~doppler_defines/powers.dm
@@ -12,3 +12,9 @@ GLOBAL_LIST_INIT(path_core_powers, list(
 	"path_resonant" = /datum/power/meditate,
 	"path_mortal" = /datum/power/tenacious
 ))
+/**
+ * Abberant defines
+ * I guess put abbertant definitions here?
+ */
+
+#define MARTIALART_MONSTERSTRIKE "Monsterous strike"

--- a/code/__DEFINES/~doppler_defines/powers.dm
+++ b/code/__DEFINES/~doppler_defines/powers.dm
@@ -12,9 +12,4 @@ GLOBAL_LIST_INIT(path_core_powers, list(
 	"path_resonant" = /datum/power/meditate,
 	"path_mortal" = /datum/power/tenacious
 ))
-/**
- * Abberant defines
- * I guess put abbertant definitions here?
- */
 
-#define MARTIALART_MONSTERSTRIKE "Monsterous strike"

--- a/code/__DEFINES/~doppler_defines/traits.dm
+++ b/code/__DEFINES/~doppler_defines/traits.dm
@@ -120,3 +120,9 @@
 #define TRAIT_POWER_MONSTERSTRENGTH "power_monsterstrength"
 #define TRAIT_POWER_BLOODSPIKE "power_bloodspike"
 #define TRAIT_POWER_BONESHIELD "power_boneshield"
+#define TRAIT_POWER_CAVITY "power_cavity"
+#define TRAIT_POWER_BIOTACKLER "power_biotackler"
+
+// Resonance supression
+
+#define TRAIT_RESONANCE_SUPRESSED "resonance_supressed"

--- a/code/__DEFINES/~doppler_defines/traits.dm
+++ b/code/__DEFINES/~doppler_defines/traits.dm
@@ -117,3 +117,6 @@
 #define TRAIT_POWER_MEDICAL "power_medical"
 #define TRAIT_POWER_ENGINEERING "power_engineering"
 #define TRAIT_POWER_SERVICE "power_service"
+#define TRAIT_POWER_MONSTERSTRENGTH "power_monsterstrength"
+#define TRAIT_POWER_BLOODSPIKE "power_bloodspike"
+#define TRAIT_POWER_BONESHIELD "power_boneshield"

--- a/code/modules/antagonists/voidwalker/voidwalker_abilities.dm
+++ b/code/modules/antagonists/voidwalker/voidwalker_abilities.dm
@@ -65,3 +65,4 @@
 	button_icon = 'icons/mob/actions/actions_voidwalker.dmi'
 	button_icon_state = "voidwalker_telepathy"
 	panel = null
+	check_flags = AB_CHECK_CONSCIOUS

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -925,6 +925,10 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	if(attacking_bodypart.unarmed_damage_low)
 		if((target.body_position == LYING_DOWN) || HAS_TRAIT(user, TRAIT_PERFECT_ATTACKER) || staggered || user_drunkenness && HAS_TRAIT(user, TRAIT_DRUNKEN_BRAWLER)) //kicks and attacks against staggered targets never miss (provided your species deals more than 0 damage). Drunken brawlers while drunk also don't miss
 			miss_chance = 0
+		// DOPPLER EDIT ADDITION START
+		if(HAS_TRAIT(user, TRAIT_POWER_MONSTERSTRENGTH))
+			miss_chance = 0
+		// DOPPLER EDIT ADDITION END
 		else
 			miss_chance = clamp(UNARMED_MISS_CHANCE_BASE - limb_accuracy + (user.getFireLoss()*0.5 + user.getBruteLoss()*0.5), 0, UNARMED_MISS_CHANCE_MAX) //Limb miss chance + various damage. capped at 80 so there is at least a chance to land a hit.
 

--- a/modular_doppler/modular_powers/powers/_powers.dm
+++ b/modular_doppler/modular_powers/powers/_powers.dm
@@ -167,3 +167,20 @@ GLOBAL_DATUM_INIT(power_handler, /datum/power_handler, new)
 		to_chat(target, chat_string)
 
 	where_items_spawned = null
+
+// Component for checking resonance suppression
+
+/datum/component/resonance_suppression
+	//What status effect to apply when the signal is received the resonance is actively being suppressed
+	var/effect
+
+/datum/component/resonance_suppression/Initialize(effect = effect)
+	src.effect = effect
+	RegisterSignal(parent, COSMIG_RESONANCE_SUPRESSED, PROC_REF(apply_effect), TRUE)
+	RegisterSignal(parent, COSMIG_RESONANCE_UNSUPRESSED, PROC_REF(remove_effect), TRUE)
+
+/datum/component/resonance_suppression/proc/apply_effect(mob/living/carbon/human/owner)
+	owner.apply_status_effect(effect)
+
+/datum/component/resonance_suppression/proc/remove_effect(mob/living/carbon/human/owner)
+	owner.remove_status_effect(effect)

--- a/modular_doppler/modular_powers/powers/resonant_powers/aberrant.dm
+++ b/modular_doppler/modular_powers/powers/resonant_powers/aberrant.dm
@@ -27,10 +27,154 @@
 /datum/power/muscly
 	name = "Condensed Musculature"
 	desc = "You're far more athletic than the average person."
+	cost = 3
+	root_power = /datum/power/muscly
+	power_type = TRAIT_PATH_SUBTYPE_ABERRANT
+	power_traits = list(TRAIT_POWER_MUSCLY, TRAIT_STRENGTH, TRAIT_STIMMED)
+
+/datum/power/muscly/add(mob/living/carbon/human/target)
+	target.mind.set_level(/datum/skill/athletics, 4, silent = TRUE)
+
+/datum/power/monsterstrength
+	name = "Monstrous Strength"
+	desc = "Gain the ability to hit much harder with your unarmed attacks as well as block foes back with your blows"
 	cost = 5
 	root_power = /datum/power/muscly
 	power_type = TRAIT_PATH_SUBTYPE_ABERRANT
-	power_traits = list(TRAIT_POWER_MUSCLY)
+	power_traits = list(TRAIT_POWER_MONSTERSTRENGTH)
+
+/datum/power/monsterstrength/add(mob/living/carbon/human/target)
+	var/datum/action/new_action = new /datum/action/cooldown/spell/monstrous_stance(target.mind || target)
+	var/obj/item/bodypart/arm/right/right_arm = target.get_bodypart(BODY_ZONE_R_ARM)
+	right_arm.unarmed_damage_high = initial(right_arm.unarmed_damage_high) + 5
+	right_arm.unarmed_damage_low = initial(right_arm.unarmed_damage_low) + 5
+	var/obj/item/bodypart/arm/left/left_arm = target.get_bodypart(BODY_ZONE_L_ARM)
+	left_arm.unarmed_damage_high = initial(left_arm.unarmed_damage_high) + 5
+	left_arm.unarmed_damage_high = initial(left_arm.unarmed_damage_high) + 5
+
+/datum/action/cooldown/spell/monstrous_stance
+	name = "Monstrous Stance"
+	desc = "Channel your unnatural strength into a single devestating blow"
+	button_icon_state = "scream_for_me"
+	cooldown_time = 1.5 MINUTES
+	spell_requirements = NONE
+	invocation_type = INVOCATION_NONE
+	check_flags = AB_CHECK_INCAPACITATED|AB_CHECK_HANDS_BLOCKED|AB_CHECK_CONSCIOUS
+
+/datum/action/cooldown/spell/monstrous_stance/cast(mob/living/carbon/human/target)
+	. = ..()
+	if(!.)
+		return
+	var/datum/martial_art/monstrous_strike/mstrike = new()
+	mstrike.teach(target, make_temporary = TRUE)
+
+/datum/martial_art/monstrous_strike
+	name = "Monstrous Strike"
+	id = MARTIALART_MONSTERSTRIKE
+
+/datum/martial_art/monstrous_strike/harm_act(mob/living/attacker, mob/living/defender)
+	var/final_damage = rand(15, 20)
+	var/datum/martial_art/monstrous_strike/mstrike = new()
+	var/atk_verb = pick("punch", "smash", "crack")
+	if(defender.check_block(attacker, final_damage, "[attacker]'s [atk_verb]", UNARMED_ATTACK))
+		return
+
+	attacker.do_attack_animation(defender, ATTACK_EFFECT_PUNCH)
+	defender.visible_message(
+		span_danger("[attacker] [atk_verb]ed [defender] with such inhuman strength that it sends [defender.p_them()] flying backwards!"), \
+		span_userdanger("You're [atk_verb]ed by [attacker] with such inhuman strength that it sends you flying backwards!"),
+		span_hear("You hear a sickening sound of flesh hitting flesh!"),
+		null,
+		attacker,
+	)
+	to_chat(attacker, span_danger("You [atk_verb] [defender] with such inhuman strength that it sends [defender.p_them()] flying backwards!"))
+	defender.apply_damage(final_damage, attacker.get_attack_type())
+	playsound(defender, 'sound/effects/meteorimpact.ogg', 25, TRUE, -1)
+	var/throwtarget = get_edge_target_turf(attacker, get_dir(attacker, get_step_away(defender, attacker)))
+	defender.throw_at(throwtarget, 2, 2, attacker)
+	mstrike.remove(attacker)
+	log_combat(attacker, defender, "[atk_verb] (Monstrous Strike)")
+
+/datum/power/blood_spike
+	name = "Blood spike"
+	desc = "Manipulate your own blood into a jagged spike able to be thrown for low damage but high embed chance. Each use reduces your own blood level by 5%"
+	cost = 2
+	root_power = /datum/power/blood_spike
+	power_type = TRAIT_PATH_SUBTYPE_ABERRANT
+	power_traits = list(TRAIT_POWER_BLOODSPIKE)
+
+/datum/power/blood_spike/add(mob/living/carbon/human/target)
+	var/datum/action/new_action = new /datum/action/cooldown/spell/blood_spike(target.mind || target)
+
+/datum/action/cooldown/spell/blood_spike
+	name = "Form Blood Spike"
+	desc = "Form a spike made from your own blood, it makes a poor weapon but can be throw for low damage but a high chance to embed"
+	button_icon = 'icons/obj/weapons/thrown.dmi'
+	button_icon_state = "tonguespike"
+	cooldown_time = 0
+	spell_requirements = NONE
+	invocation_type = INVOCATION_NONE
+	check_flags = AB_CHECK_INCAPACITATED|AB_CHECK_HANDS_BLOCKED|AB_CHECK_CONSCIOUS
+
+/datum/action/cooldown/spell/blood_spike/cast(mob/living/carbon/human/target)
+	. = ..()
+	target.put_in_hands(/obj/item/throwing_star/blood_spike)
+	target.blood_volume = initial(target.blood_volume) - 28
+
+/obj/item/throwing_star/blood_spike
+	name = "Blood spike"
+	desc = "A mass of blood formed into a spike and congealed by resonant means"
+	icon_state = "tonguespike"
+	icon = 'icons/obj/weapons/thrown.dmi'
+	inhand_icon_state = null
+	force = 8
+	throwforce = 5
+	embed_type = /datum/embedding/blood_spike
+
+/datum/embedding/blood_spike
+	pain_mult = 3
+	fall_chance = 20
+	jostle_chance = 20
+	remove_pain_mult = 2
+	rip_time = 2 SECONDS
+
+/datum/power/bone_shield
+	name = "Bone Shield"
+	desc = "Twist and sculp the bone in your arm to form a fragile but protective bone shield. It will have a very high chance of blocking an attack for you but will shatter in the process. Forming one is harmless to you but exhausting"
+	cost = 2
+	root_power = /datum/power/bone_shield
+	power_type = TRAIT_PATH_SUBTYPE_ABERRANT
+	power_traits = list(TRAIT_POWER_BONESHIELD)
+
+/datum/power/bone_shield/add(mob/living/carbon/human/target)
+	var/datum/action/new_action = new /datum/action/cooldown/spell/bone_shield(target.mind || target)
+
+/datum/action/cooldown/spell/bone_shield
+	name = "Form Bone Shield"
+	desc = "Channel resonance through your very bones to cause your arm's bones to grow into a delicate but protective shield. This exhausts you in the process"
+	button_icon = 'icons/obj/weapons/shields.dmi'
+	button_icon_state = "moonflower_shield"
+	cooldown_time =  1.5 MINUTES
+	spell_requirements = NONE
+	invocation_type = INVOCATION_NONE
+	check_flags = AB_CHECK_INCAPACITATED|AB_CHECK_HANDS_BLOCKED|AB_CHECK_CONSCIOUS
+
+/datum/action/cooldown/spell/bone_shield/cast(mob/living/carbon/human/target)
+	. = ..()
+	target.adjustStaminaLoss(75)
+	target.put_in_hands(/obj/item/shield/goliath/resonant)
+
+/obj/item/shield/goliath/resonant
+	name = "Fused Bone Shield"
+	desc = "A fragile shield formed of your own bone, easy to block attacks with but likely to shatter from it"
+	force = 5
+	block_chance = 90
+	shield_break_leftover = /obj/item/stack/sheet/bone
+
+/obj/item/shield/goliath/resonant/on_shield_block(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", damage = 0, attack_type = MELEE_ATTACK, damage_type = BRUTE)
+	. = ..()
+	src.atom_destruction()
+
 
 /datum/power/bestial
 	name = "Latent Bestial Traits"

--- a/modular_doppler/modular_powers/powers/resonant_powers/aberrant.dm
+++ b/modular_doppler/modular_powers/powers/resonant_powers/aberrant.dm
@@ -2,6 +2,49 @@
  * Root powers
  */
 
+// A proc to be ran when a root power that conflicts with cybernetics is applied
+/mob/living/carbon/human/proc/cybernetics_sickness_process()
+	if(src.check_cybernetics() == TRUE)
+		src.apply_status_effect(/datum/status_effect/cybernetics_conflict)
+	RegisterSignal(src, COMSIG_CARBON_GAIN_ORGAN, PROC_REF(on_organ_gain), TRUE)
+	RegisterSignal(src, COMSIG_CARBON_LOSE_ORGAN, PROC_REF(on_organ_lose), TRUE)
+
+/mob/living/carbon/human/proc/check_cybernetics()
+	var/cybernetic_found = FALSE
+	for(var/obj/item/organ/organ as anything in src.organs)
+		// allows razor claws for now, so beasties can still have claws and not die. Eventually make an organic version hopefully
+		if(IS_ROBOTIC_ORGAN(organ) && !(organ.organ_flags & ORGAN_HIDDEN))
+			cybernetic_found = TRUE
+			break
+	return cybernetic_found
+
+/mob/living/carbon/human/proc/on_organ_gain(datum/source, obj/item/organ/new_organ, special)
+	SIGNAL_HANDLER
+	if(IS_ROBOTIC_ORGAN(new_organ) && !(new_organ.organ_flags & ORGAN_HIDDEN))
+		src.apply_status_effect(/datum/status_effect/cybernetics_conflict)
+
+/mob/living/carbon/human/proc/on_organ_lose(datum/source, special)
+	SIGNAL_HANDLER
+	if(!src.check_cybernetics())
+		src.remove_status_effect(/datum/status_effect/cybernetics_conflict)
+
+/datum/status_effect/cybernetics_conflict
+	id = "cybernetics_abberant_conflict"
+	alert_type = /atom/movable/screen/alert/status_effect/cybernetics_conflict
+	var/disgust_per_tick = 1
+	var/max_disgust = DISGUST_LEVEL_DISGUSTED
+	var/max_tox = 75
+
+/datum/status_effect/cybernetics_conflict/tick(seconds_between_ticks)
+	owner.adjust_disgust(disgust_per_tick, max_disgust)
+	if(owner.getToxLoss() < 75)
+		owner.adjustToxLoss(3)
+
+/atom/movable/screen/alert/status_effect/cybernetics_conflict
+	name = "Cybernetics conflict"
+	desc = "Your resonant deviancies are conflicting with the cybernetics within you, making you increasingly ill"
+	maptext_y = 2
+	attached_effect = /datum/status_effect/cybernetics_conflict
 /datum/power/cuprous_heart
 	name = "Cuprous Heart"
 	desc = "Your heart and blood are Living Copper. Your wounds and injuries naturally seal themselves, and you're resistant \
@@ -26,7 +69,7 @@
 
 /datum/power/muscly
 	name = "Condensed Musculature"
-	desc = "You're far more athletic than the average person."
+	desc = "You're far more athletic than the average person. This conflicts with cybernetic organs, causing sickness"
 	cost = 3
 	root_power = /datum/power/muscly
 	power_type = TRAIT_PATH_SUBTYPE_ABERRANT
@@ -34,70 +77,66 @@
 
 /datum/power/muscly/add(mob/living/carbon/human/target)
 	target.mind.set_level(/datum/skill/athletics, 4, silent = TRUE)
+	target.cybernetics_sickness_process()
 
 /datum/power/monsterstrength
 	name = "Monstrous Strength"
-	desc = "Gain the ability to hit much harder with your unarmed attacks as well as block foes back with your blows. At the cost of being able to use batons or guns"
+	desc = "Gain the ability to hit much harder with your unarmed attacks as well as block foes back with your blows. At the cost of being able to use batons or guns. This conflicts with cybernetic organs, causing sickness"
 	cost = 5
 	root_power = /datum/power/muscly
 	power_type = TRAIT_PATH_SUBTYPE_ABERRANT
 	power_traits = list(TRAIT_POWER_MONSTERSTRENGTH, TRAIT_CHUNKYFINGERS)
 
 /datum/power/monsterstrength/add(mob/living/carbon/human/target)
-	var/datum/action/new_action = new /datum/action/cooldown/spell/monstrous_stance(target.mind || target)
+	var/datum/action/new_action = new /datum/action/cooldown/spell/touch/monstrous_stance(target.mind || target)
+	new_action.Grant(target)
 	var/obj/item/bodypart/arm/right/right_arm = target.get_bodypart(BODY_ZONE_R_ARM)
 	right_arm.unarmed_damage_high = initial(right_arm.unarmed_damage_high) + 5
-	right_arm.unarmed_damage_low = initial(right_arm.unarmed_damage_low) + 5
+	right_arm.unarmed_damage_low = right_arm.unarmed_damage_high
 	var/obj/item/bodypart/arm/left/left_arm = target.get_bodypart(BODY_ZONE_L_ARM)
 	left_arm.unarmed_damage_high = initial(left_arm.unarmed_damage_high) + 5
-	left_arm.unarmed_damage_high = initial(left_arm.unarmed_damage_high) + 5
+	left_arm.unarmed_damage_low = left_arm.unarmed_damage_high
 
-/datum/action/cooldown/spell/monstrous_stance
+
+/datum/action/cooldown/spell/touch/monstrous_stance
 	name = "Monstrous Stance"
 	desc = "Channel your unnatural strength into a single devestating blow"
 	button_icon_state = "scream_for_me"
-	cooldown_time = 1.5 MINUTES
+	cooldown_time = 1 MINUTES
 	spell_requirements = NONE
 	invocation_type = INVOCATION_NONE
 	check_flags = AB_CHECK_INCAPACITATED|AB_CHECK_HANDS_BLOCKED|AB_CHECK_CONSCIOUS
+	draw_message = span_notice("You tense your arm in preperation to deliver a devestating blow")
+	drop_message = span_notice("You relax your arm")
+	hand_path = /obj/item/melee/touch_attack/monstrous_strike
 
-/datum/action/cooldown/spell/monstrous_stance/cast(mob/living/carbon/human/target)
-	. = ..()
-	if(!.)
-		return
-	var/datum/martial_art/monstrous_strike/mstrike = new()
-	mstrike.teach(target, make_temporary = TRUE)
+/obj/item/melee/touch_attack/monstrous_strike
+	name = "monstrous strike"
+	desc = "A prepared strike of inhuman strength"
+	icon = 'icons/obj/weapons/hand.dmi'
+	icon_state = "scream_for_me"
+	inhand_icon_state = "monster_strike"
 
-/datum/martial_art/monstrous_strike
-	name = "Monstrous Strike"
-	id = MARTIALART_MONSTERSTRIKE
-
-/datum/martial_art/monstrous_strike/harm_act(mob/living/attacker, mob/living/defender)
-	var/final_damage = rand(15, 20)
-	var/datum/martial_art/monstrous_strike/mstrike = new()
+/datum/action/cooldown/spell/touch/monstrous_stance/cast_on_hand_hit(obj/item/melee/touch_attack/hand, mob/living/victim, mob/living/carbon/caster)
 	var/atk_verb = pick("punch", "smash", "crack")
-	if(defender.check_block(attacker, final_damage, "[attacker]'s [atk_verb]", UNARMED_ATTACK))
-		return
-
-	attacker.do_attack_animation(defender, ATTACK_EFFECT_PUNCH)
-	defender.visible_message(
-		span_danger("[attacker] [atk_verb]ed [defender] with such inhuman strength that it sends [defender.p_them()] flying backwards!"), \
-		span_userdanger("You're [atk_verb]ed by [attacker] with such inhuman strength that it sends you flying backwards!"),
+	caster.do_attack_animation(victim, ATTACK_EFFECT_PUNCH)
+	victim.visible_message(
+		span_danger("[caster] [atk_verb]ed [victim] with such inhuman strength that it sends [victim.p_them()] flying backwards!"), \
+		span_userdanger("You're [atk_verb]ed by [caster] with such inhuman strength that it sends you flying backwards!"),
 		span_hear("You hear a sickening sound of flesh hitting flesh!"),
 		null,
-		attacker,
+		caster,
 	)
-	to_chat(attacker, span_danger("You [atk_verb] [defender] with such inhuman strength that it sends [defender.p_them()] flying backwards!"))
-	defender.apply_damage(final_damage, attacker.get_attack_type())
-	playsound(defender, 'sound/effects/meteorimpact.ogg', 25, TRUE, -1)
-	var/throwtarget = get_edge_target_turf(attacker, get_dir(attacker, get_step_away(defender, attacker)))
-	defender.throw_at(throwtarget, 2, 2, attacker)
-	mstrike.remove(attacker)
-	log_combat(attacker, defender, "[atk_verb] (Monstrous Strike)")
+	to_chat(caster, span_danger("You [atk_verb] [victim] with such inhuman strength that it sends [victim.p_them()] flying backwards!"))
+	victim.apply_damage(25, def_zone = caster.zone_selected)
+	playsound(victim, 'sound/effects/meteorimpact.ogg', 25, TRUE, -1)
+	var/throwtarget = get_edge_target_turf(caster, get_dir(caster, get_step_away(victim, caster)))
+	victim.throw_at(throwtarget, 2, 2, caster)
+	return TRUE
 
 /datum/power/blood_spike
 	name = "Blood spike"
-	desc = "Manipulate your own blood into a jagged spike able to be thrown for low damage but high embed chance. Each use reduces your own blood level by 5%"
+	desc = "Manipulate your own blood into a jagged spike able to be thrown for low damage but high embed chance. Each use reduces your own blood level by 5%. This conflicts with cybernetic organs, causing sickness"
 	cost = 2
 	root_power = /datum/power/blood_spike
 	power_type = TRAIT_PATH_SUBTYPE_ABERRANT
@@ -105,6 +144,8 @@
 
 /datum/power/blood_spike/add(mob/living/carbon/human/target)
 	var/datum/action/new_action = new /datum/action/cooldown/spell/blood_spike(target.mind || target)
+	new_action.Grant(target)
+	target.cybernetics_sickness_process()
 
 /datum/action/cooldown/spell/blood_spike
 	name = "Form Blood Spike"
@@ -115,11 +156,23 @@
 	spell_requirements = NONE
 	invocation_type = INVOCATION_NONE
 	check_flags = AB_CHECK_INCAPACITATED|AB_CHECK_HANDS_BLOCKED|AB_CHECK_CONSCIOUS
+	sound = 'sound/effects/wounds/blood3.ogg'
 
 /datum/action/cooldown/spell/blood_spike/cast(mob/living/carbon/human/target)
 	. = ..()
-	target.put_in_hands(/obj/item/throwing_star/blood_spike)
-	target.blood_volume = initial(target.blood_volume) - 28
+	var/obj/item/throwing_star/blood_spike/new_spike = new /obj/item/throwing_star/blood_spike
+	if(!target.put_in_hands(new_spike, del_on_fail = TRUE))
+		reset_spell_cooldown()
+		if (target.usable_hands == 0)
+			to_chat(target, span_warning("You dont have any usable hands!"))
+		else
+			to_chat(target, span_warning("Your hands are full!"))
+		return FALSE
+	target.visible_message(
+		span_danger("[target] rips blood from their veins and forms it into a spike!"),
+		span_danger("You rip blood from your veins and form it into a spike!"))
+	playsound(target, sound, 50, vary = TRUE)
+	target.blood_volume -= 28
 
 /obj/item/throwing_star/blood_spike
 	name = "Blood spike"
@@ -140,7 +193,7 @@
 
 /datum/power/bone_shield
 	name = "Bone Shield"
-	desc = "Twist and sculp the bone in your arm to form a fragile but protective bone shield. It will have a very high chance of blocking an attack for you but will shatter in the process. Forming one is harmless to you but exhausting"
+	desc = "Twist and sculp the bone in your arm to form a fragile but protective bone shield. It will have a very high chance of blocking an attack for you but will shatter in the process. Forming one is harmless to you but exhausting. This conflicts with cybernetic organs, causing sickness"
 	cost = 2
 	root_power = /datum/power/bone_shield
 	power_type = TRAIT_PATH_SUBTYPE_ABERRANT
@@ -148,21 +201,36 @@
 
 /datum/power/bone_shield/add(mob/living/carbon/human/target)
 	var/datum/action/new_action = new /datum/action/cooldown/spell/bone_shield(target.mind || target)
+	new_action.Grant(target)
+	target.cybernetics_sickness_process()
 
 /datum/action/cooldown/spell/bone_shield
 	name = "Form Bone Shield"
 	desc = "Channel resonance through your very bones to cause your arm's bones to grow into a delicate but protective shield. This exhausts you in the process"
-	button_icon = 'icons/obj/weapons/shields.dmi'
-	button_icon_state = "moonflower_shield"
+	button_icon = 'modular_doppler/hearthkin/tribal_extended/icons/shields.dmi'
+	button_icon_state = "goliath_shield"
 	cooldown_time =  1.5 MINUTES
 	spell_requirements = NONE
 	invocation_type = INVOCATION_NONE
 	check_flags = AB_CHECK_INCAPACITATED|AB_CHECK_HANDS_BLOCKED|AB_CHECK_CONSCIOUS
+	sound = 'sound/effects/wounds/crack2.ogg'
 
 /datum/action/cooldown/spell/bone_shield/cast(mob/living/carbon/human/target)
 	. = ..()
+	var/obj/item/shield/goliath/resonant/new_shield = new /obj/item/shield/goliath/resonant
+	if(!target.put_in_hands(new_shield, del_on_fail = TRUE))
+		reset_spell_cooldown()
+		if (target.usable_hands == 0)
+			to_chat(target, span_warning("You dont have any usable hands!"))
+		else
+			to_chat(target, span_warning("Your hands are full!"))
+		return FALSE
+	target.visible_message(
+		span_danger("[target]'s arm begins to twist and grob into a bone shield!"),
+		span_danger("You twist and grow your arms bone to form a shield!"))
+	playsound(target, sound, 50, vary = TRUE)
 	target.adjustStaminaLoss(75)
-	target.put_in_hands(/obj/item/shield/goliath/resonant)
+
 
 /obj/item/shield/goliath/resonant
 	name = "Fused Bone Shield"
@@ -171,9 +239,20 @@
 	block_chance = 90
 	shield_break_leftover = /obj/item/stack/sheet/bone
 
+/obj/item/shield/goliath/resonant/Initialize(mapload)
+	. = ..()
+	ADD_TRAIT(src, TRAIT_NODROP, HAND_REPLACEMENT_TRAIT)
+
 /obj/item/shield/goliath/resonant/on_shield_block(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", damage = 0, attack_type = MELEE_ATTACK, damage_type = BRUTE)
 	. = ..()
 	src.atom_destruction()
+
+/obj/item/shield/goliath/resonant/attack_self(mob/user)
+	user.visible_message(
+		span_danger("[user]'s bashes their shield causing it to crumble!"),
+		span_danger("You bash your shield causing it to crumble!"))
+	src.atom_destruction()
+
 
 
 /datum/power/bestial

--- a/modular_doppler/modular_powers/powers/resonant_powers/aberrant.dm
+++ b/modular_doppler/modular_powers/powers/resonant_powers/aberrant.dm
@@ -37,11 +37,11 @@
 
 /datum/power/monsterstrength
 	name = "Monstrous Strength"
-	desc = "Gain the ability to hit much harder with your unarmed attacks as well as block foes back with your blows"
+	desc = "Gain the ability to hit much harder with your unarmed attacks as well as block foes back with your blows. At the cost of being able to use batons or guns"
 	cost = 5
 	root_power = /datum/power/muscly
 	power_type = TRAIT_PATH_SUBTYPE_ABERRANT
-	power_traits = list(TRAIT_POWER_MONSTERSTRENGTH)
+	power_traits = list(TRAIT_POWER_MONSTERSTRENGTH, TRAIT_CHUNKYFINGERS)
 
 /datum/power/monsterstrength/add(mob/living/carbon/human/target)
 	var/datum/action/new_action = new /datum/action/cooldown/spell/monstrous_stance(target.mind || target)

--- a/modular_doppler/modular_powers/powers/resonant_powers/aberrant.dm
+++ b/modular_doppler/modular_powers/powers/resonant_powers/aberrant.dm
@@ -356,6 +356,61 @@
 	src.atom_destruction()
 
 
+/datum/power/prying_claws
+	name = "Prying claws"
+	desc = "Grants sharp claws ending in a hook. Formed by a resonant deviancy they are remarkably dense and function as not only "
+	cost = 2
+	root_power = /datum/power/muscly
+	power_type = TRAIT_PATH_SUBTYPE_ABERRANT
+	power_traits = list(TRAIT_POWER_CLAWS)
+
+/datum/power/prying_claws/add(mob/living/carbon/human/target)
+
+/datum/action/innate/extend_prying_claws
+	name = "Extend claws"
+	check_flags = AB_CHECK_INCAPACITATED|AB_CHECK_HANDS_BLOCKED|AB_CHECK_CONSCIOUS
+	button_icon_state = "wolverine"
+	button_icon = 'modular_doppler/modular_medical/icons/implants.dmi'
+	background_icon_state = "bg_default"
+	// What will be given in-hand
+	var/obj/item/knife/prying_claws/prying_claws
+
+/datum/action/innate/extend_prying_claws/Activate()
+	. = ..()
+	for(var/obj/item/hand_item/item in owner.held_items)
+		if(item)
+			owner.balloon_alert(owner, "hand occupied!")
+			return
+	prying_claws = new
+	owner.put_in_active_hand(prying_claws)
+/obj/item/knife/prying_claws
+	name = "Prying claws"
+	desc = "A set of sharp claws with a hook at the end and unnatturally dense. The hook combined with the density allows for it to deliver horrific wounds and even pry things open"
+	icon = 'modular_doppler/modular_medical/icons/implants.dmi'
+	righthand_file = 'modular_doppler/modular_medical/icons/implants_righthand.dmi'
+	lefthand_file = 'modular_doppler/modular_medical/icons/implants_lefthand.dmi'
+	icon_state = "wolverine"
+	inhand_icon_state = "wolverine"
+	force = 10
+	w_class = WEIGHT_CLASS_BULKY
+	wound_bonus = 5
+	tool_behaviour = TOOL_CROWBAR
+	toolspeed = 1
+
+/obj/item/knife/prying_claws/initialize(mapload)
+	. = ..()
+	ADD_TRAIT(src, TRAIT_NODROP, HAND_REPLACEMENT_TRAIT)
+
+/datum/action/innate/osseus_toolset/Activate()
+	. = ..()
+	wrench = new
+	pick = new
+	screwdriver = new
+	var/list/tools = list(
+		"Osseus Wrench" = image(icon = 'modular_doppler/hearthkin/primitive_production/icons/primitive_tools.dmi', icon_state = "wrench"),
+		"Osseus cutters" = image(icon = 'modular_doppler/hearthkin/primitive_production/icons/primitive_tools.dmi', icon_state = "cutters"),
+		"Osseus screwdriver" = image(icon = 'modular_doppler/hearthkin/primitive_production/icons/primitive_tools.dmi', icon_state = "cutters"),
+	)
 
 /datum/power/bestial
 	name = "Latent Bestial Traits"

--- a/modular_doppler/modular_powers/powers/resonant_powers/aberrant.dm
+++ b/modular_doppler/modular_powers/powers/resonant_powers/aberrant.dm
@@ -80,8 +80,8 @@
 	target.cybernetics_sickness_process()
 
 /datum/power/monsterstrength
-	name = "Monstrous Strength"
-	desc = "Gain the ability to hit much harder with your unarmed attacks as well as block foes back with your blows. At the cost of being able to use batons or guns. This conflicts with cybernetic organs, causing sickness"
+	name = "Musculoskeletal Redistribution"
+	desc = "A Deviancy characterized by an abnormally muscular upper body, providing advantages in hand-to-hand combat at the cost of the dexterity required for fine manipulation, e.g. pulling a firearm's trigger"
 	cost = 5
 	root_power = /datum/power/muscly
 	power_type = TRAIT_PATH_SUBTYPE_ABERRANT


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request


 So this has done a few things. Firstly condensed musculature actually does something, your athletics will start at 4 and you'll get the strength and stimmed traits, meaning you'll be able to further level it faster and do a bit better boxing. Lastly all these abberant abilities will make you very sick and if you have any cybernetic organs. Prosthetics are fine for now but that's subject to change. I struggled enough trying to get the organ rejection working

Now for the exciting stuff!

Adds three abilities (none of which are in the design doc)

Musculoskeletal Redistribution: Increases your unarmed melee damage and grants an ability that powers up your next hit to deal even more damage and knock back your foe! 60 second cooldown. This comes at the cost of your ability to use guns and batons.

Blood spike: Allows you to sacrifice 5% of your blood to form a blood spike that makes a very poor weapon but excellent throwing weapon, not dealing much damage even then but guaranteed to embed and deal more damage as they enemy moves about. Basically a shitty throwing star but has no cooldown so can be spammed till you bleed out

Bone shield: Forms a fragile but very protective bone shield from one of your arms. It'll shatter after one hit from ANYTHING even disarms but has a 90% block chance. 90 second cooldown and deals 75 stamina damage to you when used

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

We gotta get the ball rolling with these powers! 

Personally I found the abberant tree in the design doc to be rather mundane, most of the abilities could just as well be genemod traits. So I aim to add abilities revolving around monstrous abilities (Bites, knock backs, maybe anti resonant venoms) Inspired from the initial adrenal gland and condensed musculature abilities from the design doc, Blood manipulation powers, sacrificing your own blood for offensive capabilities inspired by juni talking about it. And bone manipulation powers, defensive and utility based powers that exhaust or harm you directly inspired by uuhhm my own stupid brain
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog


<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Abberant ability Monstrous strength. Hit harder and power up for one big strike
add: Abberant ability blood spike. Spend your own blood to form a blood spike, for use as a throwing weapon
add: Abberant ability bone shield. Form a fragile bone shield from your arm to block a single hit before shattering
add: Actually implements condensed musculature. It grants you 4 athletic levels to start and makes further leveling of it easier
add: Cybernetics rejection when using cybernetics and aberrant stuff
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
