### PR TITLE
Fix security officer alt titles not working with subdepartment assignments

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -599,7 +599,7 @@ SUBSYSTEM_DEF(job)
 		else
 			handle_auto_deadmin_roles(player_client, job.title)
 
-	setup_alt_job_items(equipping, job, player_client) // DOPPLER EDIT: alternative job titles
+	setup_alt_job_title(equipping, job, player_client) // DOPPLER ADDITION: alternative job titles
 	job.after_spawn(equipping, player_client)
 
 /datum/controller/subsystem/job/proc/handle_auto_deadmin_roles(client/C, rank)

--- a/code/datums/records/manifest.dm
+++ b/code/datums/records/manifest.dm
@@ -117,8 +117,8 @@ GLOBAL_DATUM_INIT(manifest, /datum/manifest, new)
 	person.dna.copy_dna(record_dna)
 
 	// DOPPLER EDIT ADDITION BEGIN - ALTERNATIVE_JOB_TITLES
-	// The alt job title, if user picked one, or the default
-	var/chosen_assignment = person_client?.prefs.alt_job_titles[assignment] || assignment
+	// The alt job title is set to the ID's assignment before we inject
+	var/chosen_assignment = id_card?.assignment || assignment
 	// DOPPLER EDIT ADDITION END - ALTERNATIVE_JOB_TITLES
 
 	var/datum/record/locked/lockfile = new(

--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -128,6 +128,7 @@ GLOBAL_LIST_EMPTY(security_officer_distribution)
 		var/assignment = worn_id.get_trim_assignment()
 		if(istype(pda) && !isnull(assignment))
 			pda.imprint_id(spawning.real_name, assignment)
+		SSjob.setup_alt_job_title(spawning, src, player_client) // DOPPLER ADDITION: alternative job titles
 
 	var/spawn_point = pick(LAZYACCESS(GLOB.department_security_spawns, department))
 

--- a/modular_doppler/alt_job_titles/alt_job_title_modifiers.dm
+++ b/modular_doppler/alt_job_titles/alt_job_title_modifiers.dm
@@ -1,0 +1,39 @@
+/**
+ * Some specific jobs may require a modifier to be applied to their alt title.
+ * Here is where we handle doing such.
+ */
+
+// Applies any potential modifiers to our alt title
+/datum/id_trim/proc/get_modified_title(base_title)
+	return base_title
+
+// Applies any potential modifiers to our alt title
+/obj/item/card/id/proc/get_modified_title(base_title)
+	if(trim)
+		return trim.get_modified_title(base_title)
+	return base_title
+
+/**
+ * Departmental security requires appending the subdepartment after its alt job title.
+ */
+
+/datum/id_trim/job/security_officer
+	// Which string to append to our title based on our subdepartment, if any
+	var/subdepartment_title_modifier
+
+/datum/id_trim/job/security_officer/get_modified_title(base_title)
+	if(subdepartment_title_modifier)
+		return "[base_title] ([subdepartment_title_modifier])"
+	return ..()
+
+/datum/id_trim/job/security_officer/supply
+	subdepartment_title_modifier = SEC_DEPT_SUPPLY
+
+/datum/id_trim/job/security_officer/engineering
+	subdepartment_title_modifier = SEC_DEPT_ENGINEERING
+
+/datum/id_trim/job/security_officer/medical
+	subdepartment_title_modifier = SEC_DEPT_MEDICAL
+
+/datum/id_trim/job/security_officer/science
+	subdepartment_title_modifier = SEC_DEPT_SCIENCE

--- a/modular_doppler/alt_job_titles/job.dm
+++ b/modular_doppler/alt_job_titles/job.dm
@@ -1,13 +1,10 @@
 // ALTERNATIVE_JOB_TITLES
 
 /**
- * Shows a list of all current and future polls and buttons to edit or delete them or create a new poll.
- *
- * All extra functionality to run on new player mobs, in a place where we actually have the client,
- * and haven't called COMSIG_GLOB_JOB_AFTER_SPAWN yet, so we are running before the wallet trait,
- * and other things that rely on items already being settled.
+ * Sets a human's ID/PDA title to match their preferred alt title for the given job.
+ * Run after we apply or make modifications to a given assignment during roundstart/latejoin setup.
  */
-/datum/controller/subsystem/job/proc/setup_alt_job_items(mob/living/carbon/human/equipping, datum/job/job, client/player_client)
+/datum/controller/subsystem/job/proc/setup_alt_job_title(mob/living/carbon/human/equipping, datum/job/job, client/player_client)
 	if(!player_client)
 		return
 
@@ -16,8 +13,9 @@
 
 	var/chosen_title = player_client.prefs.alt_job_titles[job.title] || job.title
 
-	var/obj/item/card/id/card = equipping.wear_id
+	var/obj/item/card/id/card = equipping.get_idcard(hand_first = FALSE)
 	if(istype(card))
+		chosen_title = card.get_modified_title(chosen_title)
 		card.assignment = chosen_title
 		card.update_label()
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6604,6 +6604,7 @@
 #include "modular_doppler\advanced_reskin\code\advanced_reskin.dm"
 #include "modular_doppler\ai_brain_shit\ai_brain.dm"
 #include "modular_doppler\ai_qol\code\eye.dm"
+#include "modular_doppler\alt_job_titles\alt_job_title_modifiers.dm"
 #include "modular_doppler\alt_job_titles\alt_job_titles.dm"
 #include "modular_doppler\alt_job_titles\job.dm"
 #include "modular_doppler\announcer\code\config.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

So this fixes security officer alt titles by... well. It just makes the security officer job re-run alt title setup after assigning a sub-department.
I considered simply moving alt title setup until after security officers handle their thing, but really security officers are the snowflake'd behaviour here and for most other jobs the current place works better. Hence! Just making it so security officers re-run it if need be.

Now, doing *just* that would simply override the subdepartment rank with the given alt title, which feels off.
So we implement a new proc `/datum/id_trim/proc/get_modified_title(base_title)`, which allows a given trim to decide whether we should be applying some flavour of modification to a given alt title.
This allows us to make the departmental security officer trims simply append their subdepartment to whatever alt title you chose.

As a side to this, we make it so manifest injections pull straight from the ID assignment instead of from prefs, given all this is done before manifest injection anyway. This makes it so the manifest actually gets the modified alt title, instead of just the alt title from prefs.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

less jank :+1:

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: [DOPPLER] Security officer alt titles work again, and account for subdepartment assignments.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
