### PR TITLE
Adds Traumatized, a quirk that lets you pick a brain trauma to be stuck with

### DIFF
--- a/modular_doppler/_HELPERS/preferences.dm
+++ b/modular_doppler/_HELPERS/preferences.dm
@@ -50,3 +50,25 @@ GLOBAL_LIST_INIT(all_powers, init_all_powers())
 		powers_list += power_type
 
 	return powers_list
+
+/// List of all Brain Traumas for the Quirk. NOT every Trauma in the game
+/// Many are left out because they're covered by other quirks or are strictly beneficial
+GLOBAL_LIST_INIT(quirk_trauma_choice, list(
+	"Expressive Aphasia" = /datum/brain_trauma/mild/expressive_aphasia,
+	"Mind Echo" = /datum/brain_trauma/mild/mind_echo,
+	"Possessive" = /datum/brain_trauma/mild/possessive,
+	"Aphasia" = /datum/brain_trauma/severe/aphasia,
+	"Existential Crisis" = /datum/brain_trauma/special/existential_crisis,
+	"Monophobia" = /datum/brain_trauma/severe/monophobia,
+	"Discoordination" = /datum/brain_trauma/severe/discoordination,
+	"Kleptomania" = /datum/brain_trauma/severe/kleptomaniac,
+	"Lumiphobia" = /datum/brain_trauma/magic/lumiphobia,
+	"Poltergeist" = /datum/brain_trauma/magic/poltergeist,
+	"Stalking Phantom" = /datum/brain_trauma/magic/stalker,
+	"Stuttering" = /datum/brain_trauma/mild/stuttering,
+	"Dumbness" = /datum/brain_trauma/mild/dumbness,
+	"Concussion" = /datum/brain_trauma/mild/concussion,
+	"Muscle Weakness" = /datum/brain_trauma/mild/muscle_weakness,
+	"Muscle Spasms" = /datum/brain_trauma/mild/muscle_spasms,
+	"Nervous cough" = /datum/brain_trauma/mild/nervous_cough,
+))

--- a/modular_doppler/modular_quirks/traumatized/traumatized.dm
+++ b/modular_doppler/modular_quirks/traumatized/traumatized.dm
@@ -3,7 +3,7 @@
 	desc = "A terrible trauma has been inflicted on you from your past or birth."
 	value = 0
 	medical_record_text = "Patient's brain waves show signs of permanent neurological trauma"
-	icon = FA_ICON_BRAIN
+	icon = FA_ICON_DIZZY
 
 /datum/quirk/traumatized/post_add()
 	. = ..()

--- a/modular_doppler/modular_quirks/traumatized/traumatized.dm
+++ b/modular_doppler/modular_quirks/traumatized/traumatized.dm
@@ -1,0 +1,43 @@
+/datum/quirk/traumatized
+	name = "Traumatized"
+	desc = "A terrible trauma has been inflicted on you from your past or birth."
+	value = 0
+	medical_record_text = "Patient's brain waves show signs of permanent neurological trauma"
+	icon = FA_ICON_BRAIN
+
+/datum/quirk/traumatized/post_add()
+	. = ..()
+	var/trauma_name = quirk_holder.client?.prefs.read_preference(/datum/preference/choiced/trauma_chosen) || "Random"
+	var/datum/brain_trauma/actual_trauma
+	var/mob/living/carbon/human/victim = quirk_holder
+
+	trauma_name = trauma_name == "Random" ? pick(GLOB.quirk_trauma_choice) : trauma_name //quirked up ternary statement
+	actual_trauma = GLOB.quirk_trauma_choice[trauma_name]
+
+	victim.gain_trauma(actual_trauma, TRAUMA_RESILIENCE_ABSOLUTE)
+
+//Pref stuff
+/datum/quirk_constant_data/traumatized
+	associated_typepath = /datum/quirk/traumatized
+	customization_options = list(/datum/preference/choiced/trauma_chosen)
+
+/datum/preference/choiced/trauma_chosen
+	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
+	savefile_key = "trauma"
+	savefile_identifier = PREFERENCE_CHARACTER
+	should_generate_icons = FALSE
+
+/datum/preference/choiced/trauma_chosen/init_possible_values()
+	return assoc_to_keys(GLOB.quirk_trauma_choice) + "Random"
+
+/datum/preference/choiced/trauma_chosen/create_default_value()
+	return "Random"
+
+/datum/preference/choiced/trauma_chosen/is_accessible(datum/preferences/preferences)
+	if (!..(preferences))
+		return FALSE
+
+	return "Traumatized" in preferences.all_quirks
+
+/datum/preference/choiced/trauma_chosen/apply_to_human(mob/living/carbon/human/target, value)
+	return

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7216,6 +7216,7 @@
 #include "modular_doppler\modular_quirks\permitted_cybernetic\code\preferences.dm"
 #include "modular_doppler\modular_quirks\system_shock\system_shock.dm"
 #include "modular_doppler\modular_quirks\tranquility\code\tranquility.dm"
+#include "modular_doppler\modular_quirks\traumatized\traumatized.dm"
 #include "modular_doppler\modular_quirks\undersized\gun.dm"
 #include "modular_doppler\modular_quirks\undersized\held_undersized_examine.dm"
 #include "modular_doppler\modular_quirks\undersized\held_undersized_id.dm"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/dopplershift_preferences/traumatized.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/dopplershift_preferences/traumatized.tsx
@@ -1,0 +1,7 @@
+import { Feature } from '../base';
+import { FeatureDropdownInput } from '../dropdowns';
+
+export const trauma: Feature<number> = {
+  name: 'Chosen Trauma',
+  component: FeatureDropdownInput,
+};

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/dopplershift_preferences/traumatized.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/dopplershift_preferences/traumatized.tsx
@@ -1,7 +1,7 @@
-import { Feature } from '../base';
+import { FeatureChoiced } from '../base';
 import { FeatureDropdownInput } from '../dropdowns';
 
-export const trauma: Feature<number> = {
+export const trauma: FeatureChoiced = {
   name: 'Chosen Trauma',
   component: FeatureDropdownInput,
 };


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Like 3 hours ago Dopamiin was like "I wish there was a quirk that would let you start with a certain brain trauma"
![image](https://github.com/user-attachments/assets/ece5ca9e-111a-4aaa-8345-9dc1c5a1dd7b)

Please yell at me if the Typescript is weird or I put things where they don't belong organization wise
In modular _HELPERS I've initialized a Global List for the options this quirk has.

## Why It's Good For The Game
Dopamiin wanted to play Monophobia
I wanted to play Dumb, and or Aphasia
The Poltergeist or Stalker ones are pretty cool too. 

The list of options is manually selected rather than generated. I've excluded: Any brain trauma that's strictly positive rather than negative, traumas given by other quirks, Split Person, Imaginary Friend, and all Heretic traumas. 

The rest of the Mild and Severe Traumas are included. 

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

![image](https://github.com/user-attachments/assets/c33ee670-2631-4261-8004-a2f6bd8b88f4)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: You can choose a brain trauma for your creacher
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
