### PR TITLE
salt nerfs the spear

### DIFF
--- a/modular_doppler/reagent_forging/code/forge_weapons.dm
+++ b/modular_doppler/reagent_forging/code/forge_weapons.dm
@@ -123,7 +123,7 @@
 	attack_verb_simple = list("attack", "poke", "jab", "tear", "lacerate", "gore")
 	wound_bonus = -15
 	bare_wound_bonus = 15
-	reach = 2
+	block_chance = 10
 	sharpness = SHARP_EDGED
 
 /datum/embedding/forged_spear


### PR DESCRIPTION
## About The Pull Request

reduces the spear's reach from 2 tiles to 1 tile, because it was able to hit across z levels, which is pretty bonkers. in exchange it has a 10% block chance. given that it has among the highest damage of a forge weapon at 23, at the cost of not being stackable with a buckler in this mode, it seemed like a decent balance choice.

## Why It's Good For The Game

2 tile reach is kind of busted as is but being able to hit across z levels with relatively impunity against everyone but another spear wielder is a bit goofy. arguably reach shouldn't hit across zs in the first place but its inherited tg behavior and thus way harder to work around