### PR TITLE
Reverses the mouse actions on the security sheathe

### DIFF
--- a/modular_doppler/modular_weapons/code/sec_swords/sheath.dm
+++ b/modular_doppler/modular_weapons/code/sec_swords/sheath.dm
@@ -46,7 +46,7 @@
 	if(length(contents))
 		. += span_notice("<b>Left Click</b> to draw a stored blade, <b>Right Click</b> to draw a stored baton while wearing.")
 
-/obj/item/storage/belt/secsword/attack_hand(mob/user, list/modifiers)
+/obj/item/storage/belt/secsword/attack_hand_secondary(mob/user, list/modifiers)
 	if(!(user.get_slot_by_item(src) & ITEM_SLOT_BELT) && !(user.get_slot_by_item(src) & ITEM_SLOT_BACK) && !(user.get_slot_by_item(src) & ITEM_SLOT_SUITSTORE))
 		return ..()
 	for(var/obj/item/melee/secblade/blade_runner in contents)
@@ -54,10 +54,10 @@
 		user.put_in_hands(blade_runner)
 		playsound(user, 'sound/items/sheath.ogg', 50, TRUE)
 		update_appearance()
-		return
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 	return ..()
 
-/obj/item/storage/belt/secsword/attack_hand_secondary(mob/user, list/modifiers)
+/obj/item/storage/belt/secsword/attack_hand(mob/user, list/modifiers)
 	if(!(user.get_slot_by_item(src) & ITEM_SLOT_BELT) && !(user.get_slot_by_item(src) & ITEM_SLOT_BACK) && !(user.get_slot_by_item(src) & ITEM_SLOT_SUITSTORE))
 		return ..()
 	for(var/obj/item/melee/baton/doppler_security/simply_shocking in contents)
@@ -65,7 +65,7 @@
 		user.put_in_hands(simply_shocking)
 		playsound(user, 'sound/items/sheath.ogg', 50, TRUE)
 		update_appearance()
-		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+		return
 	return ..()
 
 /obj/item/storage/belt/secsword/update_icon_state()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Simply swaps attack_hand vs attack_hand_secondary for the sec sheathe. And the return values because secondary clicks runtime if you don't play nicely with them.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
When I play sec, and I suddenly need to draw a weapon, i click on the sheathe. I go sicko mode and suddenly IM the bad guy

Minor change. Isn't about to solve everyone's issues. But I think we'd (or I'd) benefit from the kneejerk reaction being the less-lethal option
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: swapped the primary and secondary click functions for the sec sheathe
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
