### PR TITLE
Organic Rations Printer synthesized seeds passover

### DIFF
--- a/modular_doppler/colony_fabricator/code/design_datums/rations_printer_designs/seeds.dm
+++ b/modular_doppler/colony_fabricator/code/design_datums/rations_printer_designs/seeds.dm
@@ -53,12 +53,12 @@
 		RND_CATEGORY_AKHTER_SEEDS,
 	)
 
-/datum/design/organic_oat_seed
-	name = "Oat Seed Pack"
-	id = "oganic_oat_seed"
+/datum/design/organic_wheat_seed
+	name = "Wheat Seed Pack"
+	id = "oganic_wheat_seed"
 	build_type = BIOGENERATOR
 	materials = list(/datum/material/biomass = 25)
-	build_path = /obj/item/seeds/wheat/oat
+	build_path = /obj/item/seeds/wheat
 	category = list(
 		RND_CATEGORY_INITIAL,
 		RND_CATEGORY_AKHTER_SEEDS,
@@ -81,6 +81,39 @@
 	build_type = BIOGENERATOR
 	materials = list(/datum/material/biomass = 25)
 	build_path = /obj/item/seeds/plump
+	category = list(
+		RND_CATEGORY_INITIAL,
+		RND_CATEGORY_AKHTER_SEEDS,
+	)
+
+/datum/design/organic_towercap_seed
+	name = "Tower-cap Seed Pack"
+	id = "oganic_towercap_seed"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass = 25)
+	build_path = /obj/item/seeds/tower
+	category = list(
+		RND_CATEGORY_INITIAL,
+		RND_CATEGORY_AKHTER_SEEDS,
+	)
+
+/datum/design/organic_tobacco_seed
+	name = "Tobacco Seed Pack"
+	id = "oganic_tobacco_seed"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass = 25)
+	build_path = /obj/item/seeds/tobacco
+	category = list(
+		RND_CATEGORY_INITIAL,
+		RND_CATEGORY_AKHTER_SEEDS,
+	)
+
+/datum/design/organic_ambrosia_seed
+	name = "Ambrosia Vulgaris Seed Pack"
+	id = "oganic_ambrosia_seed"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass = 25)
+	build_path = /obj/item/seeds/ambrosia
 	category = list(
 		RND_CATEGORY_INITIAL,
 		RND_CATEGORY_AKHTER_SEEDS,


### PR DESCRIPTION
## About The Pull Request

![image](https://github.com/user-attachments/assets/fa8cef91-4bc9-462d-80b7-a36848e7d02e)

Oat Seeds are replaced with Wheat Seeds.
Tower-caps, tobacco and ambrosia vulgaris are added to the printable list.

## Why It's Good For The Game

Even as much as my celiac ass hates to admit it, wheat is kind of an essential plant, and oats mutate from it anyways.
Tower-caps are downright necessary in a colonization scenario, with quite a few things expecting you to be able to produce wood. Considering this is pretty much the only source of these for a colony aside from random luck with weed rolls, yeah...
Ambrosia vulgaris can be grinded down for drugs, toxin and most importantly, Libital and Aiuri, allowing for a semi-primitive way of producing medicine in a colony. It can also be mutated into the safer Ambrosia Deus, which contains omnizine and no inherent toxin.
Tobacco... Is honestly just here as a fun joke more than anything. Sure, smokers need it but honestly it's really just here because it's funny to see Tobacco be considered an essential seed for colonies to grow.

## Changelog

:cl:
balance: The organic rations printer can no longer print oat seeds, but tower-caps, wheat, tobacco and ambrosia vulgaris have been added to the printables list.
/:cl:
