### PR TITLE
Shuttle Ore Scoops now have a weighted list and also work more than once.

### DIFF
--- a/modular_doppler/shuttle_gear/code/ore_scoop.dm
+++ b/modular_doppler/shuttle_gear/code/ore_scoop.dm
@@ -19,14 +19,14 @@
 	var/callback_tracker
 	/// Weighted list of the ores we can spawn
 	var/list/mineral_breakdown = list(
-		/datum/material/iron = 1,
-		/datum/material/glass = 1,
-		/datum/material/plasma = 1,
-		/datum/material/titanium = 1,
-		/datum/material/silver = 1,
-		/datum/material/gold = 1,
+		/datum/material/iron = 5,
+		/datum/material/glass = 5,
+		/datum/material/titanium = 5,
+		/datum/material/silver = 3,
+		/datum/material/gold = 3,
+		/datum/material/plasma = 2,
+		/datum/material/uranium = 2,
 		/datum/material/diamond = 1,
-		/datum/material/uranium = 1,
 		/datum/material/bluespace = 1,
 		/datum/material/plastic = 1,
 	)
@@ -147,5 +147,6 @@
 		flying = FALSE
 		if(callback_tracker)
 			deltimer(callback_tracker)
+			callback_tracker = null
 
 #undef MINERALS_PER_BOULDER


### PR DESCRIPTION
## About The Pull Request

Shuttle ore scoops now have a weighted list. This was already supported but for some reason all the ores were set to one. You're now more likely to get more common materials like iron and glass, with more weighting given to titanium because of it's use in shuttle construction.

<details>
<summary>The weighted list in question.</summary>
  
- Iron: 5
- Glass: 5
- Titanium: 5
- Silver: 3
- Gold: 3
- Plasma: 2
- Uranium: 2
- Diamond: 1
- Bluespace: 1
- Plastic: 1
</details>

This PR also fixes shuttle ore scoops only working once and then breaking forever after flying more than once.

## Why It's Good For The Game

You're much more likely to use iron and glass than diamonds or bluespace. And bugs being fixed is good.

## Changelog

:cl:
balance: Shuttle ore scoops are now weighted in which ores they produce.
fix: Shuttle ore scoops no longer break after flying once.
/:cl: