### PR TITLE
DIY large shuttle gets a powered driver, DIY small shuttle size fix.

### DIFF
--- a/_maps/shuttles/~doppler_shuttles/diy_diy_large.dmm
+++ b/_maps/shuttles/~doppler_shuttles/diy_diy_large.dmm
@@ -721,6 +721,7 @@
 /obj/machinery/light/cold/directional/north,
 /obj/machinery/light_switch/directional/north,
 /obj/item/circuitboard/machine/techfab,
+/obj/item/screwdriver/omni_drill,
 /turf/open/floor/iron/dark/smooth_large,
 /area/shuttle/personally_bought/do_it_yourself_large)
 "Rf" = (

--- a/modular_doppler/ships_r_us/code/shuttle_templates/incomplete.dm
+++ b/modular_doppler/ships_r_us/code/shuttle_templates/incomplete.dm
@@ -12,7 +12,7 @@
 	credit_cost = CARGO_CRATE_VALUE * 6
 	suffix = "diy_small"
 	width = 15
-	height = 11
+	height = 7
 	personal_shuttle_size = PERSONAL_SHIP_SMALL
 
 /area/shuttle/personally_bought/do_it_yourself_small


### PR DESCRIPTION
## About The Pull Request

The DIY large shuttle gets a powered driver, and a small bug with the DIY small shuttle's size incorrectly using the size of the medium shuttle is fixed.

## Why It's Good For The Game

So the DIY large shuttle's whole thing is being quite self-sufficient, after all, it's _do-it-yourself_, and unlike the small one there's a colony fabricator, circuit imprinter and techfab. You're obviously meant to be able to do things yourself... But because the colony fabricator can't make basic wrenches or screwdrivers and the techfab comes in circuit board format, you can't actually set up until you pilfer a wrench and screwdriver from somewhere else. The medium shuttle doesn't run into this issue because it has a pre-built autolathe, so no changes there. I just made it a powered driver instead of screwdriver+wrench because it fits the colony theme.

as for the small shuttle's size, bugs bad

## Changelog

:cl:
balance: The large DIY shuttle now has a powered driver to enable self-sufficiency.
/:cl: