### PR TITLE
[NONMODULAR] When she told me WE should port this she meant YOU should port this (Ethereal changes)

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -466,7 +466,7 @@
 #define DOOR_CRUSH_DAMAGE 15 //the amount of damage that airlocks deal when they crush you
 
 #define HUNGER_FACTOR 0.05 //factor at which mob nutrition decreases
-#define ETHEREAL_DISCHARGE_RATE (1e-3 * STANDARD_ETHEREAL_CHARGE / 2) // Rate at which ethereal stomach charge decreases. DOPPLER EDIT ORIGINAL: ETHEREAL_DISCHARGE_RATE (1e-3 * STANDARD_ETHEREAL_CHARGE)
+#define ETHEREAL_DISCHARGE_RATE (1e-3 * STANDARD_ETHEREAL_CHARGE * 0.75) // Rate at which ethereal stomach charge decreases. DOPPLER EDIT ORIGINAL: ETHEREAL_DISCHARGE_RATE (1e-3 * STANDARD_ETHEREAL_CHARGE)
 /// How much nutrition eating clothes as moth gives and drains
 #define CLOTHING_NUTRITION_GAIN 15
 #define REAGENTS_METABOLISM 0.2 //How many units of reagent are consumed per second, by default.

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -466,7 +466,7 @@
 #define DOOR_CRUSH_DAMAGE 15 //the amount of damage that airlocks deal when they crush you
 
 #define HUNGER_FACTOR 0.05 //factor at which mob nutrition decreases
-#define ETHEREAL_DISCHARGE_RATE (1e-3 * STANDARD_ETHEREAL_CHARGE) // Rate at which ethereal stomach charge decreases
+#define ETHEREAL_DISCHARGE_RATE (1e-3 * STANDARD_ETHEREAL_CHARGE / 2) // Rate at which ethereal stomach charge decreases. DOPPLER EDIT ORIGINAL: ETHEREAL_DISCHARGE_RATE (1e-3 * STANDARD_ETHEREAL_CHARGE)
 /// How much nutrition eating clothes as moth gives and drains
 #define CLOTHING_NUTRITION_GAIN 15
 #define REAGENTS_METABOLISM 0.2 //How many units of reagent are consumed per second, by default.

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -219,7 +219,8 @@
 #define TRAUMA_RESILIENCE_LOBOTOMY 3 //Curable with lobotomy
 #define TRAUMA_RESILIENCE_WOUND 4 //Curable by healing the head wound
 #define TRAUMA_RESILIENCE_MAGIC 5 //Curable only with magic
-#define TRAUMA_RESILIENCE_ABSOLUTE 6 //This is here to stay
+#define TRAUMA_RESILIENCE_ETHEREAL 6 //DOPPLER ADDITION FOR ETHEREAL REWORK
+#define TRAUMA_RESILIENCE_ABSOLUTE 7 //DOPPLER EDIT: 6 -> 7
 
 //Limit of traumas for each resilience tier
 #define TRAUMA_LIMIT_BASIC 3

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -265,6 +265,8 @@
 				trauma_desc = conditional_tooltip("Deep-rooted ", "Repair via Lobotomy.", add_tooltips)
 			if(TRAUMA_RESILIENCE_WOUND)
 				trauma_desc = conditional_tooltip("Fracture-derived ", "Repair via treatment of wounds afflicting the head.", add_tooltips)
+			if(TRAUMA_RESILIENCE_ETHEREAL) //DOPPLER ADDITION
+				trauma_desc = conditional_tooltip("Ethereal ", "Result of Crystalline Regeneration, repair one per brain surgery.", add_tooltips) //DOPPLER ADDITION
 			if(TRAUMA_RESILIENCE_MAGIC, TRAUMA_RESILIENCE_ABSOLUTE)
 				trauma_desc = conditional_tooltip("Permanent ", "Irreparable under normal circumstances.", add_tooltips)
 		trauma_desc += capitalize(trauma.scan_desc)

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -68,6 +68,8 @@
 		if(limb.limb_id == SPECIES_ETHEREAL)
 			limb.update_limb(is_creating = TRUE)
 
+	new_ethereal.dna.add_mutation(/datum/mutation/human/shock, MUT_NORMAL) //DOPPLER EDIT ADDITION
+
 /datum/species/ethereal/on_species_loss(mob/living/carbon/human/former_ethereal, datum/species/new_species, pref_load)
 	UnregisterSignal(former_ethereal, list(
 		COMSIG_ATOM_EMAG_ACT,
@@ -77,6 +79,7 @@
 		COMSIG_LIVING_HEALTH_UPDATE,
 	))
 	QDEL_NULL(ethereal_light)
+	former_ethereal.dna.remove_mutation(/datum/mutation/human/shock) //DOPPLER EDIT ADDITION
 	return ..()
 
 /datum/species/ethereal/randomize_features()

--- a/code/modules/power/apc/apc_attack.dm
+++ b/code/modules/power/apc/apc_attack.dm
@@ -43,11 +43,13 @@
 	// Ethereals can't drain APCs under half charge, so that they are forced to look to alternative power sources if the station is running low
 	if(cell.charge() < half_max_charge)
 		addtimer(CALLBACK(src, TYPE_PROC_REF(/atom, balloon_alert), user, "safeties prevent draining!"), ETHEREAL_APC_ALERT_DELAY)
+		user.visible_message(span_notice("[src] displays a red X, sealing ports as 'safeties enabled' flashes across the screen!")) //DOPPLER EDIT ADDITION
 		return
 
 	var/obj/item/stock_parts/power_store/stomach_cell = used_stomach.cell
 	used_stomach.drain_time = world.time + ETHEREAL_APC_DRAIN_TIME
 	addtimer(CALLBACK(src, TYPE_PROC_REF(/atom, balloon_alert), user, "draining power..."), ETHEREAL_APC_ALERT_DELAY)
+	user.visible_message(span_notice("[user] presses their fingers into [src]'s screen, static jumping up [user.p_their()] arm as they drain it!")) //DOPPLER EDIT ADDITION
 	while(do_after(user, ETHEREAL_APC_DRAIN_TIME, target = src))
 		if(isnull(used_stomach) || (used_stomach != user.get_organ_slot(ORGAN_SLOT_STOMACH)))
 			balloon_alert(user, "stomach removed!?")
@@ -59,6 +61,7 @@
 			balloon_alert(user, "safeties kicked in!")
 			return
 
+		to_chat(user, span_purple("You try to drain some of [src]'s energy into yourself...")) //DOPPLER EDIT ADDITION
 		var/our_available_charge = cell.charge() - half_max_charge
 		var/stomach_used_charge = stomach_cell.used_charge()
 		var/potential_charge = min(our_available_charge, stomach_used_charge)

--- a/code/modules/surgery/brain_surgery.dm
+++ b/code/modules/surgery/brain_surgery.dm
@@ -71,6 +71,7 @@
 		target.mind.remove_antag_datum(/datum/antagonist/brainwashed)
 	target.setOrganLoss(ORGAN_SLOT_BRAIN, target.get_organ_loss(ORGAN_SLOT_BRAIN) - 50) //we set damage in this case in order to clear the "failing" flag
 	target.cure_all_traumas(TRAUMA_RESILIENCE_SURGERY)
+	target.cure_trauma_type(/datum/brain_trauma, TRAUMA_RESILIENCE_ETHEREAL) //DOPPLER ADDITION
 	if(target.get_organ_loss(ORGAN_SLOT_BRAIN) > 0)
 		to_chat(user, "[target]'s brain looks like it could be fixed further.")
 	return ..()

--- a/code/modules/surgery/organs/internal/heart/heart_ethereal.dm
+++ b/code/modules/surgery/organs/internal/heart/heart_ethereal.dm
@@ -228,14 +228,13 @@
 
 	playsound(get_turf(regenerating), 'sound/mobs/humanoids/ethereal/ethereal_revive.ogg', 100)
 	to_chat(regenerating, span_notice("You burst out of the crystal with vigour... </span><span class='userdanger'>But at a cost."))
-	regenerating.revive(HEAL_ALL & ~HEAL_REFRESH_ORGANS & ~HEAL_TRAUMAS) //Doppler Edit: (Adds ~HEAL_TRAUMAS) Ethereal regeneration no longer cures traumas.
-
+	regenerating.revive(HEAL_ALL & ~HEAL_REFRESH_ORGANS)
 	regenerating.apply_status_effect(/datum/status_effect/vulnerable_to_damage) //DOPPLER EDIT ADDITION
 
 	if(prob(10)) //10% chance for a severe trauma
-		regenerating.gain_trauma_type(BRAIN_TRAUMA_SEVERE, TRAUMA_RESILIENCE_SURGERY) //DOPPLER EDIT: TRAUMA_RESILICENCE_ABSOLUTE -> TRAUMA_RESILIENCE_SURGERY
+		regenerating.gain_trauma_type(BRAIN_TRAUMA_SEVERE, TRAUMA_RESILIENCE_ETHEREAL) //DOPPLER EDIT: TRAUMA_RESILICENCE_ABSOLUTE -> TRAUMA_RESILIENCE_SURGERY
 	else
-		regenerating.gain_trauma_type(BRAIN_TRAUMA_MILD, TRAUMA_RESILIENCE_SURGERY) //DOPPLER EDIT: TRAUMA_RESILICENCE_ABSOLUTE -> TRAUMA_RESILIENCE_SURGERY
+		regenerating.gain_trauma_type(BRAIN_TRAUMA_MILD, TRAUMA_RESILIENCE_ETHEREAL) //DOPPLER EDIT: TRAUMA_RESILICENCE_ABSOLUTE -> TRAUMA_RESILIENCE_SURGERY
 
 	// revive calls fully heal -> deletes the crystal.
 	// this qdeleted check is just for sanity.

--- a/code/modules/surgery/organs/internal/heart/heart_ethereal.dm
+++ b/code/modules/surgery/organs/internal/heart/heart_ethereal.dm
@@ -228,7 +228,7 @@
 
 	playsound(get_turf(regenerating), 'sound/mobs/humanoids/ethereal/ethereal_revive.ogg', 100)
 	to_chat(regenerating, span_notice("You burst out of the crystal with vigour... </span><span class='userdanger'>But at a cost."))
-	regenerating.revive(HEAL_ALL & ~HEAL_REFRESH_ORGANS)
+	regenerating.revive(HEAL_ALL & ~HEAL_REFRESH_ORGANS & ~HEAL_TRAUMAS) //Doppler Edit: (Adds ~HEAL_TRAUMAS) Ethereal regeneration no longer cures traumas.
 
 	regenerating.apply_status_effect(/datum/status_effect/vulnerable_to_damage) //DOPPLER EDIT ADDITION
 

--- a/code/modules/surgery/organs/internal/heart/heart_ethereal.dm
+++ b/code/modules/surgery/organs/internal/heart/heart_ethereal.dm
@@ -230,10 +230,12 @@
 	to_chat(regenerating, span_notice("You burst out of the crystal with vigour... </span><span class='userdanger'>But at a cost."))
 	regenerating.revive(HEAL_ALL & ~HEAL_REFRESH_ORGANS)
 
+	regenerating.apply_status_effect(/datum/status_effect/vulnerable_to_damage) //DOPPLER EDIT ADDITION
+
 	if(prob(10)) //10% chance for a severe trauma
-		regenerating.gain_trauma_type(BRAIN_TRAUMA_SEVERE, TRAUMA_RESILIENCE_ABSOLUTE)
+		regenerating.gain_trauma_type(BRAIN_TRAUMA_SEVERE, TRAUMA_RESILIENCE_SURGERY) //DOPPLER EDIT: TRAUMA_RESILICENCE_ABSOLUTE -> TRAUMA_RESILIENCE_SURGERY
 	else
-		regenerating.gain_trauma_type(BRAIN_TRAUMA_MILD, TRAUMA_RESILIENCE_ABSOLUTE)
+		regenerating.gain_trauma_type(BRAIN_TRAUMA_MILD, TRAUMA_RESILIENCE_SURGERY) //DOPPLER EDIT: TRAUMA_RESILICENCE_ABSOLUTE -> TRAUMA_RESILIENCE_SURGERY
 
 	// revive calls fully heal -> deletes the crystal.
 	// this qdeleted check is just for sanity.

--- a/code/modules/unit_tests/ethereal_revival.dm
+++ b/code/modules/unit_tests/ethereal_revival.dm
@@ -26,8 +26,7 @@
 	instant_crystallise(victim, respawn_heart)
 	TEST_ASSERT_NULL(respawn_heart.current_crystal, "Ethereal crystallised while heart was on cooldown.")
 
-	//Doppler Removal. We're not testing for this anymore and it fucks with counting.
-	//victim.gain_trauma(/datum/brain_trauma/special/ptsd, resilience = TRAUMA_RESILIENCE_BASIC) // One you can't gain via revival
+	victim.gain_trauma(/datum/brain_trauma/special/ptsd, resilience = TRAUMA_RESILIENCE_BASIC) // One you can't gain via revival
 	var/obj/item/bodypart/leg/left_leg = victim.get_bodypart(BODY_ZONE_L_LEG)
 	left_leg.dismember()
 	var/obj/item/bodypart/leg/right_leg = victim.get_bodypart(BODY_ZONE_R_LEG)
@@ -39,8 +38,7 @@
 	TEST_ASSERT_NOTNULL(victim.get_bodypart(BODY_ZONE_L_LEG), "Ethereal failed to regrow limb when reviving.")
 	TEST_ASSERT(!length(right_leg.wounds), "Ethereal failed to fix wound when reviving.")
 	var/list/current_traumas = victim.get_traumas()
-	//Doppler Removal Ethereals no longer heal any brain damage on regeneration.
-	//TEST_ASSERT(!(locate(/datum/brain_trauma/special/ptsd) in current_traumas), "Ethereal failed to heal curable brain trauma when reviving.")
+	TEST_ASSERT(!(locate(/datum/brain_trauma/special/ptsd) in current_traumas), "Ethereal failed to heal curable brain trauma when reviving.")
 	TEST_ASSERT(length(current_traumas) == 1, "Ethereal failed to gain trauma when reviving.")
 
 	kill_and_revive(victim, respawn_heart)

--- a/code/modules/unit_tests/ethereal_revival.dm
+++ b/code/modules/unit_tests/ethereal_revival.dm
@@ -38,7 +38,8 @@
 	TEST_ASSERT_NOTNULL(victim.get_bodypart(BODY_ZONE_L_LEG), "Ethereal failed to regrow limb when reviving.")
 	TEST_ASSERT(!length(right_leg.wounds), "Ethereal failed to fix wound when reviving.")
 	var/list/current_traumas = victim.get_traumas()
-	TEST_ASSERT(!(locate(/datum/brain_trauma/special/ptsd) in current_traumas), "Ethereal failed to heal curable brain trauma when reviving.")
+	//Doppler Removal Ethereals no longer heal any brain damage on regeneration.
+	//TEST_ASSERT(!(locate(/datum/brain_trauma/special/ptsd) in current_traumas), "Ethereal failed to heal curable brain trauma when reviving.")
 	TEST_ASSERT(length(current_traumas) == 1, "Ethereal failed to gain trauma when reviving.")
 
 	kill_and_revive(victim, respawn_heart)

--- a/code/modules/unit_tests/ethereal_revival.dm
+++ b/code/modules/unit_tests/ethereal_revival.dm
@@ -26,7 +26,8 @@
 	instant_crystallise(victim, respawn_heart)
 	TEST_ASSERT_NULL(respawn_heart.current_crystal, "Ethereal crystallised while heart was on cooldown.")
 
-	victim.gain_trauma(/datum/brain_trauma/special/ptsd, resilience = TRAUMA_RESILIENCE_BASIC) // One you can't gain via revival
+	//Doppler Removal. We're not testing for this anymore and it fucks with counting.
+	//victim.gain_trauma(/datum/brain_trauma/special/ptsd, resilience = TRAUMA_RESILIENCE_BASIC) // One you can't gain via revival
 	var/obj/item/bodypart/leg/left_leg = victim.get_bodypart(BODY_ZONE_L_LEG)
 	left_leg.dismember()
 	var/obj/item/bodypart/leg/right_leg = victim.get_bodypart(BODY_ZONE_R_LEG)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. Lowers Ethereal hunger rate by 25%
2. Adds some messages to draining from an APC for more user feedback
3. Regenerating Ethereals gain traumas that can be cured with surgery instead of permanent ones.
4. Ethereals are vulnerable to damage after regenerating.
5. Ethereals are immune to shocks entirely, tiders rejoice
6. You no longer take toxins damage from being fully charged. (But still from dangerously overcharged)
7. You heal a little bit of toxins if you're in the perfect charge range.
8. Some extra visual indicators for an Ethereal being dangerously overcharged

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I'd like to sit for more than five minutes during psych RP without starving to death mainly. The rest of the perks are from what Juni asked me to port.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Ethereal changes more suitable for an HRP environment
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
