### PR TITLE
more NT lore renaming and also synthroach fix, oops

### DIFF
--- a/code/modules/mob/living/basic/vermin/cockroach.dm
+++ b/code/modules/mob/living/basic/vermin/cockroach.dm
@@ -163,12 +163,17 @@
 		squash_callback = TYPE_PROC_REF(/mob/living/basic/cockroach/hauberoach, on_squish), \
 	)
 
+//NONMODULAR DOPPLER EDIT START
 ///Proc used to override the squashing behavior of the normal cockroach.
 /mob/living/basic/cockroach/hauberoach/proc/on_squish(mob/living/cockroach, mob/living/living_target)
 	if(!istype(living_target))
 		return FALSE //We failed to run the invoke. Might be because we're a structure. Let the squashable element handle it then!
+	if(living_target.mob_size <= MOB_SIZE_SMALL)
+		return FALSE
+	if(living_target.movement_type & MOVETYPES_NOT_TOUCHING_GROUND)
+		return FALSE
 
-//NONMODULAR DOPPLER EDIT START
+
 	switch(rand(1,2))
 		if(1)
 			explosion(src, light_impact_range = 2, flame_range = 1)

--- a/modular_doppler/modular_mobs/simple_animal/cockroach.dm
+++ b/modular_doppler/modular_mobs/simple_animal/cockroach.dm
@@ -10,6 +10,9 @@
 	icon_state = "synthroach"
 	icon_dead = "synthroach_no_animation"
 
+/mob/living/basic/cockroach/glockroach() //have to do this for some reason
+	return FALSE
+
 /mob/living/basic/cockroach/hauberoach
 	name = "spikeroach"
 	desc = "Synthroach. Sacrificial idiot. Practically trying to run under your boots. Beeps ominously. Its entire body is a crumple zone containing very fun mixtures of small-scale ordinance. Feels, generally, like a bad idea."
@@ -17,8 +20,14 @@
 	icon_state = "spikeroach"
 	icon_dead = "synthroach_no_animation"
 
+/mob/living/basic/cockroach/hauberoach() //have to do this for some reason
+	return FALSE
+
 /mob/living/basic/cockroach/glockroach/mobroach
 	name = "gunroach"
 	desc = "Primordial biosynth-weaponry trapped in a cylinder of frenetically-firing silicon tetrachlorides. Purposeless once-weapon for a battle that ended a long time ago. No reparations were paid to it. More pressingly; literally frothing at the mouth to shoot you."
 	icon = 'modular_doppler/modular_mobs/simple_animal/synthroach.dmi'
 	icon_state = "gunroach"
+
+/mob/living/basic/cockroach/mobroach() //have to do this for some reason
+	return FALSE

--- a/modular_doppler/modular_mobs/simple_animal/cockroach.dm
+++ b/modular_doppler/modular_mobs/simple_animal/cockroach.dm
@@ -10,7 +10,8 @@
 	icon_state = "synthroach"
 	icon_dead = "synthroach_no_animation"
 
-/mob/living/basic/cockroach/glockroach/emp_act() //emp's were killing them for some reason i just can not explain. idfk.
+/mob/living/basic/cockroach/glockroach/emp_act(severity) //emp's were killing them for some reason i just can not explain. idfk.
+	. = ..()
 	return FALSE
 
 /mob/living/basic/cockroach/hauberoach
@@ -20,7 +21,8 @@
 	icon_state = "spikeroach"
 	icon_dead = "synthroach_no_animation"
 
-/mob/living/basic/cockroach/hauberoach/emp_act()
+/mob/living/basic/cockroach/hauberoach/emp_act(severity)
+	. = ..()
 	return FALSE
 
 /mob/living/basic/cockroach/glockroach/mobroach
@@ -29,5 +31,6 @@
 	icon = 'modular_doppler/modular_mobs/simple_animal/synthroach.dmi'
 	icon_state = "gunroach"
 
-/mob/living/basic/cockroach/glockroach/mobroach/emp_act()
+/mob/living/basic/cockroach/glockroach/mobroach/emp_act(severity)
+	. = ..()
 	return FALSE

--- a/modular_doppler/modular_mobs/simple_animal/cockroach.dm
+++ b/modular_doppler/modular_mobs/simple_animal/cockroach.dm
@@ -10,7 +10,7 @@
 	icon_state = "synthroach"
 	icon_dead = "synthroach_no_animation"
 
-/mob/living/basic/cockroach/glockroach() //have to do this for some reason
+/mob/living/basic/cockroach/glockroach/emp_act() //emp's were killing them for some reason i just can not explain. idfk.
 	return FALSE
 
 /mob/living/basic/cockroach/hauberoach
@@ -20,7 +20,7 @@
 	icon_state = "spikeroach"
 	icon_dead = "synthroach_no_animation"
 
-/mob/living/basic/cockroach/hauberoach() //have to do this for some reason
+/mob/living/basic/cockroach/hauberoach/emp_act()
 	return FALSE
 
 /mob/living/basic/cockroach/glockroach/mobroach
@@ -29,5 +29,5 @@
 	icon = 'modular_doppler/modular_mobs/simple_animal/synthroach.dmi'
 	icon_state = "gunroach"
 
-/mob/living/basic/cockroach/mobroach() //have to do this for some reason
+/mob/living/basic/cockroach/glockroach/mobroach/emp_act()
 	return FALSE

--- a/modular_doppler/z_lore_rename.dm
+++ b/modular_doppler/z_lore_rename.dm
@@ -55,6 +55,14 @@
 	name = "Grog"
 	description = "Watered-down rum, scallywag approved!"
 
+/obj/machinery/icecream_vat
+	name = "ice cream vat"
+	desc = "Ding-aling ding dong. Get your 4CA-approved ice cream! Has helpful nutritional detail stickers. Shockingly: contains sugar and dairy!"
+
+/obj/item/flashlight/flare
+	name = "flare"
+	desc = "A red flare. There are instructions on the side: 'pull cord, make light'. This is repeated in roughly ten languages, and there are helpful pictures to go with it."
+
 //antag stuff
 
 /obj/effect/mob_spawn/ghost_role/human/lavaland_syndicate/comms/icemoon
@@ -152,10 +160,8 @@
 	desc = "An old, but reliable laser-gun pattern that's old enough to drink. Suffers from ammo issues but its unique ability to recharge its ammo without the need of a magazine helps compensate. Can probably drop it in a vat of acid and it'll keep working."
 
 /mob/living/basic/mining_drone
-	name = "\improper Nanotrasen minebot"
-	desc = "The instructions printed on the side read: This is a small robot used to support miners, can be set to search and collect loose ore, or to help fend off wildlife."
-
-
+	name = "\improper Port Authority minebot"
+	desc = "An old, but rugged design, based off of open-source software. Reassuring. The instructions printed on the side read: This is a small robot used to support miners, can be set to search and collect loose ore, or to help fend off wildlife."
 
 /obj/item/clothing/under/rank/security/officer
 	name = "security uniform"
@@ -185,6 +191,21 @@
 	name = "prison jumpskirt"
 	desc = "Standardised 4CA prisoner-wear. Has an ID tag at the back. Its suit sensors are stuck in the \"Fully On\" position."
 
+/obj/item/clothing/accessory/pride
+	name = "pride pin"
+	desc = "A holographic pin to show off your pride. Futuristic!"
+
 /obj/item/skeleton_key
 	name = "skeleton key"
 	desc = "An artifact usually found in the hands of the natives of the planet below, which the 4CA is benevolently advancing!"
+
+// MOBS
+
+/mob/living/basic/carp/pet/lia
+	name = "Lia"
+	real_name = "Lia"
+	desc = "A failed experiment of the 4CA Void Corps to create weaponised carp technology. This less than intimidating carp now serves as the Head of Security's pet."
+
+/mob/living/basic/spider/maintenance
+	name = "duct spider"
+	desc = "Near-universal pests; poor biosecurity and nonexistent invasive species prevention on the 4CA's part has led to these pests infesting nearly every modern ship and station."


### PR DESCRIPTION
## About The Pull Request

more NT lore renaming in modular folder. hauberoaches were squashing and detonating each other. oops! fixed.

## Why It's Good For The Game

TECHNICALLY synthroaches ARE lore so it's an atomized PR

## Changelog

:cl:
add: more NT renames
fix: stopped spikeroaches from getting too excited
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
