### PR TITLE
Back at it Again

### DIFF
--- a/_maps/map_files/Pubbystation/pubbystation.dmm
+++ b/_maps/map_files/Pubbystation/pubbystation.dmm
@@ -2136,7 +2136,8 @@
 /obj/machinery/light/directional/east,
 /obj/machinery/scanner_gate{
 	scangate_mode = "Warrant";
-	req_access = list("security")
+	req_access = list("security");
+	locked = 1
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
@@ -9180,7 +9181,8 @@
 	},
 /obj/machinery/scanner_gate{
 	scangate_mode = "Warrant";
-	req_access = list("security")
+	req_access = list("security");
+	locked = 1
 	},
 /turf/open/floor/iron/white/corner{
 	dir = 1
@@ -9373,7 +9375,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/scanner_gate{
 	scangate_mode = "Warrant";
-	req_access = list("security")
+	req_access = list("security");
+	locked = 1
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
@@ -12226,7 +12229,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/scanner_gate{
 	scangate_mode = "Warrant";
-	req_access = list("security")
+	req_access = list("security");
+	locked = 1
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
@@ -12725,7 +12729,8 @@
 	},
 /obj/machinery/scanner_gate{
 	scangate_mode = "Warrant";
-	req_access = list("security")
+	req_access = list("security");
+	locked = 1
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
@@ -12879,7 +12884,8 @@
 /obj/structure/sign/departments/security/directional/north,
 /obj/machinery/scanner_gate{
 	scangate_mode = "Warrant";
-	req_access = list("security")
+	req_access = list("security");
+	locked = 1
 	},
 /turf/open/floor/iron/white/corner{
 	dir = 1
@@ -13335,7 +13341,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/scanner_gate{
 	scangate_mode = "Warrant";
-	req_access = list("security")
+	req_access = list("security");
+	locked = 1
 	},
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/secondary/entry)
@@ -13416,7 +13423,8 @@
 /obj/effect/turf_decal/delivery/white,
 /obj/machinery/scanner_gate{
 	scangate_mode = "Warrant";
-	req_access = list("security")
+	req_access = list("security");
+	locked = 1
 	},
 /turf/open/floor/iron/dark,
 /area/station/commons/lounge)
@@ -20253,7 +20261,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/scanner_gate{
 	scangate_mode = "Warrant";
-	req_access = list("security")
+	req_access = list("security");
+	locked = 1
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
@@ -27566,11 +27575,12 @@
 /turf/open/floor/iron/dark,
 /area/station/service/library)
 "cAB" = (
-/obj/effect/turf_decal/tile/purple/half/contrasted{
-	dir = 1
+/obj/structure/sign/painting/library_private{
+	pixel_x = 32
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/station/service/library)
+/area/station/service/library/private)
 "cAC" = (
 /obj/structure/chair/wood/wings{
 	dir = 1
@@ -27587,21 +27597,12 @@
 /obj/structure/chair/wood/wings{
 	dir = 1
 	},
-/obj/effect/landmark/start/librarian,
 /turf/open/floor/iron/dark,
 /area/station/service/library)
 "cAH" = (
 /obj/machinery/light/small/directional/south,
 /obj/machinery/newscaster/directional/south,
 /obj/structure/table/wood,
-/obj/item/book/granter/crafting_recipe/boneyard_notes{
-	pixel_x = 6;
-	pixel_y = 0
-	},
-/obj/item/book/granter/crafting_recipe/fletching{
-	pixel_x = -8;
-	pixel_y = 0
-	},
 /turf/open/floor/iron/dark,
 /area/station/service/library)
 "cAI" = (
@@ -27625,9 +27626,8 @@
 /turf/open/space,
 /area/space/nearstation)
 "cAS" = (
-/obj/machinery/vending/wardrobe/curator_wardrobe,
-/turf/open/floor/iron/dark,
-/area/station/service/library)
+/turf/closed/wall/mineral/iron,
+/area/station/service/library/private)
 "cAT" = (
 /obj/effect/spawner/random/trash/crushed_can,
 /turf/open/floor/iron/white/smooth_large,
@@ -27637,7 +27637,6 @@
 	c_tag = "Monastery Archives Aft";
 	network = list("ss13","monastery")
 	},
-/obj/machinery/bookbinder,
 /turf/open/floor/iron/dark,
 /area/station/service/library)
 "cAV" = (
@@ -28927,8 +28926,12 @@
 /obj/structure/sign/painting/library_private{
 	pixel_x = -32
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/libraryscanner,
 /turf/open/floor/iron/dark,
-/area/station/service/library/artgallery)
+/area/station/service/library/private)
 "dDZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -29498,6 +29501,12 @@
 	desc = "It reads: PRIVATE EXHIBIT -  Please inquire with library staff for guided tours.";
 	name = "\improper Private Section Notice";
 	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/library/artgallery)
@@ -33126,8 +33135,11 @@
 /obj/structure/sign/painting/library_private{
 	pixel_x = 32
 	},
+/obj/machinery/modular_computer/preset/curator{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
-/area/station/service/library/artgallery)
+/area/station/service/library/private)
 "gXQ" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/electric_yellow{
@@ -36161,6 +36173,16 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal)
+"jCM" = (
+/obj/structure/sign/painting/library_private{
+	pixel_x = -32
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/bookbinder,
+/turf/open/floor/iron/dark,
+/area/station/service/library/private)
 "jDA" = (
 /obj/item/chair,
 /obj/effect/mapping_helpers/broken_floor,
@@ -36829,7 +36851,8 @@
 /obj/structure/cable,
 /obj/machinery/scanner_gate{
 	scangate_mode = "Warrant";
-	req_access = list("security")
+	req_access = list("security");
+	locked = 1
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
@@ -37787,6 +37810,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/commons/dorms)
+"kTR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/service/library/private)
 "kUj" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -37841,8 +37873,11 @@
 	pixel_x = 32
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
-/area/station/service/library/artgallery)
+/area/station/service/library/private)
 "kVN" = (
 /obj/effect/turf_decal/tile/pine_green,
 /obj/structure/cable,
@@ -41490,8 +41525,9 @@
 /obj/structure/sign/painting/library_private{
 	pixel_x = 32
 	},
+/obj/effect/landmark/start/librarian,
 /turf/open/floor/iron/dark,
-/area/station/service/library/artgallery)
+/area/station/service/library/private)
 "nWK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -44106,7 +44142,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/scanner_gate{
 	scangate_mode = "Warrant";
-	req_access = list("security")
+	req_access = list("security");
+	locked = 1
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
@@ -45769,12 +45806,18 @@
 /turf/open/floor/wood,
 /area/station/maintenance/department/engine)
 "reR" = (
-/obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb,
-/obj/item/camera,
+/obj/structure/table/wood,
+/obj/item/book/granter/crafting_recipe/fletching{
+	pixel_x = -8;
+	pixel_y = 0
+	},
+/obj/item/book/granter/crafting_recipe/boneyard_notes{
+	pixel_x = 6;
+	pixel_y = 0
+	},
 /turf/open/floor/iron/dark,
-/area/station/service/library/artgallery)
+/area/station/service/library/private)
 "reV" = (
 /obj/structure/table,
 /obj/structure/maintenance_loot_structure/toolbox/random,
@@ -45891,6 +45934,19 @@
 	},
 /turf/open/floor/iron/large,
 /area/station/engineering/lobby)
+"rlc" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/airlock/grunge{
+	name = "Library Office"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/library,
+/turf/open/floor/iron/dark,
+/area/station/service/library/private)
 "rle" = (
 /obj/structure/cable,
 /turf/open/floor/wood,
@@ -46936,6 +46992,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/carpet,
 /area/station/service/library/artgallery)
 "rVt" = (
@@ -47402,7 +47461,8 @@
 /obj/effect/turf_decal/delivery/white,
 /obj/machinery/scanner_gate{
 	scangate_mode = "Warrant";
-	req_access = list("security")
+	req_access = list("security");
+	locked = 1
 	},
 /turf/open/floor/iron/dark,
 /area/station/commons/lounge)
@@ -47478,7 +47538,8 @@
 /obj/structure/cable,
 /obj/machinery/scanner_gate{
 	scangate_mode = "Warrant";
-	req_access = list("security")
+	req_access = list("security");
+	locked = 1
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
@@ -47860,11 +47921,10 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/engineering/atmos)
 "sBW" = (
-/obj/structure/closet/crate/bin,
-/obj/item/reagent_containers/cup/rag,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/destructible/cult/item_dispenser/archives/library,
 /turf/open/floor/iron/dark,
-/area/station/service/library/artgallery)
+/area/station/service/library/private)
 "sBZ" = (
 /obj/effect/spawner/random/trash/food_packaging,
 /turf/open/floor/iron/dark,
@@ -49446,8 +49506,9 @@
 /obj/structure/sign/painting/library_private{
 	pixel_x = -32
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
-/area/station/service/library/artgallery)
+/area/station/service/library/private)
 "tGj" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -50885,11 +50946,21 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/lobby)
+"uHK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/service/library/artgallery)
 "uIb" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/scanner_gate{
 	scangate_mode = "Warrant";
-	req_access = list("security")
+	req_access = list("security");
+	locked = 1
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
@@ -50899,10 +50970,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "uIv" = (
-/obj/structure/bookcase/random/adult,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/wardrobe/curator_wardrobe,
 /turf/open/floor/iron/dark,
-/area/station/service/library/artgallery)
+/area/station/service/library/private)
 "uIR" = (
 /obj/structure/chair/stool/bar/directional/east,
 /turf/open/floor/plating,
@@ -51105,7 +51175,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/machinery/libraryscanner,
 /turf/open/floor/iron/dark,
 /area/station/service/library)
 "uUh" = (
@@ -51623,7 +51692,8 @@
 /obj/structure/cable,
 /obj/machinery/scanner_gate{
 	scangate_mode = "Warrant";
-	req_access = list("security")
+	req_access = list("security");
+	locked = 1
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
@@ -54446,7 +54516,8 @@
 	},
 /obj/machinery/scanner_gate{
 	scangate_mode = "Warrant";
-	req_access = list("security")
+	req_access = list("security");
+	locked = 1
 	},
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/secondary/exit/departure_lounge)
@@ -54554,7 +54625,8 @@
 /obj/structure/cable,
 /obj/machinery/scanner_gate{
 	scangate_mode = "Warrant";
-	req_access = list("security")
+	req_access = list("security");
+	locked = 1
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
@@ -55297,7 +55369,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/dim/directional/east,
 /turf/open/floor/iron/dark,
-/area/station/service/library/artgallery)
+/area/station/service/library/private)
 "xMS" = (
 /obj/machinery/door/window/left/directional/north{
 	name = "Conveyor Access";
@@ -70492,7 +70564,7 @@ mcy
 cAK
 xBB
 cAr
-cAB
+cAK
 cyU
 cjp
 aaa
@@ -71008,7 +71080,7 @@ xBB
 pGZ
 xBB
 syW
-cAS
+cAK
 cjp
 cyU
 cjp
@@ -72291,7 +72363,7 @@ czO
 ctZ
 iBp
 cAy
-cAB
+cAK
 cyU
 cjp
 aht
@@ -74066,7 +74138,7 @@ pIy
 voM
 fdN
 whJ
-roy
+uHK
 roy
 roy
 ndF
@@ -74575,14 +74647,14 @@ roy
 pYc
 roy
 gda
-whJ
-whJ
-whJ
-whJ
-whJ
-roy
-roy
-whJ
+cAS
+cAS
+cAS
+cAS
+cAS
+rlc
+cAS
+cAS
 whJ
 whJ
 whJ
@@ -74832,14 +74904,14 @@ fdN
 fdN
 fdN
 ndF
-whJ
+cAS
 reR
 tFt
+jCM
 dCh
-dCh
-roy
+kTR
 sBW
-whJ
+cAS
 cfN
 cfN
 cfN
@@ -75089,14 +75161,14 @@ gkQ
 gkQ
 gkQ
 xkB
-whJ
+cAS
 uIv
-kVM
+cAB
 nWF
 xMQ
 kVM
 gXh
-whJ
+cAS
 cfN
 aaa
 aaa
@@ -75346,14 +75418,14 @@ wIX
 wIX
 wIX
 wIX
-whJ
-whJ
-whJ
-whJ
-whJ
-whJ
-whJ
-whJ
+cAS
+cAS
+cAS
+cAS
+cAS
+cAS
+cAS
+cAS
 aaa
 aaa
 aaa
@@ -85623,7 +85695,7 @@ uVW
 nZX
 nZX
 nZX
-aht
+nZX
 aht
 aht
 fon
@@ -85878,9 +85950,9 @@ lWv
 lWv
 iow
 tSU
+eoo
 fhE
 nZX
-aht
 aaa
 aaa
 fon
@@ -86135,9 +86207,9 @@ jzi
 xsm
 wza
 lWv
+wza
 hCE
 nZX
-aaa
 bBW
 aaa
 aaa
@@ -86392,9 +86464,9 @@ uRk
 tqO
 wza
 lWv
+wza
 cCI
 cbj
-abI
 aaa
 aaa
 fon
@@ -86649,9 +86721,9 @@ uRk
 mZR
 uTI
 mfI
+wza
 sWj
 nZX
-abI
 aht
 aht
 fon
@@ -86906,9 +86978,9 @@ uRk
 uRk
 uRk
 slC
+wza
 sWj
 nZX
-abI
 aaa
 aaa
 fon
@@ -87163,9 +87235,9 @@ ciH
 ipH
 jOe
 dWO
+wza
 bhU
 nZX
-abI
 aht
 aht
 fon
@@ -87420,9 +87492,9 @@ uRk
 uRk
 uRk
 lvD
+wza
 sWj
 nZX
-aht
 aaa
 aaa
 fon
@@ -87677,9 +87749,9 @@ uRk
 sIq
 vRw
 jZV
+wza
 sWj
 nZX
-aaa
 aaa
 aaa
 aaa
@@ -87934,9 +88006,9 @@ uRk
 eqg
 dZj
 lWv
+wza
 cCI
 cbj
-aht
 aaa
 aaa
 fon
@@ -88191,9 +88263,9 @@ wpI
 pDz
 wza
 lWv
+wza
 sWj
 nZX
-abI
 aht
 aht
 fon
@@ -88448,9 +88520,9 @@ lWv
 cjt
 ftb
 vLy
+uTI
 pKg
 nZX
-abI
 aaa
 aaa
 aby
@@ -88707,7 +88779,7 @@ liR
 nZX
 nZX
 nZX
-abI
+nZX
 aht
 abI
 fon

--- a/_maps/map_files/Pubbystation/pubbystation.dmm
+++ b/_maps/map_files/Pubbystation/pubbystation.dmm
@@ -20104,6 +20104,9 @@
 /obj/machinery/newscaster/directional/south,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /obj/structure/table/glass,
+/obj/effect/turf_decal/siding/blue{
+	dir = 4
+	},
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1
 	},
@@ -20174,6 +20177,7 @@
 	dir = 1
 	},
 /obj/structure/sign/poster/official/build/directional/north,
+/obj/effect/turf_decal/trimline/electric_yellow/corner,
 /turf/open/floor/iron/white/smooth_edge,
 /area/station/engineering/atmos)
 "bMe" = (
@@ -20212,9 +20216,6 @@
 /obj/item/pipe_dispenser,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /obj/structure/table/glass,
-/obj/effect/turf_decal/siding/blue{
-	dir = 4
-	},
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1
 	},
@@ -20360,11 +20361,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "bMX" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Pure to Port"
+/obj/effect/turf_decal/trimline/electric_yellow/line{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue/full,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/engineering/atmos)
 "bMY" = (
@@ -20680,29 +20679,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/engineering/atmos/office)
-"bOk" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
+"bOn" = (
+/obj/effect/turf_decal/trimline/electric_yellow/line,
+/obj/machinery/atmospherics/pipe/layer_manifold/visible{
+	dir = 4
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/engineering/atmos)
-"bOn" = (
-/obj/machinery/light/directional/west,
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Air to Port"
-	},
-/obj/structure/extinguisher_cabinet/directional/west,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white/side{
-	dir = 8
-	},
-/area/station/engineering/atmos)
 "bOo" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Mix to Port"
-	},
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
 	},
@@ -20873,16 +20857,17 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
 	},
+/obj/effect/turf_decal/siding/blue/corner,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/engineering/atmos)
 "bOX" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+/obj/effect/turf_decal/siding/blue,
+/obj/effect/turf_decal/trimline/electric_yellow/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/blue/corner,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/engineering/atmos)
 "bOZ" = (
@@ -21265,18 +21250,15 @@
 	},
 /area/station/engineering/atmos)
 "bQK" = (
-/obj/machinery/portable_atmospherics/canister,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue/full,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/engineering/atmos)
-"bQM" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/service/library/artgallery)
+"bQM" = (
 /obj/effect/turf_decal/tile/blue/full,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/white/smooth_large,
@@ -21656,15 +21638,18 @@
 	},
 /area/station/engineering/atmos)
 "bSf" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron/white/side{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/area/station/engineering/atmos)
+/obj/machinery/door/airlock/grunge{
+	name = "Library Office"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/library,
+/turf/open/floor/iron/dark,
+/area/station/service/library/private)
 "bSg" = (
 /obj/structure/grille,
 /turf/open/space,
@@ -21679,9 +21664,12 @@
 	},
 /area/station/engineering/atmos)
 "bSj" = (
-/obj/machinery/holopad,
-/turf/open/floor/iron/textured_large,
-/area/station/engineering/atmos)
+/obj/structure/sign/painting/library_private{
+	pixel_x = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/station/service/library/private)
 "bSk" = (
 /obj/machinery/atmospherics/miner/plasma,
 /turf/open/floor/engine/plasma,
@@ -21808,15 +21796,8 @@
 	},
 /area/station/engineering/atmos/office)
 "bSR" = (
-/obj/item/wrench,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white/side{
-	dir = 8
-	},
-/area/station/engineering/atmos)
+/turf/closed/wall/mineral/iron,
+/area/station/service/library/private)
 "bSS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -21828,13 +21809,10 @@
 /turf/open/floor/iron/white,
 /area/station/engineering/atmos/office)
 "bST" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 4
+/obj/effect/turf_decal/box/corners{
+	dir = 1
 	},
-/turf/open/floor/iron/white/side{
-	dir = 4
-	},
+/turf/open/floor/iron/textured_large,
 /area/station/engineering/atmos)
 "bSV" = (
 /obj/machinery/camera/directional/east{
@@ -22138,26 +22116,14 @@
 "bTR" = (
 /obj/item/beacon,
 /obj/effect/turf_decal/box/corners,
-/obj/effect/turf_decal/box/corners{
-	dir = 8
-	},
 /turf/open/floor/iron/textured_large,
-/area/station/engineering/atmos)
-"bTS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
-/obj/structure/chair/stool/bar/directional/east,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/white/side{
-	dir = 4
-	},
 /area/station/engineering/atmos)
 "bTT" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/heater{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue/full,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/engineering/atmos)
 "bTV" = (
@@ -22258,9 +22224,10 @@
 /obj/structure/sign/poster/official/jim_nortons/directional/west,
 /obj/machinery/light/directional/west,
 /obj/structure/rack,
-/obj/item/geiger_counter,
-/obj/item/clothing/suit/utility/radiation,
-/obj/item/clothing/head/utility/radiation,
+/obj/item/clothing/head/utility/hardhat/orange,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/head/utility/hardhat/orange,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/lobby)
 "bUn" = (
@@ -22300,6 +22267,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue/full,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/engineering/atmos)
 "bUx" = (
@@ -23108,9 +23076,6 @@
 /area/station/engineering/atmos)
 "bXC" = (
 /obj/machinery/vending/wardrobe/atmos_wardrobe,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
 	},
@@ -23265,8 +23230,8 @@
 /turf/open/floor/plating,
 /area/station/engineering/engine_smes)
 "bYj" = (
-/obj/machinery/vending/engivend,
 /obj/effect/turf_decal/tile/electric_yellow/full,
+/obj/machinery/vending/engivend,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/main)
 "bYk" = (
@@ -23275,8 +23240,8 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/main)
 "bYl" = (
-/obj/structure/closet/firecloset,
 /obj/effect/turf_decal/tile/electric_yellow/full,
+/obj/machinery/vending/wardrobe/engi_wardrobe,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/main)
 "bYm" = (
@@ -23614,11 +23579,12 @@
 /obj/structure/fireaxecabinet{
 	pixel_y = 32
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
+	},
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/siding/blue{
+	dir = 4
 	},
 /turf/open/floor/iron/white/smooth_edge,
 /area/station/engineering/atmos)
@@ -24222,7 +24188,7 @@
 	req_access = list("engineering")
 	},
 /obj/effect/turf_decal/tile/electric_yellow/anticorner/contrasted,
-/obj/structure/closet/radiation,
+/obj/structure/closet/firecloset,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/main)
 "cdS" = (
@@ -24267,7 +24233,7 @@
 /obj/effect/turf_decal/tile/electric_yellow/anticorner/contrasted{
 	dir = 8
 	},
-/obj/structure/closet/secure_closet/engineering_electrical,
+/obj/structure/closet/radiation,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/main)
 "cdY" = (
@@ -27574,13 +27540,6 @@
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/service/library)
-"cAB" = (
-/obj/structure/sign/painting/library_private{
-	pixel_x = 32
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/station/service/library/private)
 "cAC" = (
 /obj/structure/chair/wood/wings{
 	dir = 1
@@ -27626,7 +27585,14 @@
 /turf/open/space,
 /area/space/nearstation)
 "cAS" = (
-/turf/closed/wall/mineral/iron,
+/obj/structure/sign/painting/library_private{
+	pixel_x = -32
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/bookbinder,
+/turf/open/floor/iron/dark,
 /area/station/service/library/private)
 "cAT" = (
 /obj/effect/spawner/random/trash/crushed_can,
@@ -28725,15 +28691,11 @@
 	c_tag = "Atmospherics Mixing"
 	},
 /obj/structure/reagent_dispensers/fueltank/large,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/blue{
-	dir = 4
-	},
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/white/smooth_edge,
 /area/station/engineering/atmos)
 "dtK" = (
@@ -29969,7 +29931,6 @@
 /area/station/engineering/storage_shared)
 "ete" = (
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/effect/mapping_helpers/apc/cell_10k,
 /obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/storage_shared)
@@ -30337,14 +30298,6 @@
 "eLG" = (
 /turf/closed/wall,
 /area/station/maintenance/department/medical/morgue)
-"eLN" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer2,
-/obj/effect/turf_decal/siding/blue/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/white/smooth_large,
-/area/station/engineering/atmos)
 "eMp" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -30897,11 +30850,7 @@
 /area/station/engineering/supermatter)
 "feN" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/obj/effect/turf_decal/trimline/electric_yellow/line{
-	dir = 4
-	},
-/turf/open/floor/iron/white/smooth_large,
+/turf/open/floor/iron/white/textured_large,
 /area/station/engineering/atmos)
 "feU" = (
 /obj/structure/table,
@@ -31493,9 +31442,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "fDm" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/visible{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/blue{
 	dir = 1
@@ -31621,19 +31567,6 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/main)
-"fIA" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Mix to Port"
-	},
-/obj/effect/turf_decal/siding/blue,
-/obj/effect/turf_decal/trimline/electric_yellow/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/white/smooth_large,
-/area/station/engineering/atmos)
 "fIH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -31666,16 +31599,14 @@
 /turf/open/floor/iron/white/smooth_edge,
 /area/station/science/ordnance)
 "fJw" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Supermatter Mix Pump"
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/blue{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/turf/open/floor/iron/white/smooth_large,
-/area/station/engineering/atmos)
+/turf/open/floor/iron/dark,
+/area/station/service/library/private)
 "fKj" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Mineral Room"
@@ -31999,14 +31930,6 @@
 /mob/living/basic/butterfly,
 /turf/open/floor/grass,
 /area/station/medical/psychology)
-"gbu" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Port to Filter"
-	},
-/obj/effect/turf_decal/tile/blue/half/contrasted,
-/turf/open/floor/iron/white/side,
-/area/station/engineering/atmos)
 "gbK" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -32574,11 +32497,10 @@
 /turf/open/floor/wood,
 /area/station/science/lab)
 "gAp" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
 	},
+/obj/machinery/holopad,
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
@@ -33221,19 +33143,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
-"hfi" = (
-/obj/machinery/light/directional/west,
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Port to Filter"
-	},
-/obj/structure/extinguisher_cabinet/directional/west,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white/side{
-	dir = 8
-	},
-/area/station/engineering/atmos)
 "hfw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -34760,14 +34669,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
 "irW" = (
-/obj/machinery/portable_atmospherics/canister,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
+/obj/effect/turf_decal/box/corners{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue/full,
-/obj/machinery/light/small/directional/west,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron/white/smooth_large,
+/turf/open/floor/iron/textured_large,
 /area/station/engineering/atmos)
 "irZ" = (
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -35903,9 +35808,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "jpx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer2,
 /obj/effect/turf_decal/trimline/electric_yellow/corner{
 	dir = 8
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Supermatter Mix Pump"
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/engineering/atmos)
@@ -36173,16 +36081,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal)
-"jCM" = (
-/obj/structure/sign/painting/library_private{
-	pixel_x = -32
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/bookbinder,
-/turf/open/floor/iron/dark,
-/area/station/service/library/private)
 "jDA" = (
 /obj/item/chair,
 /obj/effect/mapping_helpers/broken_floor,
@@ -37184,16 +37082,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
-"krn" = (
-/obj/machinery/portable_atmospherics/canister,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/obj/item/radio/intercom/directional/west,
-/obj/effect/turf_decal/tile/blue/full,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/engineering/atmos)
 "krA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -37257,9 +37145,6 @@
 	},
 /area/station/engineering/atmos/hfr_room)
 "ksv" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
 	},
@@ -37810,15 +37695,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/commons/dorms)
-"kTR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/service/library/private)
 "kUj" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -38156,15 +38032,6 @@
 /obj/structure/cable,
 /turf/closed/wall,
 /area/station/maintenance/department/science/central)
-"lhg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white/side{
-	dir = 8
-	},
-/area/station/engineering/atmos)
 "lhu" = (
 /obj/machinery/shieldgen,
 /obj/machinery/light/directional/east,
@@ -39189,10 +39056,10 @@
 /turf/open/floor/wood/large,
 /area/station/science/research)
 "mbe" = (
-/obj/machinery/vending/wardrobe/engi_wardrobe,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/closet/secure_closet/engineering_personal,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/storage_shared)
 "mbJ" = (
@@ -41075,7 +40942,6 @@
 /area/station/science/xenobiology)
 "nEp" = (
 /obj/item/cigbutt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
 /turf/open/floor/iron/white/side{
 	dir = 6
@@ -41459,14 +41325,8 @@
 	},
 /area/station/medical/treatment_center)
 "nUq" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/blue/half/contrasted,
-/turf/open/floor/iron/white/side{
-	dir = 10
-	},
+/turf/open/floor/iron/white/side,
 /area/station/engineering/atmos)
 "nVz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -44810,8 +44670,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "qoW" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
 	},
@@ -45185,15 +45043,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/commons/storage/primary)
-"qDq" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/white/side{
-	dir = 9
-	},
-/area/station/engineering/atmos)
 "qDU" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -45934,19 +45783,6 @@
 	},
 /turf/open/floor/iron/large,
 /area/station/engineering/lobby)
-"rlc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/door/airlock/grunge{
-	name = "Library Office"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/service/library,
-/turf/open/floor/iron/dark,
-/area/station/service/library/private)
 "rle" = (
 /obj/structure/cable,
 /turf/open/floor/wood,
@@ -46078,9 +45914,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/table/reinforced/rglass,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty,
+/obj/structure/closet/secure_closet/engineering_welding,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/storage_shared)
 "rpu" = (
@@ -47699,7 +47533,7 @@
 "svY" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/electric_yellow/half/contrasted,
-/obj/structure/closet/secure_closet/engineering_welding,
+/obj/structure/closet/radiation,
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 1
 	},
@@ -48024,7 +47858,9 @@
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "sGc" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer2,
+/obj/effect/turf_decal/siding/blue/corner{
+	dir = 4
+	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/engineering/atmos)
 "sGm" = (
@@ -48536,7 +48372,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/structure/closet/firecloset,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "taT" = (
@@ -48735,9 +48570,7 @@
 /area/station/maintenance/department/cargo)
 "tfG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/table/reinforced/rglass,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
+/obj/structure/closet/secure_closet/engineering_electrical,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/storage_shared)
 "tfP" = (
@@ -50576,13 +50409,13 @@
 /area/station/science/xenobiology)
 "uvr" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/electric_yellow/corner,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/electric_yellow/line,
 /turf/open/floor/iron/white/smooth_edge,
 /area/station/engineering/atmos)
 "uvs" = (
@@ -50591,7 +50424,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/electric_yellow/half/contrasted,
-/obj/structure/closet/radiation,
+/obj/structure/closet/emcloset,
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 1
 	},
@@ -50946,15 +50779,6 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/lobby)
-"uHK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/service/library/artgallery)
 "uIb" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/scanner_gate{
@@ -51854,13 +51678,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
-"vsJ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/obj/effect/turf_decal/trimline/electric_yellow/line{
-	dir = 4
-	},
-/turf/open/floor/iron/white/smooth_large,
-/area/station/engineering/atmos)
 "vtl" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -52246,9 +52063,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "vKt" = (
-/obj/effect/turf_decal/box/corners{
-	dir = 1
-	},
 /obj/effect/turf_decal/box/corners{
 	dir = 4
 	},
@@ -53086,7 +52900,6 @@
 /turf/open/floor/iron/freezer,
 /area/station/medical/coldroom)
 "wnz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 4
 	},
@@ -53186,12 +52999,12 @@
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/medical)
 "wrA" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/electric_yellow/line{
 	dir = 4
 	},
-/obj/structure/closet/emcloset,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
+/turf/open/floor/iron/white/smooth_large,
+/area/station/engineering/atmos)
 "wrD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -53987,12 +53800,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
-"wUN" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer2,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/engineering/atmos)
 "wVC" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Sci";
@@ -55613,14 +55420,6 @@
 "xXp" = (
 /turf/closed/wall,
 /area/station/service/chapel)
-"xXv" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
-/obj/effect/turf_decal/siding/blue{
-	dir = 1
-	},
-/turf/open/floor/iron/white/smooth_large,
-/area/station/engineering/atmos)
 "xXQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -74138,7 +73937,7 @@ pIy
 voM
 fdN
 whJ
-uHK
+bQK
 roy
 roy
 ndF
@@ -74647,14 +74446,14 @@ roy
 pYc
 roy
 gda
-cAS
-cAS
-cAS
-cAS
-cAS
-rlc
-cAS
-cAS
+bSR
+bSR
+bSR
+bSR
+bSR
+bSf
+bSR
+bSR
 whJ
 whJ
 whJ
@@ -74904,14 +74703,14 @@ fdN
 fdN
 fdN
 ndF
-cAS
+bSR
 reR
 tFt
-jCM
-dCh
-kTR
-sBW
 cAS
+dCh
+fJw
+sBW
+bSR
 cfN
 cfN
 cfN
@@ -75161,14 +74960,14 @@ gkQ
 gkQ
 gkQ
 xkB
-cAS
+bSR
 uIv
-cAB
+bSj
 nWF
 xMQ
 kVM
 gXh
-cAS
+bSR
 cfN
 aaa
 aaa
@@ -75418,14 +75217,14 @@ wIX
 wIX
 wIX
 wIX
-cAS
-cAS
-cAS
-cAS
-cAS
-cAS
-cAS
-cAS
+bSR
+bSR
+bSR
+bSR
+bSR
+bSR
+bSR
+bSR
 aaa
 aaa
 aaa
@@ -82599,7 +82398,7 @@ acN
 mci
 vKD
 pAb
-ceq
+tkr
 ceq
 acN
 aaa
@@ -82856,7 +82655,7 @@ cri
 eVW
 nqa
 tkr
-ceq
+tkr
 ceq
 acN
 aaa
@@ -86195,7 +85994,7 @@ adC
 cdR
 qFu
 taF
-wrA
+uTI
 uTI
 rYZ
 thT
@@ -91321,7 +91120,7 @@ wBF
 wBF
 wBF
 bWP
-fuR
+bOn
 xhP
 xhP
 jNe
@@ -91835,8 +91634,8 @@ rij
 hXC
 bTP
 eKY
-wUN
-bOk
+aAK
+bWO
 wCz
 mvA
 qIz
@@ -92092,7 +91891,7 @@ toD
 kpp
 bTQ
 ksv
-sGc
+aAK
 eUb
 wCz
 wwr
@@ -92349,7 +92148,7 @@ bQJ
 bRx
 bPQ
 bXC
-sGc
+aAK
 bpQ
 wCz
 wwr
@@ -92597,7 +92396,7 @@ bJM
 fBp
 qux
 bNg
-bWO
+bIG
 bOW
 bLV
 bPQ
@@ -92853,17 +92652,17 @@ bIE
 hjW
 fBp
 bMd
-aAK
-bIG
+wrA
+bMX
 bOX
 bMk
-bPQ
-krn
+bST
+rEy
+rEy
+rEy
 irW
-bQK
-bPQ
 dsR
-eLN
+fDm
 pyH
 wCz
 pyH
@@ -93111,14 +92910,14 @@ bKM
 fBp
 uvr
 feN
-vsJ
-fIA
-qDq
-bOn
-lhg
-bSf
-bSR
-hfi
+xhP
+hPH
+qoW
+rEy
+rEy
+rEy
+rEy
+rEy
 nUq
 fDm
 pyH
@@ -93373,11 +93172,11 @@ hPH
 qoW
 vKt
 rEy
-bSj
+rEy
 rEy
 bTR
-gbu
-fJw
+nUq
+fDm
 qkk
 keN
 bWO
@@ -93629,12 +93428,12 @@ xhP
 hPH
 wnz
 bOo
-bST
+bOo
 gAp
-bST
-bTS
+bOo
+bOo
 nEp
-xXv
+fDm
 jty
 bMe
 pHb
@@ -93884,11 +93683,11 @@ eDR
 pFB
 xhP
 hPH
-bMX
+gri
 gri
 bQM
 bQM
-bQM
+gri
 bTT
 bUv
 iBq

--- a/_maps/map_files/Pubbystation/pubbystation.dmm
+++ b/_maps/map_files/Pubbystation/pubbystation.dmm
@@ -3558,7 +3558,6 @@
 /obj/machinery/atmospherics/components/unary/airlock_pump/silent{
 	dir = 8
 	},
-/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "apn" = (
@@ -4973,7 +4972,6 @@
 /area/station/command/bridge)
 "auV" = (
 /obj/machinery/atmospherics/components/unary/airlock_pump/silent,
-/obj/machinery/airalarm/directional/east,
 /turf/open/floor/plating,
 /area/station/command/bridge)
 "auW" = (
@@ -10614,7 +10612,6 @@
 /obj/machinery/atmospherics/components/unary/airlock_pump/silent{
 	dir = 4
 	},
-/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit/departure_lounge)
 "aTN" = (
@@ -25077,7 +25074,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plating,
 /area/station/service/chapel/funeral)
 "cjH" = (
@@ -28603,7 +28599,6 @@
 /obj/machinery/atmospherics/components/unary/airlock_pump/silent{
 	dir = 4
 	},
-/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit/departure_lounge)
 "dqY" = (
@@ -31890,6 +31885,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/miningfoundry)
+"fYf" = (
+/obj/structure/cable,
+/turf/closed/wall/mineral/titanium,
+/area/space/nearstation)
 "fZi" = (
 /obj/structure/cable,
 /obj/machinery/door/window/brigdoor{
@@ -31905,12 +31904,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
-"fZY" = (
-/obj/structure/fluff/tram_rail/end{
-	dir = 1
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "gam" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "kitchenwindowshutters";
@@ -32009,13 +32002,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
-"gfn" = (
-/obj/structure/fluff/tram_rail{
-	dir = 1
-	},
-/obj/structure/fluff/tram_rail/end,
-/turf/open/space/basic,
-/area/space/nearstation)
 "gfC" = (
 /obj/machinery/computer/cargo{
 	dir = 1
@@ -33832,7 +33818,6 @@
 /obj/machinery/atmospherics/components/unary/airlock_pump/silent{
 	dir = 1
 	},
-/obj/machinery/airalarm/directional/west,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
 "hGq" = (
@@ -34093,13 +34078,6 @@
 	dir = 4
 	},
 /area/station/medical/medbay)
-"hQy" = (
-/obj/structure/fluff/sat_dish{
-	pixel_x = -11;
-	pixel_y = 21
-	},
-/turf/closed/wall/mineral/titanium,
-/area/space/nearstation)
 "hQz" = (
 /obj/structure/closet/emcloset/anchored,
 /turf/open/floor/plating,
@@ -34142,6 +34120,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"hSC" = (
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "hSM" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -34276,13 +34258,6 @@
 /obj/item/epic_loot/plasma_explosive,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
-"hXa" = (
-/obj/structure/fluff/tram_rail/anchor{
-	dir = 1
-	},
-/obj/structure/fluff/tram_rail/anchor,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "hXk" = (
 /obj/effect/spawner/random/engineering/tank,
 /turf/open/floor/plating,
@@ -34485,6 +34460,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/cargo/storage)
+"ihh" = (
+/obj/structure/fluff/commsbuoy_receiver{
+	desc = "A dish-shaped component of the Comms Sat used to detect and retransmitd signals."
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "ihj" = (
 /obj/item/clothing/suit/toggle/labcoat/science,
 /obj/effect/spawner/random/epic_loot/random_maint_loot_structure,
@@ -35127,9 +35108,6 @@
 /obj/effect/turf_decal/trimline/electric_yellow/line,
 /turf/open/floor/iron/white/smooth_edge,
 /area/station/engineering/atmos)
-"iJp" = (
-/turf/closed/wall/mineral/titanium,
-/area/space/nearstation)
 "iJH" = (
 /obj/structure/table,
 /obj/item/stack/sheet/plasteel{
@@ -35301,6 +35279,13 @@
 /obj/effect/turf_decal/tile/pine_green/half/contrasted,
 /turf/open/floor/iron/white,
 /area/station/medical/psychology)
+"iSh" = (
+/obj/structure/fluff/tram_rail{
+	dir = 1
+	},
+/obj/structure/fluff/tram_rail,
+/turf/open/space/basic,
+/area/space/nearstation)
 "iSi" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/science/central)
@@ -36224,12 +36209,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/storage)
-"jJk" = (
-/obj/structure/fluff/tram_rail{
-	dir = 1
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "jJm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding{
@@ -36507,10 +36486,6 @@
 /obj/structure/sign/gym,
 /turf/closed/wall,
 /area/station/maintenance/department/crew_quarters/dorms)
-"jTK" = (
-/obj/structure/cable,
-/turf/closed/wall/mineral/titanium,
-/area/space/nearstation)
 "jUF" = (
 /obj/structure/grille/broken,
 /obj/structure/cable,
@@ -37237,6 +37212,14 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/science/genetics)
+"kuM" = (
+/obj/structure/fluff/sat_dish{
+	pixel_x = 24;
+	pixel_y = 10;
+	dir = 4
+	},
+/turf/closed/wall/mineral/titanium,
+/area/space/nearstation)
 "kvp" = (
 /obj/machinery/door/window/left/directional/north{
 	name = "Medbay Delivery";
@@ -43958,7 +43941,6 @@
 /area/station/cargo/sorting)
 "pMh" = (
 /obj/machinery/atmospherics/components/unary/airlock_pump/silent,
-/obj/machinery/airalarm/directional/east,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
 "pMG" = (
@@ -44348,7 +44330,6 @@
 /obj/machinery/atmospherics/components/unary/airlock_pump/silent{
 	dir = 8
 	},
-/obj/machinery/airalarm/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard)
 "qdj" = (
@@ -44607,12 +44588,11 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/engineering/atmos)
 "qkI" = (
-/obj/structure/closet/emcloset{
-	anchored = 1
+/obj/structure/fluff/tram_rail/end{
+	dir = 1
 	},
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron,
-/area/station/security/eva)
+/turf/open/space/basic,
+/area/space/nearstation)
 "qkS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -44842,10 +44822,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/ordnance/storage)
-"qra" = (
-/obj/structure/cable,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "qrw" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal/delivery_chute{
@@ -45903,7 +45879,6 @@
 /area/space/nearstation)
 "rnF" = (
 /obj/structure/cable,
-/obj/machinery/airalarm/directional/north,
 /obj/machinery/atmospherics/components/unary/airlock_pump/silent{
 	dir = 4
 	},
@@ -46770,6 +46745,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
+"rPS" = (
+/obj/structure/fluff/tram_rail/anchor{
+	dir = 1
+	},
+/obj/structure/fluff/tram_rail/anchor,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "rPY" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -47294,13 +47276,6 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/cyan/visible,
 /turf/closed/wall,
 /area/station/maintenance/department/security/brig)
-"skE" = (
-/obj/structure/fluff/tram_rail{
-	dir = 1
-	},
-/obj/structure/fluff/tram_rail,
-/turf/open/space/basic,
-/area/space/nearstation)
 "skS" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -49712,14 +49687,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
-"tVX" = (
-/obj/structure/fluff/sat_dish{
-	pixel_x = 24;
-	pixel_y = 10;
-	dir = 4
-	},
-/turf/closed/wall/mineral/titanium,
-/area/space/nearstation)
 "tWc" = (
 /obj/structure/sign/directions/science{
 	dir = 4;
@@ -50685,6 +50652,13 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
+"uAN" = (
+/obj/structure/fluff/sat_dish{
+	pixel_x = -11;
+	pixel_y = 21
+	},
+/turf/closed/wall/mineral/titanium,
+/area/space/nearstation)
 "uAU" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue,
@@ -50977,6 +50951,12 @@
 /obj/machinery/portable_atmospherics/canister/anesthetic_mix,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
+"uQa" = (
+/obj/structure/fluff/tram_rail{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "uQl" = (
 /obj/structure/girder,
 /obj/effect/mapping_helpers/burnt_floor,
@@ -51404,10 +51384,12 @@
 /turf/open/floor/iron/terracotta/small,
 /area/station/service/kitchen)
 "vdY" = (
-/obj/machinery/atmospherics/components/unary/airlock_pump/silent,
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/plating,
-/area/station/hallway/secondary/entry)
+/obj/structure/fluff/tram_rail{
+	dir = 1
+	},
+/obj/structure/fluff/tram_rail/end,
+/turf/open/space/basic,
+/area/space/nearstation)
 "veb" = (
 /obj/effect/spawner/random/structure/table_or_rack,
 /obj/machinery/light/cold/dim/directional/north,
@@ -53566,7 +53548,6 @@
 /obj/machinery/atmospherics/components/unary/airlock_pump/silent{
 	dir = 4
 	},
-/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit/departure_lounge)
 "wKP" = (
@@ -54212,12 +54193,8 @@
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
 "xeP" = (
-/obj/machinery/atmospherics/components/unary/airlock_pump/silent{
-	dir = 1
-	},
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/plating,
-/area/station/hallway/secondary/entry)
+/turf/closed/wall/mineral/titanium,
+/area/space/nearstation)
 "xff" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -55207,12 +55184,6 @@
 	},
 /turf/open/floor/iron/large,
 /area/station/engineering/lobby)
-"xLQ" = (
-/obj/structure/fluff/commsbuoy_receiver{
-	desc = "A dish-shaped component of the Comms Sat used to detect and retransmitd signals."
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "xLS" = (
 /obj/machinery/requests_console/directional/west{
 	department = "Research Director's Desk";
@@ -74727,7 +74698,7 @@ hXW
 nJB
 tqd
 dux
-xeP
+hGg
 aYF
 aaa
 aaa
@@ -76278,7 +76249,7 @@ aaa
 aaa
 aaa
 bbQ
-vdY
+pMh
 bdV
 tqd
 jsa
@@ -76472,7 +76443,7 @@ aaa
 kaA
 cdm
 ofe
-qkI
+uUS
 iVP
 uUS
 ofe
@@ -84593,8 +84564,8 @@ aaa
 aaa
 aaa
 aaa
-hQy
-iJp
+uAN
+xeP
 aaa
 iBJ
 clw
@@ -84851,9 +84822,9 @@ aaa
 aaa
 aaa
 aaa
-iJp
-iJp
-qra
+xeP
+xeP
+hSC
 clw
 nTk
 nTk
@@ -85108,9 +85079,9 @@ aaa
 aaa
 aaa
 aaa
-xLQ
-jTK
-qra
+ihh
+fYf
+hSC
 clw
 lou
 ckM
@@ -85365,8 +85336,8 @@ aaa
 aaa
 aaa
 aaa
-iJp
-iJp
+xeP
+xeP
 mVM
 clw
 ckM
@@ -85621,9 +85592,9 @@ aaa
 aaa
 aaa
 aaa
-tVX
-iJp
-hXa
+kuM
+xeP
+rPS
 abI
 clw
 clw
@@ -85880,7 +85851,7 @@ aaa
 aaa
 aaa
 aaa
-skE
+iSh
 aaa
 aaa
 aaa
@@ -86137,7 +86108,7 @@ aaa
 aaa
 aaa
 aaa
-skE
+iSh
 aaa
 aaa
 aaa
@@ -86394,7 +86365,7 @@ aaa
 aaa
 aaa
 aaa
-gfn
+vdY
 aaa
 aaa
 aaa
@@ -86651,7 +86622,7 @@ aaa
 aaa
 aaa
 aaa
-jJk
+uQa
 aaa
 aaa
 aaa
@@ -86908,7 +86879,7 @@ aaa
 aaa
 aaa
 aaa
-jJk
+uQa
 aaa
 aaa
 aaa
@@ -87165,7 +87136,7 @@ aaa
 aaa
 aaa
 aaa
-fZY
+qkI
 aaa
 aaa
 aaa

--- a/_maps/map_files/Pubbystation/pubbystation.dmm
+++ b/_maps/map_files/Pubbystation/pubbystation.dmm
@@ -13346,10 +13346,6 @@
 	},
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/secondary/entry)
-"bfb" = (
-/obj/structure/sign/nanotrasen,
-/turf/closed/wall,
-/area/station/commons/vacant_room/commissary)
 "bfe" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
@@ -20361,11 +20357,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "bMX" = (
-/obj/effect/turf_decal/trimline/electric_yellow/line{
+/obj/structure/sign/painting/large/library{
 	dir = 4
 	},
-/turf/open/floor/iron/white/smooth_large,
-/area/station/engineering/atmos)
+/turf/open/floor/iron/dark,
+/area/station/service/chapel/monastery)
 "bMY" = (
 /obj/effect/turf_decal/tile/blue/full,
 /obj/structure/fluff/shower_drain,
@@ -20679,13 +20675,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/engineering/atmos/office)
-"bOn" = (
-/obj/effect/turf_decal/trimline/electric_yellow/line,
-/obj/machinery/atmospherics/pipe/layer_manifold/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/white/smooth_large,
-/area/station/engineering/atmos)
+"bOk" = (
+/obj/structure/sign/painting/library_secure,
+/turf/closed/wall/mineral/iron,
+/area/station/service/library/private)
 "bOo" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
@@ -21250,14 +21243,12 @@
 	},
 /area/station/engineering/atmos)
 "bQK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+/obj/effect/turf_decal/trimline/electric_yellow/line,
+/obj/machinery/atmospherics/pipe/layer_manifold/visible{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
-/area/station/service/library/artgallery)
+/turf/open/floor/iron/white/smooth_large,
+/area/station/engineering/atmos)
 "bQM" = (
 /obj/effect/turf_decal/tile/blue/full,
 /obj/effect/turf_decal/bot,
@@ -21638,18 +21629,12 @@
 	},
 /area/station/engineering/atmos)
 "bSf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/door/airlock/grunge{
-	name = "Library Office"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/service/library,
-/turf/open/floor/iron/dark,
-/area/station/service/library/private)
+/obj/structure/cable,
+/turf/open/floor/carpet,
+/area/station/service/library/artgallery)
 "bSg" = (
 /obj/structure/grille,
 /turf/open/space,
@@ -21664,10 +21649,10 @@
 	},
 /area/station/engineering/atmos)
 "bSj" = (
-/obj/structure/sign/painting/library_private{
-	pixel_x = 32
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/bookbinder,
 /turf/open/floor/iron/dark,
 /area/station/service/library/private)
 "bSk" = (
@@ -21796,8 +21781,9 @@
 	},
 /area/station/engineering/atmos/office)
 "bSR" = (
+/obj/structure/sign/painting/large/library,
 /turf/closed/wall/mineral/iron,
-/area/station/service/library/private)
+/area/station/service/library/lounge)
 "bSS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -21808,12 +21794,6 @@
 /obj/structure/table/glass,
 /turf/open/floor/iron/white,
 /area/station/engineering/atmos/office)
-"bST" = (
-/obj/effect/turf_decal/box/corners{
-	dir = 1
-	},
-/turf/open/floor/iron/textured_large,
-/area/station/engineering/atmos)
 "bSV" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Atmospherics Starboard"
@@ -22118,6 +22098,10 @@
 /obj/effect/turf_decal/box/corners,
 /turf/open/floor/iron/textured_large,
 /area/station/engineering/atmos)
+"bTS" = (
+/obj/structure/sign/painting/library_private,
+/turf/closed/wall/mineral/iron,
+/area/station/service/library/artgallery)
 "bTT" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/heater{
 	dir = 8
@@ -27540,6 +27524,20 @@
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/service/library)
+"cAB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/airlock/grunge{
+	name = "Library Office"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/library,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/service/library/private)
 "cAC" = (
 /obj/structure/chair/wood/wings{
 	dir = 1
@@ -27585,15 +27583,14 @@
 /turf/open/space,
 /area/space/nearstation)
 "cAS" = (
-/obj/structure/sign/painting/library_private{
-	pixel_x = -32
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/bookbinder,
-/turf/open/floor/iron/dark,
-/area/station/service/library/private)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/carpet,
+/area/station/service/library)
 "cAT" = (
 /obj/effect/spawner/random/trash/crushed_can,
 /turf/open/floor/iron/white/smooth_large,
@@ -28885,9 +28882,6 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningfoundry)
 "dCh" = (
-/obj/structure/sign/painting/library_private{
-	pixel_x = -32
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
@@ -28983,6 +28977,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/service/library/artgallery)
 "dGO" = (
@@ -29470,6 +29465,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/service/library/artgallery)
 "ebD" = (
@@ -30298,6 +30294,16 @@
 "eLG" = (
 /turf/closed/wall,
 /area/station/maintenance/department/medical/morgue)
+"eLN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/service/library/artgallery)
 "eMp" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -31327,9 +31333,6 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/supply)
 "fwx" = (
-/obj/structure/sign/painting/library_secure{
-	pixel_y = -32
-	},
 /obj/structure/table/wood/fancy,
 /obj/item/stack/sheet/bone{
 	pixel_y = 6
@@ -31442,12 +31445,15 @@
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "fDm" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/blue{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/turf/open/floor/iron/white/smooth_large,
-/area/station/engineering/atmos)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/service/library/artgallery)
 "fDM" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron/white/smooth_large,
@@ -31598,15 +31604,6 @@
 	},
 /turf/open/floor/iron/white/smooth_edge,
 /area/station/science/ordnance)
-"fJw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/service/library/private)
 "fKj" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Mineral Room"
@@ -31930,6 +31927,13 @@
 /mob/living/basic/butterfly,
 /turf/open/floor/grass,
 /area/station/medical/psychology)
+"gbu" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/electric_yellow/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white/smooth_large,
+/area/station/engineering/atmos)
 "gbK" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -33054,9 +33058,6 @@
 /area/station/science/genetics)
 "gXh" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/painting/library_private{
-	pixel_x = 32
-	},
 /obj/machinery/modular_computer/preset/curator{
 	dir = 1
 	},
@@ -34669,10 +34670,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
 "irW" = (
-/obj/effect/turf_decal/box/corners{
-	dir = 8
+/obj/effect/turf_decal/trimline/electric_yellow/line{
+	dir = 4
 	},
-/turf/open/floor/iron/textured_large,
+/turf/open/floor/iron/white/smooth_large,
 /area/station/engineering/atmos)
 "irZ" = (
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -37082,6 +37083,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
+"krn" = (
+/obj/effect/turf_decal/box/corners{
+	dir = 1
+	},
+/turf/open/floor/iron/textured_large,
+/area/station/engineering/atmos)
 "krA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -37745,13 +37752,11 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
 "kVM" = (
-/obj/structure/sign/painting/library_private{
-	pixel_x = 32
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/service/library/private)
 "kVN" = (
@@ -38032,6 +38037,10 @@
 /obj/structure/cable,
 /turf/closed/wall,
 /area/station/maintenance/department/science/central)
+"lhg" = (
+/obj/structure/sign/painting/large/library,
+/turf/closed/wall/mineral/iron,
+/area/station/service/library/artgallery)
 "lhu" = (
 /obj/machinery/shieldgen,
 /obj/machinery/light/directional/east,
@@ -41382,10 +41391,9 @@
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "nWF" = (
-/obj/structure/sign/painting/library_private{
-	pixel_x = 32
-	},
 /obj/effect/landmark/start/librarian,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/service/library/private)
 "nWK" = (
@@ -44670,13 +44678,15 @@
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "qoW" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/turf/open/floor/iron/white/side{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/area/station/engineering/atmos)
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/service/library/private)
 "qph" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -45043,6 +45053,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/commons/storage/primary)
+"qDq" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white/side{
+	dir = 1
+	},
+/area/station/engineering/atmos)
 "qDU" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -45665,6 +45683,7 @@
 	pixel_x = 6;
 	pixel_y = 0
 	},
+/obj/item/book/granter/sign_language,
 /turf/open/floor/iron/dark,
 /area/station/service/library/private)
 "reV" = (
@@ -46829,6 +46848,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/station/service/library/artgallery)
 "rVt" = (
@@ -47757,6 +47777,7 @@
 "sBW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/destructible/cult/item_dispenser/archives/library,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/service/library/private)
 "sBZ" = (
@@ -49336,9 +49357,6 @@
 /area/station/command/heads_quarters/cmo)
 "tFt" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/painting/library_private{
-	pixel_x = -32
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
 /area/station/service/library/private)
@@ -51678,6 +51696,9 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
+"vsJ" = (
+/turf/closed/wall/mineral/iron,
+/area/station/service/library/private)
 "vtl" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -52957,9 +52978,6 @@
 /turf/open/floor/iron/white,
 /area/station/maintenance/disposal/incinerator)
 "woX" = (
-/obj/structure/sign/painting/library_secure{
-	pixel_y = -32
-	},
 /obj/structure/table/wood/fancy,
 /obj/item/reagent_containers/cup/mortar{
 	pixel_y = 8
@@ -52999,11 +53017,10 @@
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/medical)
 "wrA" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/electric_yellow/line{
-	dir = 4
+/obj/effect/turf_decal/box/corners{
+	dir = 8
 	},
-/turf/open/floor/iron/white/smooth_large,
+/turf/open/floor/iron/textured_large,
 /area/station/engineering/atmos)
 "wrD" = (
 /obj/structure/disposalpipe/segment{
@@ -53800,6 +53817,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
+"wUN" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/station/service/library/private)
 "wVC" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Sci";
@@ -55175,6 +55196,7 @@
 "xMQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/dim/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/service/library/private)
 "xMS" = (
@@ -55420,6 +55442,13 @@
 "xXp" = (
 /turf/closed/wall,
 /area/station/service/chapel)
+"xXv" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/blue{
+	dir = 1
+	},
+/turf/open/floor/iron/white/smooth_large,
+/area/station/engineering/atmos)
 "xXQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -71130,8 +71159,8 @@ cjQ
 cjQ
 cjQ
 jMS
-vNF
-vNF
+cjQ
+cjQ
 iBp
 cAu
 cAC
@@ -71387,8 +71416,8 @@ aTN
 hzh
 aTN
 weS
-xBB
-iBp
+aTN
+cAS
 ucy
 cAv
 cAD
@@ -71622,7 +71651,7 @@ cgG
 bWV
 ykY
 qFp
-cwe
+bSR
 ivQ
 clm
 lwT
@@ -72133,7 +72162,7 @@ csS
 wDx
 ykY
 cvk
-csS
+bMX
 csS
 yiF
 cfm
@@ -72906,9 +72935,9 @@ pqS
 chL
 cfm
 pIy
-voM
+fDm
 gkQ
-whJ
+bTS
 elH
 elH
 ucd
@@ -73163,7 +73192,7 @@ oMn
 ciY
 cfm
 pIy
-voM
+fDm
 rie
 whJ
 roy
@@ -73420,17 +73449,17 @@ cht
 cfm
 cfm
 nPm
-voM
+fDm
 dGd
-kkU
-kkU
+bSf
+bSf
 kkU
 kkU
 kkU
 pQA
 tqW
 fwx
-whJ
+lhg
 cfN
 aht
 aht
@@ -73937,7 +73966,7 @@ pIy
 voM
 fdN
 whJ
-bQK
+eLN
 roy
 roy
 ndF
@@ -74446,14 +74475,14 @@ roy
 pYc
 roy
 gda
-bSR
-bSR
-bSR
-bSR
-bSR
-bSf
-bSR
-bSR
+vsJ
+vsJ
+vsJ
+vsJ
+vsJ
+cAB
+vsJ
+vsJ
 whJ
 whJ
 whJ
@@ -74703,14 +74732,14 @@ fdN
 fdN
 fdN
 ndF
-bSR
+vsJ
 reR
 tFt
-cAS
+bSj
 dCh
-fJw
+qoW
 sBW
-bSR
+vsJ
 cfN
 cfN
 cfN
@@ -74960,14 +74989,14 @@ gkQ
 gkQ
 gkQ
 xkB
-bSR
+vsJ
 uIv
-bSj
+wUN
 nWF
 xMQ
 kVM
 gXh
-bSR
+vsJ
 cfN
 aaa
 aaa
@@ -75217,14 +75246,14 @@ wIX
 wIX
 wIX
 wIX
-bSR
-bSR
-bSR
-bSR
-bSR
-bSR
-bSR
-bSR
+vsJ
+vsJ
+bOk
+vsJ
+vsJ
+bOk
+bOk
+vsJ
 aaa
 aaa
 aaa
@@ -77975,7 +78004,7 @@ aXK
 bdd
 lmU
 ejn
-bfb
+bjK
 bgU
 bhF
 bib
@@ -91120,7 +91149,7 @@ wBF
 wBF
 wBF
 bWP
-bOn
+bQK
 xhP
 xhP
 jNe
@@ -92652,17 +92681,17 @@ bIE
 hjW
 fBp
 bMd
-wrA
-bMX
+gbu
+irW
 bOX
 bMk
-bST
+krn
 rEy
 rEy
 rEy
-irW
+wrA
 dsR
-fDm
+xXv
 pyH
 wCz
 pyH
@@ -92912,14 +92941,14 @@ uvr
 feN
 xhP
 hPH
-qoW
+qDq
 rEy
 rEy
 rEy
 rEy
 rEy
 nUq
-fDm
+xXv
 pyH
 lRh
 kRL
@@ -93169,14 +93198,14 @@ uTt
 xhP
 xhP
 hPH
-qoW
+qDq
 vKt
 rEy
 rEy
 rEy
 bTR
 nUq
-fDm
+xXv
 qkk
 keN
 bWO
@@ -93433,7 +93462,7 @@ gAp
 bOo
 bOo
 nEp
-fDm
+xXv
 jty
 bMe
 pHb

--- a/_maps/map_files/Pubbystation/pubbystation.dmm
+++ b/_maps/map_files/Pubbystation/pubbystation.dmm
@@ -29633,12 +29633,6 @@
 /obj/effect/landmark/atmospheric_sanity/ignore_area,
 /turf/open/floor/carpet,
 /area/station/service/library/artgallery)
-"eiu" = (
-/obj/structure/fluff/commsbuoy_receiver{
-	desc = "A dish-shaped component of the Comms Sat used to detect and retransmitd signals."
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "eiS" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/wood,
@@ -31911,6 +31905,12 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"fZY" = (
+/obj/structure/fluff/tram_rail/end{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "gam" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "kitchenwindowshutters";
@@ -32009,6 +32009,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
+"gfn" = (
+/obj/structure/fluff/tram_rail{
+	dir = 1
+	},
+/obj/structure/fluff/tram_rail/end,
+/turf/open/space/basic,
+/area/space/nearstation)
 "gfC" = (
 /obj/machinery/computer/cargo{
 	dir = 1
@@ -34086,6 +34093,13 @@
 	dir = 4
 	},
 /area/station/medical/medbay)
+"hQy" = (
+/obj/structure/fluff/sat_dish{
+	pixel_x = -11;
+	pixel_y = 21
+	},
+/turf/closed/wall/mineral/titanium,
+/area/space/nearstation)
 "hQz" = (
 /obj/structure/closet/emcloset/anchored,
 /turf/open/floor/plating,
@@ -34220,14 +34234,6 @@
 /obj/structure/cable,
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/captain/private)
-"hVX" = (
-/obj/structure/fluff/sat_dish{
-	pixel_x = 24;
-	pixel_y = 10;
-	dir = 4
-	},
-/turf/closed/wall/mineral/titanium,
-/area/space/nearstation)
 "hWo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -34270,6 +34276,13 @@
 /obj/item/epic_loot/plasma_explosive,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
+"hXa" = (
+/obj/structure/fluff/tram_rail/anchor{
+	dir = 1
+	},
+/obj/structure/fluff/tram_rail/anchor,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "hXk" = (
 /obj/effect/spawner/random/engineering/tank,
 /turf/open/floor/plating,
@@ -35114,6 +35127,9 @@
 /obj/effect/turf_decal/trimline/electric_yellow/line,
 /turf/open/floor/iron/white/smooth_edge,
 /area/station/engineering/atmos)
+"iJp" = (
+/turf/closed/wall/mineral/titanium,
+/area/space/nearstation)
 "iJH" = (
 /obj/structure/table,
 /obj/item/stack/sheet/plasteel{
@@ -36208,6 +36224,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/storage)
+"jJk" = (
+/obj/structure/fluff/tram_rail{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "jJm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding{
@@ -36485,6 +36507,10 @@
 /obj/structure/sign/gym,
 /turf/closed/wall,
 /area/station/maintenance/department/crew_quarters/dorms)
+"jTK" = (
+/obj/structure/cable,
+/turf/closed/wall/mineral/titanium,
+/area/space/nearstation)
 "jUF" = (
 /obj/structure/grille/broken,
 /obj/structure/cable,
@@ -38116,13 +38142,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
-"ljK" = (
-/obj/structure/fluff/tram_rail/anchor{
-	dir = 1
-	},
-/obj/structure/fluff/tram_rail/anchor,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "ljT" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -38928,9 +38947,6 @@
 /obj/effect/turf_decal/tile/red/anticorner/contrasted,
 /turf/open/floor/iron,
 /area/station/security/brig)
-"lTa" = (
-/turf/closed/wall/mineral/titanium,
-/area/space/nearstation)
 "lTn" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -39743,12 +39759,6 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/wood/large,
 /area/station/science/breakroom)
-"mBp" = (
-/obj/structure/fluff/tram_rail/end{
-	dir = 1
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "mBu" = (
 /obj/item/book/bible,
 /obj/structure/altar_of_gods,
@@ -39988,12 +39998,6 @@
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
-"mMC" = (
-/obj/structure/fluff/tram_rail{
-	dir = 1
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "mNv" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -40141,13 +40145,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
-"mRP" = (
-/obj/structure/fluff/sat_dish{
-	pixel_x = -11;
-	pixel_y = 21
-	},
-/turf/closed/wall/mineral/titanium,
-/area/space/nearstation)
 "mRQ" = (
 /obj/effect/turf_decal/tile/office_blue{
 	dir = 8
@@ -40203,10 +40200,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/central)
-"mUy" = (
-/obj/structure/cable,
-/turf/closed/wall/mineral/titanium,
-/area/space/nearstation)
 "mUJ" = (
 /obj/structure/cable,
 /turf/open/floor/engine,
@@ -44155,11 +44148,6 @@
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
-"pTO" = (
-/obj/structure/cable,
-/obj/structure/cable,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "pVr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -44854,6 +44842,10 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/ordnance/storage)
+"qra" = (
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "qrw" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal/delivery_chute{
@@ -47302,6 +47294,13 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/cyan/visible,
 /turf/closed/wall,
 /area/station/maintenance/department/security/brig)
+"skE" = (
+/obj/structure/fluff/tram_rail{
+	dir = 1
+	},
+/obj/structure/fluff/tram_rail,
+/turf/open/space/basic,
+/area/space/nearstation)
 "skS" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -49713,6 +49712,14 @@
 	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
+"tVX" = (
+/obj/structure/fluff/sat_dish{
+	pixel_x = 24;
+	pixel_y = 10;
+	dir = 4
+	},
+/turf/closed/wall/mineral/titanium,
+/area/space/nearstation)
 "tWc" = (
 /obj/structure/sign/directions/science{
 	dir = 4;
@@ -51833,10 +51840,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/engineering/atmos/office)
-"vvL" = (
-/obj/structure/cable,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "vvP" = (
 /obj/effect/turf_decal/tile/pine_green{
 	dir = 4
@@ -52287,13 +52290,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/supply/general,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
-"vQM" = (
-/obj/structure/fluff/tram_rail{
-	dir = 1
-	},
-/obj/structure/fluff/tram_rail,
-/turf/open/space/basic,
-/area/space/nearstation)
 "vRi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -55211,6 +55207,12 @@
 	},
 /turf/open/floor/iron/large,
 /area/station/engineering/lobby)
+"xLQ" = (
+/obj/structure/fluff/commsbuoy_receiver{
+	desc = "A dish-shaped component of the Comms Sat used to detect and retransmitd signals."
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "xLS" = (
 /obj/machinery/requests_console/directional/west{
 	department = "Research Director's Desk";
@@ -55252,13 +55254,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
-"xMJ" = (
-/obj/structure/fluff/tram_rail{
-	dir = 1
-	},
-/obj/structure/fluff/tram_rail/end,
-/turf/open/space/basic,
-/area/space/nearstation)
 "xMN" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -84598,8 +84593,8 @@ aaa
 aaa
 aaa
 aaa
-mRP
-lTa
+hQy
+iJp
 aaa
 iBJ
 clw
@@ -84856,9 +84851,9 @@ aaa
 aaa
 aaa
 aaa
-lTa
-lTa
-vvL
+iJp
+iJp
+qra
 clw
 nTk
 nTk
@@ -85113,9 +85108,9 @@ aaa
 aaa
 aaa
 aaa
-eiu
-mUy
-pTO
+xLQ
+jTK
+qra
 clw
 lou
 ckM
@@ -85370,8 +85365,8 @@ aaa
 aaa
 aaa
 aaa
-lTa
-lTa
+iJp
+iJp
 mVM
 clw
 ckM
@@ -85626,9 +85621,9 @@ aaa
 aaa
 aaa
 aaa
-hVX
-lTa
-ljK
+tVX
+iJp
+hXa
 abI
 clw
 clw
@@ -85885,7 +85880,7 @@ aaa
 aaa
 aaa
 aaa
-vQM
+skE
 aaa
 aaa
 aaa
@@ -86142,7 +86137,7 @@ aaa
 aaa
 aaa
 aaa
-vQM
+skE
 aaa
 aaa
 aaa
@@ -86399,7 +86394,7 @@ aaa
 aaa
 aaa
 aaa
-xMJ
+gfn
 aaa
 aaa
 aaa
@@ -86656,7 +86651,7 @@ aaa
 aaa
 aaa
 aaa
-mMC
+jJk
 aaa
 aaa
 aaa
@@ -86913,7 +86908,7 @@ aaa
 aaa
 aaa
 aaa
-mMC
+jJk
 aaa
 aaa
 aaa
@@ -87170,7 +87165,7 @@ aaa
 aaa
 aaa
 aaa
-mBp
+fZY
 aaa
 aaa
 aaa

--- a/_maps/map_files/Pubbystation/pubbystation.dmm
+++ b/_maps/map_files/Pubbystation/pubbystation.dmm
@@ -11304,6 +11304,7 @@
 /obj/machinery/computer/cargo,
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/machinery/door/firedoor,
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "aWw" = (

--- a/_maps/map_files/Pubbystation/pubbystation.dmm
+++ b/_maps/map_files/Pubbystation/pubbystation.dmm
@@ -29633,6 +29633,12 @@
 /obj/effect/landmark/atmospheric_sanity/ignore_area,
 /turf/open/floor/carpet,
 /area/station/service/library/artgallery)
+"eiu" = (
+/obj/structure/fluff/commsbuoy_receiver{
+	desc = "A dish-shaped component of the Comms Sat used to detect and retransmitd signals."
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "eiS" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/wood,
@@ -34214,6 +34220,14 @@
 /obj/structure/cable,
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/captain/private)
+"hVX" = (
+/obj/structure/fluff/sat_dish{
+	pixel_x = 24;
+	pixel_y = 10;
+	dir = 4
+	},
+/turf/closed/wall/mineral/titanium,
+/area/space/nearstation)
 "hWo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -34913,6 +34927,7 @@
 	start_active = 1
 	},
 /obj/structure/lattice,
+/obj/structure/cable,
 /turf/open/space/basic,
 /area/space/nearstation)
 "iBY" = (
@@ -38101,6 +38116,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"ljK" = (
+/obj/structure/fluff/tram_rail/anchor{
+	dir = 1
+	},
+/obj/structure/fluff/tram_rail/anchor,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "ljT" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -38906,6 +38928,9 @@
 /obj/effect/turf_decal/tile/red/anticorner/contrasted,
 /turf/open/floor/iron,
 /area/station/security/brig)
+"lTa" = (
+/turf/closed/wall/mineral/titanium,
+/area/space/nearstation)
 "lTn" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -39718,6 +39743,12 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/wood/large,
 /area/station/science/breakroom)
+"mBp" = (
+/obj/structure/fluff/tram_rail/end{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "mBu" = (
 /obj/item/book/bible,
 /obj/structure/altar_of_gods,
@@ -39957,6 +39988,12 @@
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
+"mMC" = (
+/obj/structure/fluff/tram_rail{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "mNv" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -40104,6 +40141,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
+"mRP" = (
+/obj/structure/fluff/sat_dish{
+	pixel_x = -11;
+	pixel_y = 21
+	},
+/turf/closed/wall/mineral/titanium,
+/area/space/nearstation)
 "mRQ" = (
 /obj/effect/turf_decal/tile/office_blue{
 	dir = 8
@@ -40159,6 +40203,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/central)
+"mUy" = (
+/obj/structure/cable,
+/turf/closed/wall/mineral/titanium,
+/area/space/nearstation)
 "mUJ" = (
 /obj/structure/cable,
 /turf/open/floor/engine,
@@ -44107,6 +44155,11 @@
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
+"pTO" = (
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "pVr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -51780,6 +51833,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/engineering/atmos/office)
+"vvL" = (
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "vvP" = (
 /obj/effect/turf_decal/tile/pine_green{
 	dir = 4
@@ -52230,6 +52287,13 @@
 /obj/effect/mapping_helpers/airlock/access/any/supply/general,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
+"vQM" = (
+/obj/structure/fluff/tram_rail{
+	dir = 1
+	},
+/obj/structure/fluff/tram_rail,
+/turf/open/space/basic,
+/area/space/nearstation)
 "vRi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -55188,6 +55252,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
+"xMJ" = (
+/obj/structure/fluff/tram_rail{
+	dir = 1
+	},
+/obj/structure/fluff/tram_rail/end,
+/turf/open/space/basic,
+/area/space/nearstation)
 "xMN" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -84527,8 +84598,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+mRP
+lTa
 aaa
 iBJ
 clw
@@ -84785,9 +84856,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aht
+lTa
+lTa
+vvL
 clw
 nTk
 nTk
@@ -85042,9 +85113,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aht
+eiu
+mUy
+pTO
 clw
 lou
 ckM
@@ -85299,9 +85370,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-abI
+lTa
+lTa
+mVM
 clw
 ckM
 uFT
@@ -85555,9 +85626,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+hVX
+lTa
+ljK
 abI
 clw
 clw
@@ -85814,7 +85885,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+vQM
 aaa
 aaa
 aaa
@@ -86071,7 +86142,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+vQM
 aaa
 aaa
 aaa
@@ -86328,7 +86399,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+xMJ
 aaa
 aaa
 aaa
@@ -86585,7 +86656,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+mMC
 aaa
 aaa
 aaa
@@ -86842,7 +86913,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+mMC
 aaa
 aaa
 aaa
@@ -87099,7 +87170,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+mBp
 aaa
 aaa
 aaa

--- a/_maps/map_files/Pubbystation/pubbystation.dmm
+++ b/_maps/map_files/Pubbystation/pubbystation.dmm
@@ -14697,16 +14697,8 @@
 /area/station/medical/medbay/lobby)
 "blr" = (
 /obj/structure/table,
-/obj/item/storage/medkit/civil_defense/stocked{
-	pixel_x = 4;
-	pixel_y = 0
-	},
 /obj/effect/turf_decal/tile/pine_green/anticorner/contrasted{
 	dir = 4
-	},
-/obj/item/storage/medkit/civil_defense/stocked{
-	pixel_x = -6;
-	pixel_y = 0
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
@@ -29304,20 +29296,8 @@
 /turf/open/floor/plating/airless,
 /area/station/maintenance/department/engine)
 "dRU" = (
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/flora/bush/pale/style_random,
-/obj/structure/flora/bush/lavendergrass/style_random,
-/obj/structure/flora/grass/brown/style_random,
-/obj/structure/flora/rock/pile/icy,
-/obj/structure/flora/bush/reed/style_random,
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/flora/bush/large/style_random{
-	pixel_x = -17;
-	pixel_y = 3
-	},
-/turf/open/floor/grass,
+/obj/machinery/medical_kiosk,
+/turf/open/floor/iron/white/smooth_large,
 /area/station/medical/medbay/lobby)
 "dSr" = (
 /obj/item/chair,
@@ -30671,6 +30651,9 @@
 "eYd" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
+	dir = 4
+	},
 /turf/open/space,
 /area/space/nearstation)
 "eYM" = (
@@ -31992,7 +31975,6 @@
 /obj/effect/turf_decal/tile/pine_green,
 /obj/effect/landmark/start/hangover,
 /obj/machinery/door/firedoor,
-/obj/structure/sign/departments/med_alt/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "gam" = (
@@ -34254,6 +34236,14 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine,
 /area/station/science/lab)
+"hTs" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
+/turf/open/space,
+/area/space/nearstation)
 "hUx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -35360,11 +35350,10 @@
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "iQR" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "iRD" = (
@@ -37413,6 +37402,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/medbay)
+"kAR" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 5
+	},
+/turf/open/space,
+/area/space/nearstation)
 "kCc" = (
 /obj/structure/plasticflaps/opaque,
 /obj/machinery/conveyor{
@@ -37799,6 +37795,21 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/commons/dorms)
+"kTv" = (
+/obj/machinery/door/window/right/directional/north{
+	name = "Medbay Front Desk";
+	req_access = list("medical")
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
+/obj/structure/table/reinforced,
+/obj/item/storage/medkit/civil_defense/comfort/stocked,
+/obj/item/storage/medkit/civil_defense/comfort/stocked{
+	pixel_x = 8;
+	pixel_y = 0
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "kUj" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -38549,16 +38560,10 @@
 /turf/open/floor/iron/dark,
 /area/station/service/library/lounge)
 "lxx" = (
-/obj/machinery/door/window/right/directional/west{
-	name = "Medbay Front Desk";
-	req_access = list("medical")
-	},
-/obj/machinery/door/firedoor,
-/obj/item/storage/medkit/civil_defense/comfort/stocked,
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
-/obj/structure/table/reinforced,
-/turf/open/floor/iron/white,
-/area/station/security/checkpoint/medical)
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/turf/open/space/basic,
+/area/space/nearstation)
 "lyd" = (
 /obj/effect/landmark/start/security_officer,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
@@ -39149,6 +39154,14 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark/small,
 /area/station/science/lab)
+"lZZ" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
+/turf/open/space/basic,
+/area/space/nearstation)
 "maH" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -39822,6 +39835,13 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/wood/large,
 /area/station/science/breakroom)
+"mBn" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 9
+	},
+/turf/open/space,
+/area/space/nearstation)
 "mBu" = (
 /obj/item/book/bible,
 /obj/structure/altar_of_gods,
@@ -41531,6 +41551,13 @@
 	},
 /turf/closed/wall/r_wall,
 /area/station/science/ordnance/burnchamber)
+"nXj" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
+/turf/open/space,
+/area/space/nearstation)
 "nXy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -41651,6 +41678,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"ocA" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 10
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "ocZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -43799,7 +43833,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
 /obj/machinery/atmospherics/pipe/layer_manifold/yellow/visible{
 	dir = 4
 	},
@@ -44772,12 +44805,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "qoi" = (
-/obj/machinery/vending/medical,
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/pine_green/half/contrasted{
 	dir = 8
 	},
+/obj/machinery/smartfridge/chemistry/preloaded,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "qoW" = (
@@ -45101,6 +45134,15 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
+"qAG" = (
+/obj/effect/turf_decal/tile/pine_green/half/contrasted{
+	dir = 8
+	},
+/obj/structure/bed/medical/emergency,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 4
+	},
+/area/station/medical/medbay/lobby)
 "qAQ" = (
 /obj/structure/cable,
 /obj/machinery/holopad,
@@ -46545,8 +46587,10 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/maintenance/disposal/incinerator)
 "rGo" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "rGD" = (
@@ -48038,10 +48082,6 @@
 "sLv" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/machinery/door/firedoor,
-/obj/item/storage/medkit/civil_defense/comfort/stocked{
-	pixel_x = 7;
-	pixel_y = 37
-	},
 /obj/item/paper_bin,
 /obj/effect/turf_decal/tile/dark_blue/opposingcorners,
 /obj/structure/table/reinforced,
@@ -49252,9 +49292,6 @@
 "tzM" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/pine_green/fourcorners,
-/obj/machinery/door/airlock/multi_tile/public/glass{
-	name = "Medbay Lobby"
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "tAh" = (
@@ -51595,6 +51632,13 @@
 	},
 /turf/open/floor/wood,
 /area/station/science/lab)
+"vjO" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 6
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "vkt" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark/textured,
@@ -51697,6 +51741,13 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
+"vph" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "vpr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -51716,10 +51767,8 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/funeral)
 "vrw" = (
+/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 5
-	},
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "vrx" = (
@@ -52145,9 +52194,6 @@
 /turf/open/floor/iron/dark,
 /area/station/service/library/artgallery)
 "vJD" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/layer_manifold/dark/visible,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -52186,7 +52232,7 @@
 /area/station/engineering/storage_shared)
 "vLx" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 9
+	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
@@ -53000,15 +53046,12 @@
 /turf/closed/wall,
 /area/station/maintenance/department/crew_quarters/dorms)
 "wnh" = (
-/obj/effect/turf_decal/tile/pine_green/half/contrasted,
-/obj/machinery/medical_kiosk,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 9
 	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/medbay/lobby)
+/turf/open/space/basic,
+/area/space/nearstation)
 "wns" = (
 /obj/structure/closet/crate/freezer/surplus_limbs,
 /obj/effect/turf_decal/weather/snow/corner,
@@ -53962,10 +54005,10 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "wWR" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 10
+	dir = 4
 	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "wXr" = (
@@ -54141,13 +54184,13 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/engineering/atmos)
 "xca" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold/cyan/visible,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
+/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
+/turf/open/space/basic,
+/area/space/nearstation)
 "xci" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 1
@@ -55438,6 +55481,14 @@
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/pine_green/anticorner/contrasted,
 /obj/structure/table,
+/obj/item/storage/medkit/civil_defense/stocked{
+	pixel_x = -6;
+	pixel_y = 0
+	},
+/obj/item/storage/medkit/civil_defense/stocked{
+	pixel_x = 4;
+	pixel_y = 0
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "xTh" = (
@@ -55455,6 +55506,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/storage_shared)
+"xTA" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "xTH" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/cup/glass/bottle/wine{
@@ -85051,10 +85109,10 @@ lEs
 gMY
 xIP
 vPE
-bpR
+kTv
 lOw
-hZH
-hZH
+qAG
+qAG
 bvl
 bwO
 aIr
@@ -85561,7 +85619,7 @@ sMg
 bik
 bja
 bja
-lxx
+ulq
 sLv
 ulq
 bja
@@ -86592,7 +86650,7 @@ cpY
 cqa
 wFr
 ufo
-wnh
+mPv
 pSy
 brj
 sWH
@@ -91766,7 +91824,7 @@ bOk
 wCz
 bXx
 qIz
-vzg
+fBp
 abI
 bJP
 bJP
@@ -92281,7 +92339,7 @@ wCz
 wwr
 sEx
 vrw
-abI
+kAR
 mkf
 cbv
 ccn
@@ -92794,8 +92852,8 @@ pyH
 wCz
 pyH
 uWA
-xgG
-abI
+vjO
+mBn
 bJP
 bJP
 bJP
@@ -93565,7 +93623,7 @@ jty
 bMe
 pHb
 gQj
-xca
+eGT
 fda
 caH
 oCb
@@ -94839,16 +94897,16 @@ vzg
 xgG
 wWR
 pFG
+vzg
 rGo
-eGT
-rGo
+fBp
 pFG
+vzg
 rGo
-eGT
 iQR
 pFG
+vzg
 rGo
-eGT
 vLx
 hzr
 ssZ
@@ -95094,7 +95152,7 @@ fBp
 avD
 abI
 mDo
-abI
+nXj
 avD
 abI
 mDo
@@ -95106,7 +95164,7 @@ wLU
 oln
 cAO
 mOH
-cAO
+hTs
 aor
 eTY
 aqp
@@ -95347,23 +95405,23 @@ bGj
 buz
 seI
 mBU
-bJP
-bMi
-mkf
-bIH
-bJP
-bMi
-mkf
-bIH
-bJP
-bMi
-mkf
-bIH
-bJP
-bMi
-mkf
-bIH
-bJP
+aht
+vph
+aht
+xTA
+ocA
+xca
+lxx
+lZZ
+lxx
+xca
+lxx
+lZZ
+lxx
+xca
+lxx
+lZZ
+wnh
 bYw
 tfh
 aAu
@@ -95605,21 +95663,21 @@ buz
 rsP
 trt
 bJP
-bMj
-bNo
-bII
+bMi
+mkf
+bIH
 bJP
-bPZ
-bQP
-bSc
+bMi
+mkf
+bIH
 bJP
-bSW
-bTV
-feh
+bMi
+mkf
+bIH
 bJP
-bWe
-bWT
-mZO
+bMi
+mkf
+bIH
 bJP
 bYw
 yby
@@ -95862,21 +95920,21 @@ wfY
 uuX
 jhq
 bJP
-awr
-bLe
-bLe
+bMj
+bNo
+bII
 bJP
-bQb
-bPh
-bQb
+bPZ
+bQP
+bSc
 bJP
-bSY
-bSk
-bSY
+bSW
+bTV
+feh
 bJP
-bWg
-bVo
-bWg
+bWe
+bWT
+mZO
 bJP
 bYw
 udE
@@ -96119,20 +96177,20 @@ iIT
 iIT
 aaa
 bJP
+awr
 bLe
-bzy
 bLe
 bJP
-aAa
-bQH
+bQb
+bPh
 bQb
 bJP
-ubq
-bVn
+bSY
+bSk
 bSY
 bJP
-lMN
-mrv
+bWg
+bVo
 bWg
 bJP
 bYw
@@ -96376,21 +96434,21 @@ umw
 iIT
 aaa
 bJP
+bLe
+bzy
+bLe
 bJP
+aAa
+bQH
+bQb
 bJP
+ubq
+bVn
+bSY
 bJP
-bJP
-bJP
-bJP
-bJP
-bJP
-bJP
-bJP
-bJP
-bJP
-bJP
-bJP
-bJP
+lMN
+mrv
+bWg
 bJP
 bYw
 ayY
@@ -96632,23 +96690,23 @@ oBc
 wRy
 iIT
 aaa
-aaa
-aaa
-aht
-aaa
-aht
-aaa
-aaa
-aaa
-abI
-aaa
-aaa
-aaa
-abI
-aaa
-aaa
-aaa
-abI
+bJP
+bJP
+bJP
+bJP
+bJP
+bJP
+bJP
+bJP
+bJP
+bJP
+bJP
+bJP
+bJP
+bJP
+bJP
+bJP
+bJP
 bYw
 bYw
 aqx

--- a/_maps/map_files/Pubbystation/pubbystation.dmm
+++ b/_maps/map_files/Pubbystation/pubbystation.dmm
@@ -23085,9 +23085,7 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/engineering/atmos)
 "bXx" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/engineering/atmos)
 "bXy" = (
@@ -23729,7 +23727,7 @@
 /area/station/engineering/atmos)
 "caC" = (
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
 "caE" = (
@@ -36425,12 +36423,10 @@
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "jNe" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/electric_yellow/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/engineering/atmos)
 "jNg" = (
@@ -39428,8 +39424,8 @@
 /turf/open/floor/plating/airless,
 /area/station/engineering/atmos)
 "mkS" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1
 	},
@@ -49147,8 +49143,8 @@
 /turf/open/floor/iron/dark,
 /area/station/service/abandoned_gambling_den)
 "tvq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "tvr" = (
@@ -53295,11 +53291,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "wwr" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 10
-	},
-/turf/open/floor/iron/white/smooth_large,
-/area/station/engineering/atmos)
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/turf/open/space,
+/area/space/nearstation)
 "wwG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -91071,7 +91066,7 @@ xhP
 qbv
 mkS
 tvq
-bZL
+wwr
 caC
 jOk
 cbs
@@ -92353,7 +92348,7 @@ bXC
 sGc
 bpQ
 wCz
-wwr
+bXx
 sEx
 vrw
 hrx

--- a/_maps/map_files/Pubbystation/pubbystation.dmm
+++ b/_maps/map_files/Pubbystation/pubbystation.dmm
@@ -15448,6 +15448,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
+"bpQ" = (
+/obj/effect/landmark/blobstart,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/engineering/atmos)
 "bpR" = (
 /obj/machinery/door/window/right/directional/north{
 	name = "Medbay Front Desk";
@@ -84215,7 +84219,7 @@ bja
 bja
 bja
 bja
-bja
+bjc
 djh
 xte
 bIy
@@ -92212,7 +92216,7 @@ bRx
 bPQ
 bXC
 sGc
-bWO
+bpQ
 wCz
 wwr
 sEx

--- a/_maps/map_files/Pubbystation/pubbystation.dmm
+++ b/_maps/map_files/Pubbystation/pubbystation.dmm
@@ -918,15 +918,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay)
-"aex" = (
-/obj/effect/turf_decal/tile/pine_green/half/contrasted{
-	dir = 8
-	},
-/obj/structure/bed/medical/emergency,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 4
-	},
-/area/station/medical/medbay/lobby)
 "aey" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/iron,
@@ -4415,7 +4406,6 @@
 "asV" = (
 /obj/structure/closet/crate/goldcrate,
 /obj/machinery/light_switch/directional/west,
-/obj/item/skub,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "asX" = (
@@ -4738,12 +4728,14 @@
 /area/station/ai_monitored/command/nuke_storage)
 "aue" = (
 /obj/structure/safe,
-/obj/item/bikehorn/golden,
-/obj/item/ammo_box/a357,
-/obj/item/tank/internals/plasma/full,
-/obj/item/disk/nuclear/fake,
-/obj/item/stack/ore/diamond,
-/obj/item/gun/energy/disabler,
+/obj/item/blueprints,
+/obj/item/epic_loot/intel_folder,
+/obj/item/folder/biscuit/confidential/emergency_spare_id_safe_code,
+/obj/item/skillchip/disk_verifier,
+/obj/item/station_charter/admin{
+	desc = "An official document entrusting the governance of the station and surrounding space to the Port Authority, and their appointed Captain."
+	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "auf" = (
@@ -5557,16 +5549,13 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "awP" = (
-/obj/machinery/door/window/right/directional/north{
-	name = "Brig Desk";
-	req_access = list("brig_entrance")
-	},
 /obj/machinery/door/poddoor/preopen{
 	id = "Secure Gate";
 	name = "Brig Shutters"
 	},
 /obj/structure/table/reinforced,
 /obj/item/food/donut/plain,
+/obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "awQ" = (
@@ -11180,6 +11169,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/service)
+"aWe" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 6
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "aWf" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Bar Access"
@@ -13313,13 +13309,6 @@
 "beI" = (
 /turf/closed/wall/r_wall,
 /area/station/science/robotics/mechbay)
-"beM" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "beP" = (
 /obj/machinery/computer/order_console/mining,
 /obj/effect/turf_decal/trimline/brown/filled/end{
@@ -26773,21 +26762,6 @@
 /obj/machinery/vending/wardrobe/chap_wardrobe,
 /turf/open/floor/carpet,
 /area/station/service/chapel/office)
-"ctY" = (
-/obj/machinery/door/window/right/directional/north{
-	name = "Medbay Front Desk";
-	req_access = list("medical")
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
-/obj/structure/table/reinforced,
-/obj/item/storage/medkit/civil_defense/comfort/stocked,
-/obj/item/storage/medkit/civil_defense/comfort/stocked{
-	pixel_x = 8;
-	pixel_y = 0
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
 "ctZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -29109,13 +29083,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"dIU" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 5
-	},
-/turf/open/space,
-/area/space/nearstation)
 "dJm" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Research Pit"
@@ -29274,13 +29241,6 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/station/science/ordnance/burnchamber)
-"dPr" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 6
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
 "dPO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -30369,6 +30329,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"eKN" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
+/turf/open/space,
+/area/space/nearstation)
 "eKY" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
@@ -31829,6 +31797,13 @@
 /obj/effect/turf_decal/tile/dark/diagonal_edge,
 /turf/open/floor/iron/white/diagonal,
 /area/station/ai_monitored/turret_protected/ai_upload)
+"fPW" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 9
+	},
+/turf/open/space,
+/area/space/nearstation)
 "fQd" = (
 /obj/machinery/conveyor{
 	id = "CargoLoad"
@@ -32396,14 +32371,6 @@
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
-"gsA" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
-/turf/open/space/basic,
-/area/space/nearstation)
 "gsB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -33831,11 +33798,6 @@
 /obj/structure/girder,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
-"hBl" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/turf/open/space/basic,
-/area/space/nearstation)
 "hBn" = (
 /obj/effect/turf_decal/tile/pine_green{
 	dir = 4
@@ -34563,6 +34525,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"igz" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
 "igC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/structure/lattice,
@@ -35611,12 +35577,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden/monastery)
-"jci" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable,
-/obj/structure/transit_tube/crossing,
-/turf/open/space/basic,
-/area/space/nearstation)
 "jcT" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -36462,13 +36422,6 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/closed/wall,
 /area/station/commons/fitness)
-"jNJ" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/turf/open/space,
-/area/space/nearstation)
 "jNZ" = (
 /obj/item/flashlight/lantern,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -38603,11 +38556,10 @@
 /turf/open/floor/iron/dark,
 /area/station/service/library/lounge)
 "lxx" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 9
-	},
-/turf/open/space,
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/obj/structure/transit_tube/crossing,
+/turf/open/space/basic,
 /area/space/nearstation)
 "lyd" = (
 /obj/effect/landmark/start/security_officer,
@@ -38638,6 +38590,13 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/science/lab)
+"lzT" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 5
+	},
+/turf/open/space,
+/area/space/nearstation)
 "lAa" = (
 /obj/machinery/computer/records/security,
 /obj/machinery/requests_console/directional/east{
@@ -39978,6 +39937,13 @@
 /obj/machinery/light/dim/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/service/library/artgallery)
+"mFA" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 9
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "mFJ" = (
 /obj/effect/turf_decal/tile/electric_yellow,
 /obj/effect/turf_decal/stripes/corner{
@@ -40142,6 +40108,11 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/command/bridge)
+"mOm" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/turf/open/space/basic,
+/area/space/nearstation)
 "mOt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -40165,6 +40136,21 @@
 /obj/effect/spawner/random/glass_debris,
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical)
+"mOy" = (
+/obj/machinery/door/window/right/directional/north{
+	name = "Medbay Front Desk";
+	req_access = list("medical")
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
+/obj/structure/table/reinforced,
+/obj/item/storage/medkit/civil_defense/comfort/stocked,
+/obj/item/storage/medkit/civil_defense/comfort/stocked{
+	pixel_x = 8;
+	pixel_y = 0
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "mOH" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
@@ -43079,6 +43065,13 @@
 	},
 /turf/open/floor/carpet/red,
 /area/station/medical/psychology)
+"pde" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
+/turf/open/space,
+/area/space/nearstation)
 "pdq" = (
 /obj/effect/decal/cleanable/oil,
 /obj/structure/maintenance_loot_structure/military_case/random,
@@ -43846,9 +43839,6 @@
 /turf/open/floor/grass,
 /area/station/hallway/secondary/exit/departure_lounge)
 "pFG" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/layer_manifold/yellow/visible{
 	dir = 4
 	},
@@ -45150,13 +45140,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
-"qAI" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 10
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "qAQ" = (
 /obj/structure/cable,
 /obj/machinery/holopad,
@@ -45974,6 +45957,13 @@
 /obj/structure/flora/bush/large/style_random,
 /turf/open/floor/grass,
 /area/station/science/genetics)
+"rlA" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "rlR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -46601,13 +46591,9 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/maintenance/disposal/incinerator)
 "rGo" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/engineering/atmos/hfr_room)
 "rGD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/effect/spawner/structure/window/reinforced,
@@ -46640,13 +46626,6 @@
 /obj/effect/landmark/start/bitrunner,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/cargo/bitrunning/den)
-"rHM" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
 "rIm" = (
 /obj/machinery/newscaster/directional/east,
 /turf/closed/wall/r_wall,
@@ -46772,7 +46751,7 @@
 /obj/machinery/atmospherics/components/unary/passive_vent/layer2{
 	dir = 1
 	},
-/obj/structure/lattice,
+/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
 "rLQ" = (
@@ -47273,6 +47252,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
+"seF" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/obj/structure/transit_tube,
+/turf/open/space/basic,
+/area/space/nearstation)
 "seI" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -47682,14 +47667,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white/smooth_half,
 /area/station/medical/medbay/central)
-"suZ" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/turf/open/space,
-/area/space/nearstation)
 "svb" = (
 /obj/structure/chair/office/tactical{
 	dir = 1
@@ -48843,6 +48820,13 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/bar)
+"tkm" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "tko" = (
 /turf/closed/wall,
 /area/station/cargo/drone_bay)
@@ -49374,6 +49358,15 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
 /area/station/service/library/artgallery)
+"tBo" = (
+/obj/effect/turf_decal/tile/pine_green/half/contrasted{
+	dir = 8
+	},
+/obj/structure/bed/medical/emergency,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 4
+	},
+/area/station/medical/medbay/lobby)
 "tBs" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/cup/glass/trophy{
@@ -50960,13 +50953,6 @@
 /obj/structure/chair/stool/bar/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
-"uJb" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "uKD" = (
 /obj/structure/chair,
 /obj/machinery/light/directional/north,
@@ -52699,6 +52685,13 @@
 /obj/machinery/vending/boozeomat,
 /turf/closed/wall,
 /area/station/service/bar)
+"wav" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 10
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "waG" = (
 /obj/structure/table/optable,
 /obj/effect/turf_decal/tile/pine_green/half/contrasted{
@@ -53069,9 +53062,11 @@
 /turf/closed/wall,
 /area/station/maintenance/department/crew_quarters/dorms)
 "wnh" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable,
-/obj/structure/transit_tube,
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
 /turf/open/space/basic,
 /area/space/nearstation)
 "wns" = (
@@ -54207,9 +54202,10 @@
 /area/station/engineering/atmos)
 "xca" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
 /turf/open/space/basic,
 /area/space/nearstation)
 "xci" = (
@@ -54481,6 +54477,13 @@
 /obj/structure/cable,
 /turf/open/floor/plastic,
 /area/station/security/lockers)
+"xjV" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "xjZ" = (
 /obj/effect/landmark/start/hangover,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -85123,10 +85126,10 @@ lEs
 gMY
 xIP
 vPE
-ctY
+mOy
 lOw
-aex
-aex
+tBo
+tBo
 bvl
 bwO
 aIr
@@ -89679,13 +89682,13 @@ agE
 agS
 agS
 ahs
-wnh
-wnh
-jci
-wnh
-wnh
-wnh
-wnh
+seF
+seF
+lxx
+seF
+seF
+seF
+seF
 ahR
 ahs
 ahs
@@ -92353,7 +92356,7 @@ wCz
 wwr
 sEx
 vrw
-dIU
+lzT
 mkf
 cbv
 ccn
@@ -92866,8 +92869,8 @@ pyH
 wCz
 pyH
 uWA
-dPr
-lxx
+aWe
+fPW
 bJP
 bJP
 bJP
@@ -94167,7 +94170,7 @@ pjM
 pjM
 hCg
 tSV
-aaa
+aht
 aaa
 aaa
 aaa
@@ -94420,11 +94423,11 @@ bOZ
 pGV
 pjM
 pjM
-pjM
-pjM
+rGo
+rGo
 wfp
 lnK
-aaa
+rLJ
 aaa
 aaa
 aaa
@@ -94681,7 +94684,7 @@ pjM
 pjM
 mtW
 tSV
-aaa
+aht
 aaa
 aaa
 aaa
@@ -94912,15 +94915,15 @@ xgG
 wWR
 pFG
 vzg
-rHM
+rlA
 fBp
 pFG
 vzg
-rHM
+rlA
 iQR
 pFG
 vzg
-rHM
+rlA
 vLx
 hzr
 ssZ
@@ -95166,7 +95169,7 @@ fBp
 avD
 abI
 mDo
-jNJ
+pde
 avD
 abI
 mDo
@@ -95178,7 +95181,7 @@ wLU
 oln
 cAO
 mOH
-suZ
+eKN
 aor
 eTY
 aqp
@@ -95420,22 +95423,22 @@ buz
 seI
 mBU
 aht
-beM
+tkm
 aht
-uJb
-qAI
-rGo
-hBl
-gsA
-hBl
-rGo
-hBl
-gsA
-hBl
-rGo
-hBl
-gsA
+xjV
+wav
 xca
+mOm
+wnh
+mOm
+xca
+mOm
+wnh
+mOm
+xca
+mOm
+wnh
+mFA
 bYw
 tfh
 aAu
@@ -96731,7 +96734,7 @@ bYw
 klp
 njg
 ryS
-aaa
+igz
 gYo
 aaa
 aaa

--- a/_maps/map_files/Pubbystation/pubbystation.dmm
+++ b/_maps/map_files/Pubbystation/pubbystation.dmm
@@ -33582,10 +33582,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/science/research)
-"hrx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/turf/closed/wall/r_wall,
-/area/station/engineering/atmos)
 "hsQ" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -48197,11 +48193,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
-"sRP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
 "sSd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/plating,
@@ -49112,6 +49103,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/abandoned_gambling_den)
+"tvq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "tvr" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
@@ -51747,6 +51743,10 @@
 "vpC" = (
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/funeral)
+"vrw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos)
 "vrx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
@@ -82854,10 +82854,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
 abI
 aaa
 aaa
@@ -82874,6 +82870,10 @@ aaa
 aaa
 aaa
 abI
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -83109,10 +83109,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
 adR
 adR
 adR
@@ -83135,6 +83131,10 @@ adR
 adR
 aaa
 adR
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -83368,10 +83368,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
 abI
 aaa
 aaa
@@ -83392,6 +83388,10 @@ aaa
 aaa
 aaa
 adR
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -83620,10 +83620,6 @@ aht
 aht
 aht
 aht
-aht
-aht
-aht
-aht
 abI
 abI
 abI
@@ -83650,6 +83646,10 @@ cmB
 cny
 adR
 abI
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -83880,10 +83880,6 @@ cig
 cgP
 cgP
 cgP
-cig
-cgP
-cgP
-cgP
 clC
 clH
 clP
@@ -83906,6 +83902,10 @@ cnr
 cmB
 aaa
 adR
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -84134,10 +84134,6 @@ pEK
 pEK
 pEK
 pEK
-pEK
-pEK
-pEK
-pEK
 blf
 clw
 clw
@@ -84163,6 +84159,10 @@ cns
 cmB
 aaa
 adR
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -84391,10 +84391,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
 teJ
 lci
 btK
@@ -84420,6 +84416,10 @@ cnt
 cmB
 aaa
 adR
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -84648,10 +84648,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
 iBJ
 clw
 hQz
@@ -84678,6 +84674,10 @@ cmB
 bfr
 adR
 abI
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -84905,10 +84905,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
 aht
 clw
 nTk
@@ -84934,6 +84930,10 @@ eel
 cmB
 aaa
 adR
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -85162,10 +85162,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
 aht
 clw
 lou
@@ -85191,6 +85187,10 @@ cnw
 cmB
 aaa
 adR
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -85419,10 +85419,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
 abI
 clw
 ckM
@@ -85448,6 +85444,10 @@ cnx
 cmB
 aaa
 adR
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -85676,10 +85676,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
 abI
 clw
 clw
@@ -85706,6 +85702,10 @@ cmB
 cnz
 adR
 abI
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -85938,10 +85938,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
 abI
 aaa
 aaa
@@ -85962,6 +85958,10 @@ aaa
 aaa
 aaa
 adR
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -86193,10 +86193,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
 adR
 adR
 adR
@@ -86219,6 +86215,10 @@ adR
 adR
 aaa
 adR
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -86452,10 +86452,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
 abI
 aaa
 aaa
@@ -86472,6 +86468,10 @@ aaa
 aaa
 aaa
 abI
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -91016,7 +91016,7 @@ xhP
 xhP
 qbv
 mkS
-sRP
+tvq
 bZL
 caC
 jOk
@@ -91787,7 +91787,7 @@ bOk
 wCz
 mvA
 qIz
-hrx
+vrw
 bZL
 bJP
 bJP
@@ -92815,7 +92815,7 @@ pyH
 wCz
 pyH
 mkS
-sRP
+tvq
 abI
 bJP
 bJP

--- a/_maps/map_files/Pubbystation/pubbystation.dmm
+++ b/_maps/map_files/Pubbystation/pubbystation.dmm
@@ -29273,6 +29273,15 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/command/bridge)
+"dQO" = (
+/obj/effect/turf_decal/tile/pine_green/half/contrasted{
+	dir = 8
+	},
+/obj/structure/bed/medical/emergency,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 4
+	},
+/area/station/medical/medbay/lobby)
 "dQU" = (
 /obj/effect/turf_decal/siding/corner{
 	dir = 4
@@ -30182,13 +30191,6 @@
 /obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
-"eFe" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "eFj" = (
 /obj/effect/turf_decal/tile/pine_green{
 	dir = 4
@@ -30362,21 +30364,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
-"eNf" = (
-/obj/machinery/door/window/right/directional/north{
-	name = "Medbay Front Desk";
-	req_access = list("medical")
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
-/obj/structure/table/reinforced,
-/obj/item/storage/medkit/civil_defense/comfort/stocked,
-/obj/item/storage/medkit/civil_defense/comfort/stocked{
-	pixel_x = 8;
-	pixel_y = 0
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
 "eNo" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/heater{
 	dir = 8
@@ -31361,13 +31348,6 @@
 /obj/item/beacon,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
-"fvY" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 9
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "fwe" = (
 /obj/machinery/firealarm/directional/west,
 /obj/structure/chair/office{
@@ -32577,6 +32557,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
+"gzs" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
 "gzy" = (
 /obj/structure/sign/poster/official/random/directional/south,
 /obj/effect/turf_decal/tile/red{
@@ -33104,6 +33088,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
+"gUH" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 6
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "gUJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -33899,6 +33890,13 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/station/hallway/primary/aft)
+"hEW" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
+/turf/open/space,
+/area/space/nearstation)
 "hEX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -34219,7 +34217,7 @@
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/hop)
 "hRF" = (
-/obj/structure/lattice,
+/obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon/burgundy,
 /turf/open/space,
 /area/space/nearstation)
@@ -34393,6 +34391,13 @@
 "hXW" = (
 /turf/closed/wall,
 /area/station/hallway/secondary/entry)
+"hYv" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "hYR" = (
 /obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 4
@@ -35104,12 +35109,13 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "iFA" = (
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
+/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
+/turf/open/space/basic,
+/area/space/nearstation)
 "iFI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -36546,6 +36552,11 @@
 /obj/structure/sign/departments/science,
 /turf/closed/wall,
 /area/station/maintenance/department/medical)
+"jSE" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/turf/open/space/basic,
+/area/space/nearstation)
 "jSF" = (
 /turf/closed/wall/r_wall,
 /area/station/hallway/secondary/command)
@@ -36665,6 +36676,14 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/medbay/lobby)
+"jWR" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
+/turf/open/space,
+/area/space/nearstation)
 "jXw" = (
 /obj/effect/landmark/start/hangover,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -36832,13 +36851,6 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/dock)
-"khj" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 10
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "khk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -36917,6 +36929,21 @@
 	},
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/secondary/entry)
+"kiw" = (
+/obj/machinery/door/window/right/directional/north{
+	name = "Medbay Front Desk";
+	req_access = list("medical")
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
+/obj/structure/table/reinforced,
+/obj/item/storage/medkit/civil_defense/comfort/stocked,
+/obj/item/storage/medkit/civil_defense/comfort/stocked{
+	pixel_x = 8;
+	pixel_y = 0
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "kjm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -37629,14 +37656,6 @@
 /obj/structure/maintenance_loot_structure/toolbox/random,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
-"kIB" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
-/turf/open/space/basic,
-/area/space/nearstation)
 "kJm" = (
 /obj/item/clothing/gloves/color/fyellow,
 /obj/item/wrench,
@@ -37933,13 +37952,6 @@
 /obj/effect/spawner/random/structure/steam_vent,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
-"kZi" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "kZq" = (
 /obj/effect/spawner/random/food_or_drink/donkpockets,
 /obj/item/wallframe/telescreen/entertainment{
@@ -38228,6 +38240,13 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"ljp" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 5
+	},
+/turf/open/space,
+/area/space/nearstation)
 "ljs" = (
 /obj/effect/spawner/random/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -38585,8 +38604,9 @@
 /turf/open/floor/iron/dark,
 /area/station/service/library/lounge)
 "lxx" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/obj/structure/transit_tube,
 /turf/open/space/basic,
 /area/space/nearstation)
 "lyd" = (
@@ -39996,6 +40016,10 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
 /turf/open/floor/iron/white,
 /area/station/maintenance/disposal/incinerator)
+"mHO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/engineering/atmos/hfr_room)
 "mIa" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -41561,10 +41585,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/station/science/ordnance/burnchamber)
-"nXt" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
 "nXy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -41633,13 +41653,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
-"oaD" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 9
-	},
-/turf/open/space,
-/area/space/nearstation)
 "oaI" = (
 /turf/open/floor/iron/dark/small,
 /area/station/science/lab)
@@ -41709,6 +41722,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
+"odk" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 10
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "odp" = (
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 8
@@ -46586,10 +46606,8 @@
 /area/station/maintenance/disposal/incinerator)
 "rGo" = (
 /obj/structure/lattice/catwalk,
-/obj/structure/cable,
-/obj/structure/transit_tube,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "rGD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/effect/spawner/structure/window/reinforced,
@@ -47327,6 +47345,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"shY" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "sij" = (
 /obj/structure/closet,
 /obj/item/food/meat/slab/monkey,
@@ -47646,13 +47671,6 @@
 	dir = 1
 	},
 /area/station/science/ordnance)
-"suG" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/turf/open/space,
-/area/space/nearstation)
 "suN" = (
 /obj/effect/turf_decal/siding/green{
 	dir = 4
@@ -47991,13 +48009,6 @@
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
-"sFl" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 5
-	},
-/turf/open/space,
-/area/space/nearstation)
 "sFA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -49863,6 +49874,13 @@
 /obj/structure/reflector/box/anchored,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
+"tZy" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "tZU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/closed/wall/r_wall,
@@ -51981,14 +51999,6 @@
 /obj/structure/table/reinforced/plasmarglass,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
-"vyl" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
-/turf/open/space/basic,
-/area/space/nearstation)
 "vyn" = (
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 1
@@ -52045,14 +52055,6 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/storage)
-"vBT" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/turf/open/space,
-/area/space/nearstation)
 "vBZ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -52380,13 +52382,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/supply/general,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
-"vQX" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 6
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
 "vRi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -52526,15 +52521,6 @@
 "vTg" = (
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/chem_storage)
-"vTF" = (
-/obj/effect/turf_decal/tile/pine_green/half/contrasted{
-	dir = 8
-	},
-/obj/structure/bed/medical/emergency,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 4
-	},
-/area/station/medical/medbay/lobby)
 "vTL" = (
 /obj/machinery/vending/tool,
 /turf/open/floor/iron/dark,
@@ -53075,9 +53061,11 @@
 /turf/closed/wall,
 /area/station/maintenance/department/crew_quarters/dorms)
 "wnh" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/marker_beacon/burgundy,
-/turf/open/space,
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 9
+	},
+/turf/open/space/basic,
 /area/space/nearstation)
 "wns" = (
 /obj/structure/closet/crate/freezer/surplus_limbs,
@@ -54213,9 +54201,11 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/engineering/atmos)
 "xca" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable,
-/obj/structure/transit_tube/crossing,
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
 /turf/open/space/basic,
 /area/space/nearstation)
 "xci" = (
@@ -55024,10 +55014,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
-"xzs" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/engineering/atmos/hfr_room)
 "xzF" = (
 /turf/closed/wall/mineral/iron,
 /area/station/service/chapel/storage)
@@ -55627,6 +55613,12 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/engineering/atmos)
+"xXw" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/obj/structure/transit_tube/crossing,
+/turf/open/space/basic,
+/area/space/nearstation)
 "xXQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -55834,6 +55826,13 @@
 	dir = 1
 	},
 /area/station/maintenance/department/medical)
+"ygK" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 9
+	},
+/turf/open/space,
+/area/space/nearstation)
 "ygW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -73544,7 +73543,7 @@ aHz
 aTM
 aHz
 abI
-aaa
+rGo
 abI
 aHz
 aTM
@@ -75555,7 +75554,7 @@ aaa
 aaa
 aaa
 aaa
-aht
+cdm
 fon
 fon
 aht
@@ -85133,10 +85132,10 @@ lEs
 gMY
 xIP
 vPE
-eNf
+kiw
 lOw
-vTF
-vTF
+dQO
+dQO
 bvl
 bwO
 aIr
@@ -89689,13 +89688,13 @@ agE
 agS
 agS
 ahs
-rGo
-rGo
-xca
-rGo
-rGo
-rGo
-rGo
+lxx
+lxx
+xXw
+lxx
+lxx
+lxx
+lxx
 ahR
 ahs
 ahs
@@ -92363,7 +92362,7 @@ wCz
 wwr
 sEx
 vrw
-sFl
+ljp
 mkf
 cbv
 ccn
@@ -92876,8 +92875,8 @@ pyH
 wCz
 pyH
 uWA
-vQX
-oaD
+gUH
+ygK
 bJP
 bJP
 bJP
@@ -94430,8 +94429,8 @@ bOZ
 pGV
 pjM
 pjM
-xzs
-xzs
+mHO
+mHO
 wfp
 lnK
 rLJ
@@ -94922,15 +94921,15 @@ xgG
 wWR
 pFG
 vzg
-iFA
+shY
 fBp
 pFG
 vzg
-iFA
+shY
 iQR
 pFG
 vzg
-iFA
+shY
 vLx
 hzr
 ssZ
@@ -95176,7 +95175,7 @@ fBp
 avD
 abI
 mDo
-suG
+hEW
 avD
 abI
 mDo
@@ -95188,7 +95187,7 @@ wLU
 oln
 cAO
 mOH
-vBT
+jWR
 aor
 eTY
 aqp
@@ -95430,22 +95429,22 @@ buz
 seI
 mBU
 aht
-eFe
+tZy
 aht
-kZi
-khj
-kIB
-lxx
-vyl
-lxx
-kIB
-lxx
-vyl
-lxx
-kIB
-lxx
-vyl
-fvY
+hYv
+odk
+xca
+jSE
+iFA
+jSE
+xca
+jSE
+iFA
+jSE
+xca
+jSE
+iFA
+wnh
 bYw
 tfh
 aAu
@@ -96741,7 +96740,7 @@ bYw
 klp
 njg
 ryS
-nXt
+gzs
 gYo
 aaa
 aaa
@@ -99318,7 +99317,7 @@ aaa
 aaa
 aaa
 aaa
-wnh
+hRF
 dKA
 cjv
 cjv
@@ -99804,23 +99803,7 @@ xjC
 xjC
 aht
 abI
-wnh
-abI
-abI
-abI
-wnh
-abI
-abI
-abI
-wnh
-abI
-abI
-abI
-wnh
-abI
-abI
-abI
-wnh
+hRF
 abI
 abI
 abI
@@ -99828,7 +99811,23 @@ hRF
 abI
 abI
 abI
-wnh
+hRF
+abI
+abI
+abI
+hRF
+abI
+abI
+abI
+hRF
+abI
+abI
+abI
+hRF
+abI
+abI
+abI
+hRF
 abI
 abI
 abI
@@ -100318,23 +100317,7 @@ xjC
 xjC
 abI
 abI
-wnh
-abI
-abI
-abI
-wnh
-abI
-abI
-abI
-wnh
-abI
-abI
-abI
-wnh
-abI
-abI
-abI
-wnh
+hRF
 abI
 abI
 abI
@@ -100342,7 +100325,23 @@ hRF
 abI
 abI
 abI
-wnh
+hRF
+abI
+abI
+abI
+hRF
+abI
+abI
+abI
+hRF
+abI
+abI
+abI
+hRF
+abI
+abI
+abI
+hRF
 abI
 abI
 abI
@@ -100860,7 +100859,7 @@ aaa
 aaa
 aaa
 aaa
-wnh
+hRF
 dKA
 cjv
 cjv

--- a/_maps/map_files/Pubbystation/pubbystation.dmm
+++ b/_maps/map_files/Pubbystation/pubbystation.dmm
@@ -15448,10 +15448,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
-"bpQ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/security/checkpoint/medical)
 "bpR" = (
 /obj/machinery/door/window/right/directional/north{
 	name = "Medbay Front Desk";
@@ -15461,7 +15457,7 @@
 /obj/effect/turf_decal/tile/dark_blue/opposingcorners,
 /obj/structure/table/reinforced,
 /turf/open/floor/iron/white,
-/area/station/security/checkpoint/medical)
+/area/station/medical/medbay/lobby)
 "bpT" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/status_display/ai{
@@ -18939,8 +18935,8 @@
 /turf/open/floor/iron/white,
 /area/station/hallway/primary/aft)
 "bFb" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/portable_atmospherics/canister/water_vapor,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/engine,
 /area/station/science/ordnance/storage)
 "bFc" = (
@@ -20957,7 +20953,7 @@
 	},
 /area/station/engineering/atmos)
 "bPh" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/obj/machinery/atmospherics/miner/n2o,
 /turf/open/floor/engine/n2o,
 /area/station/engineering/atmos)
 "bPo" = (
@@ -21693,7 +21689,7 @@
 /turf/open/floor/iron/textured_large,
 /area/station/engineering/atmos)
 "bSk" = (
-/obj/machinery/portable_atmospherics/canister/plasma,
+/obj/machinery/atmospherics/miner/plasma,
 /turf/open/floor/engine/plasma,
 /area/station/engineering/atmos)
 "bSm" = (
@@ -22550,7 +22546,7 @@
 /turf/open/floor/engine/plasma,
 /area/station/engineering/atmos)
 "bVo" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/machinery/atmospherics/miner/carbon_dioxide,
 /turf/open/floor/engine/co2,
 /area/station/engineering/atmos)
 "bVp" = (
@@ -24039,11 +24035,11 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/main)
 "ccm" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/machinery/atmospherics/miner/nitrogen,
 /turf/open/floor/engine/n2,
 /area/station/engineering/atmos)
 "ccn" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/atmospherics/miner/oxygen,
 /turf/open/floor/engine/o2,
 /area/station/engineering/atmos)
 "cco" = (
@@ -28360,8 +28356,13 @@
 /turf/open/floor/iron,
 /area/station/security/office)
 "dcN" = (
-/turf/open/space/basic,
-/area/station/tcommsat/computer)
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/water_vapor,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/engine,
+/area/station/science/ordnance/storage)
 "dcQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
@@ -35005,6 +35006,7 @@
 	network = list("tcomms");
 	start_active = 1
 	},
+/obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
 "iBY" = (
@@ -84728,7 +84730,7 @@ tLk
 bmv
 nAh
 bja
-bpQ
+xQr
 qqQ
 qEf
 bug
@@ -84822,7 +84824,7 @@ aaa
 aaa
 aaa
 aaa
-dcN
+aht
 clw
 nTk
 nTk
@@ -85079,7 +85081,7 @@ aaa
 aaa
 aaa
 aaa
-dcN
+aht
 clw
 lou
 ckM
@@ -85499,7 +85501,7 @@ lxx
 sLv
 ulq
 bja
-bja
+mKE
 vII
 frX
 dRU
@@ -94248,7 +94250,7 @@ bHw
 bBE
 bCQ
 bFc
-bFc
+dcN
 bGh
 pDe
 eAa

--- a/_maps/map_files/Pubbystation/pubbystation.dmm
+++ b/_maps/map_files/Pubbystation/pubbystation.dmm
@@ -4922,8 +4922,9 @@
 /turf/closed/wall,
 /area/station/command/heads_quarters/captain)
 "auI" = (
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/turf/open/floor/iron/white,
+/turf/open/floor/plating,
 /area/station/engineering/atmos/hfr_room)
 "auJ" = (
 /obj/structure/disposalpipe/segment,
@@ -14196,6 +14197,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
+"biA" = (
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/engineering/atmos/hfr_room)
 "biC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -15850,6 +15856,11 @@
 /obj/effect/turf_decal/tile/pine_green/anticorner/contrasted{
 	dir = 4
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "brh" = (
@@ -28469,10 +28480,6 @@
 /area/station/maintenance/department/science/xenobiology)
 "djh" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 1
 	},
@@ -28889,13 +28896,6 @@
 "dAa" = (
 /turf/closed/wall/r_wall,
 /area/station/security/lockers)
-"dAd" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/blue/half/contrasted,
-/turf/open/floor/iron/white/textured_edge{
-	dir = 1
-	},
-/area/station/engineering/atmos/hfr_room)
 "dAF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -33176,13 +33176,6 @@
 "gZl" = (
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/medbay/central)
-"gZm" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white/textured_edge,
-/area/station/engineering/atmos/hfr_room)
 "gZx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -35107,13 +35100,6 @@
 /obj/item/reagent_containers/cup/bucket,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/storage_shared)
-"iFR" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted,
-/obj/structure/cable,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/engineering/atmos/hfr_room)
 "iGi" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/window/spawner/directional/south,
@@ -36220,13 +36206,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "jFQ" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white/textured_edge{
-	dir = 4
-	},
+/turf/open/floor/plating,
 /area/station/engineering/atmos/hfr_room)
 "jFW" = (
 /obj/structure/maintenance_loot_structure/grenade_box/random,
@@ -37640,12 +37623,10 @@
 /area/station/security/range)
 "kJU" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
+	dir = 1
 	},
 /obj/structure/cable,
-/turf/open/floor/iron/white/textured_edge{
-	dir = 4
-	},
+/turf/open/floor/iron/white/textured_edge,
 /area/station/engineering/atmos/hfr_room)
 "kKf" = (
 /obj/item/kirbyplants/organic/plant8,
@@ -40411,6 +40392,14 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/engineering/atmos)
+"ncu" = (
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/light/dim/directional/west,
+/turf/open/floor/iron/white/textured,
+/area/station/engineering/atmos/hfr_room)
 "ndc" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door{
@@ -44774,6 +44763,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
+"qoF" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white/textured_edge{
+	dir = 4
+	},
+/area/station/engineering/atmos/hfr_room)
 "qoW" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
@@ -48993,14 +48991,6 @@
 /obj/effect/turf_decal/tile/dark/diagonal_edge,
 /turf/open/floor/iron/white/diagonal,
 /area/station/ai_monitored/turret_protected/ai_upload)
-"tsh" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 8
-	},
-/obj/machinery/light/dim/directional/west,
-/turf/open/floor/iron/white/textured,
-/area/station/engineering/atmos/hfr_room)
 "tsq" = (
 /obj/structure/cable,
 /obj/structure/table,
@@ -49709,10 +49699,13 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "tSV" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers,
-/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/iron/white/textured_edge{
+	dir = 4
+	},
 /area/station/engineering/atmos/hfr_room)
 "tTB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -50425,14 +50418,6 @@
 /obj/effect/turf_decal/siding/wood/corner,
 /turf/open/floor/iron/white/smooth_edge,
 /area/station/command/bridge)
-"utj" = (
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/light/dim/directional/west,
-/turf/open/floor/iron/white/textured,
-/area/station/engineering/atmos/hfr_room)
 "utT" = (
 /obj/effect/spawner/random/glass_debris,
 /obj/structure/window/reinforced/spawner/directional/east,
@@ -51061,9 +51046,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "uTc" = (
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted,
 /obj/structure/cable,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/turf/open/floor/iron/white/textured_edge{
+	dir = 1
+	},
 /area/station/engineering/atmos/hfr_room)
 "uTt" = (
 /obj/machinery/firealarm/directional/north,
@@ -51393,6 +51380,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
+"vdb" = (
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/engineering/atmos/hfr_room)
 "vdg" = (
 /obj/machinery/light/directional/south,
 /obj/structure/extinguisher_cabinet/directional/south,
@@ -53534,6 +53525,13 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
 /area/station/cargo/office)
+"wGD" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/structure/cable,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/engineering/atmos/hfr_room)
 "wGM" = (
 /obj/effect/turf_decal/tile/pine_green/half/contrasted,
 /turf/open/floor/iron/white,
@@ -53764,9 +53762,12 @@
 /turf/open/floor/carpet/red,
 /area/station/medical/psychology)
 "wQE" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 8
+	},
+/obj/machinery/light/dim/directional/west,
+/turf/open/floor/iron/white/textured,
 /area/station/engineering/atmos/hfr_room)
 "wQU" = (
 /obj/effect/spawner/random/maintenance,
@@ -92279,11 +92280,11 @@ svD
 bJP
 hzr
 hzr
-wQE
-wQE
-wQE
-wQE
-wQE
+auI
+auI
+auI
+auI
+auI
 hzr
 hzr
 aaa
@@ -92535,13 +92536,13 @@ cbu
 cbu
 bJP
 hzr
-utj
-kJU
+ncu
+tSV
 xJb
 xJb
 xJb
-jFQ
-tsh
+qoF
+wQE
 hzr
 pDW
 pDW
@@ -92791,15 +92792,15 @@ bJP
 bJP
 bJP
 bJP
-wQE
-gZm
+auI
+kJU
 jQB
 jQB
 jQB
 jQB
 jQB
-dAd
-wQE
+uTc
+auI
 aaa
 aaa
 aaa
@@ -93048,7 +93049,7 @@ gGn
 cby
 afp
 bJP
-wQE
+auI
 iGR
 jQB
 azm
@@ -93056,7 +93057,7 @@ azN
 evU
 jQB
 ijt
-wQE
+auI
 aaa
 aaa
 aaa
@@ -93305,7 +93306,7 @@ cbx
 cco
 lag
 bJP
-wQE
+auI
 iGR
 jQB
 rsy
@@ -93313,7 +93314,7 @@ rjl
 syt
 jQB
 ijt
-wQE
+auI
 aaa
 aaa
 aaa
@@ -93562,7 +93563,7 @@ oCb
 cby
 cby
 bJP
-wQE
+auI
 iGR
 jQB
 evU
@@ -93570,7 +93571,7 @@ ssU
 azm
 jQB
 ijt
-wQE
+auI
 aaa
 aaa
 aaa
@@ -93819,15 +93820,15 @@ bJP
 bJP
 bJP
 bJP
-wQE
-gZm
+auI
+kJU
 jQB
 jQB
 jQB
 jQB
 jQB
 ijt
-wQE
+auI
 aaa
 aaa
 aaa
@@ -94084,7 +94085,7 @@ pjM
 pjM
 pjM
 hCg
-wQE
+auI
 aaa
 aaa
 aaa
@@ -94341,7 +94342,7 @@ pjM
 pjM
 pjM
 wfp
-tSV
+jFQ
 aaa
 aaa
 aaa
@@ -94597,8 +94598,8 @@ pjM
 pjM
 pjM
 pjM
-iFR
-wQE
+wGD
+auI
 aaa
 aaa
 aaa
@@ -94853,8 +94854,8 @@ rfm
 sxs
 tlU
 wMm
-auI
-uTc
+vdb
+biA
 hzr
 aaa
 aaa

--- a/_maps/map_files/Pubbystation/pubbystation.dmm
+++ b/_maps/map_files/Pubbystation/pubbystation.dmm
@@ -5123,13 +5123,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/commons/fitness/recreation)
-"avo" = (
-/obj/machinery/light/small/directional/west,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/tcommsat/computer)
 "avp" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -5624,10 +5617,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "awW" = (
-/obj/structure/closet/secure_closet/medical2,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/white/textured_large,
-/area/station/medical/treatment_center)
+/obj/structure/cable,
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/tcommsat/computer)
 "awY" = (
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -5943,10 +5938,6 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port)
-"ayC" = (
-/obj/effect/spawner/random/trash/grime,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
 "ayD" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
@@ -12015,6 +12006,19 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/service)
+"aZc" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/airlock/external{
+	name = "Telecommunications External Access"
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/tcommsat/computer)
 "aZd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -13654,19 +13658,9 @@
 /turf/open/floor/plating,
 /area/station/service/kitchen)
 "bgl" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
-/obj/machinery/door/airlock/security/glass{
-	name = "Medbay Security Post"
-	},
-/obj/effect/turf_decal/tile/dark_blue/fourcorners,
-/turf/open/floor/iron,
-/area/station/security/checkpoint/medical)
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plating,
+/area/station/tcommsat/computer)
 "bgn" = (
 /obj/structure/chair{
 	dir = 4
@@ -14392,10 +14386,6 @@
 /turf/open/floor/iron/white/smooth_corner,
 /area/station/medical/treatment_center)
 "bjT" = (
-/obj/effect/spawner/random/trash/cigbutt,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/maintenance/department/medical)
-"bjU" = (
 /obj/effect/turf_decal/tile/pine_green/half{
 	dir = 1
 	},
@@ -14404,6 +14394,11 @@
 	dir = 1
 	},
 /area/station/medical/treatment_center)
+"bjU" = (
+/obj/effect/turf_decal/tile/yellow/full,
+/obj/effect/spawner/random/trash/bucket,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/maintenance/department/medical)
 "bjV" = (
 /obj/effect/turf_decal/siding/corner,
 /obj/effect/turf_decal/tile/pine_green/anticorner{
@@ -14414,19 +14409,17 @@
 	},
 /area/station/medical/treatment_center)
 "bjW" = (
-/obj/structure/closet/crate/freezer/blood,
-/obj/structure/window/spawner/directional/west,
-/obj/machinery/camera/autoname/motion/directional/north,
-/obj/machinery/button/door/directional/north{
-	id_tag = "exam";
-	name = "Entrance Lockdown"
-	},
+/obj/machinery/iv_drip,
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/treatment_center)
 "bjY" = (
-/obj/effect/turf_decal/tile/yellow/full,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/maintenance/department/medical)
+/obj/machinery/light/small/directional/west,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/tcommsat/computer)
 "bjZ" = (
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 1
@@ -14696,29 +14689,35 @@
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/treatment_center)
 "blf" = (
+/obj/effect/turf_decal/tile/pine_green/fourcorners,
+/obj/machinery/door/airlock/multi_tile/public/glass{
+	name = "Medbay Lobby";
+	red_alert_access = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/machinery/door/poddoor/shutters/colony_fabricator/preopen{
+	id_tag = "exam"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/station/medical/treatment_center)
+"bli" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/yellow/full,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/maintenance/department/medical)
-"bli" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
+/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
+/obj/machinery/door/airlock/security/glass{
+	name = "Medbay Security Post"
 	},
-/obj/machinery/door/airlock/external{
-	name = "Telecommunications External Access"
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/tcommsat/computer)
+/obj/effect/turf_decal/tile/dark_blue/fourcorners,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/medical)
 "bll" = (
-/turf/closed/wall/r_wall,
-/area/station/medical/paramedic)
+/turf/open/space/basic,
+/area/station/tcommsat/computer)
 "blo" = (
 /obj/effect/turf_decal/trimline/pine_green/line{
 	dir = 8
@@ -15127,9 +15126,12 @@
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/treatment_center)
 "bnB" = (
-/obj/effect/spawner/random/trash/crushed_can,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/maintenance/department/medical)
+/obj/structure/cable,
+/obj/structure/sign/departments/telecomms/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "bnC" = (
 /obj/machinery/requests_console/auto_name/directional/north,
 /turf/open/floor/iron,
@@ -16356,7 +16358,6 @@
 	cycle_id = "sci-gene-passthrough"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/science/xenobio,
-/obj/effect/mapping_helpers/airlock/access/any/science/genetics,
 /obj/machinery/door/airlock/public/glass{
 	name = "Xenobiology Lab"
 	},
@@ -16365,6 +16366,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/office_blue/fourcorners,
+/obj/effect/mapping_helpers/airlock/access/any/science/general,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "btB" = (
@@ -17233,7 +17235,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "sci-entrance"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/science/research,
 /obj/machinery/door/airlock/public{
 	name = "R&D"
 	},
@@ -17244,6 +17245,7 @@
 /obj/effect/turf_decal/tile/office_blue/half/contrasted{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/access/any/science/general,
 /turf/open/floor/iron/white,
 /area/station/science/lab)
 "bxt" = (
@@ -17261,7 +17263,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "sci-entrance"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/science/research,
 /obj/effect/turf_decal/siding/dark_blue/corner{
 	dir = 8
 	},
@@ -17274,6 +17275,7 @@
 /obj/machinery/door/airlock/public{
 	name = "R&D"
 	},
+/obj/effect/mapping_helpers/airlock/access/any/science/general,
 /turf/open/floor/iron/white,
 /area/station/science/lab)
 "bxx" = (
@@ -17874,9 +17876,15 @@
 /turf/open/floor/iron/terracotta,
 /area/station/medical/medbay)
 "bzX" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/chem_storage)
+/obj/effect/turf_decal/tile/pine_green/fourcorners,
+/obj/machinery/door/poddoor/shutters/colony_fabricator/preopen{
+	id_tag = "exam"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/medical/treatment_center)
 "bzZ" = (
 /obj/machinery/airalarm/directional/west,
 /obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted{
@@ -18414,13 +18422,13 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "bCp" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/right/directional/south{
-	name = "Security Checkpoint";
-	req_access = list("brig_entrance")
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/station/security/checkpoint/medical)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/yellow/full,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/maintenance/department/medical)
 "bCr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -19095,17 +19103,17 @@
 /mob/living/carbon/human/species/monkey,
 /turf/open/floor/iron/white/small,
 /area/station/medical/virology)
-"bFQ" = (
-/obj/item/stack/cable_coil,
+"bFS" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/external{
+	name = "Telecommunications External Access"
+	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/tcommsat/computer)
-"bFS" = (
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/flora/bush/flowers_pp/style_random,
-/turf/open/floor/grass,
-/area/station/medical/paramedic)
 "bGb" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Research Security Post"
@@ -19665,9 +19673,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "bJc" = (
-/obj/effect/spawner/random/trash/caution_sign,
 /turf/open/floor/iron/white/smooth_large,
-/area/station/maintenance/department/medical)
+/area/station/medical/chem_storage)
 "bJd" = (
 /obj/structure/chair/comfy/black,
 /obj/item/stack/spacecash/c100,
@@ -20039,8 +20046,8 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/dock)
 "bLs" = (
-/obj/effect/spawner/random/trash/food_packaging,
-/turf/open/floor/iron/white/smooth_large,
+/obj/effect/spawner/random/glass_debris,
+/turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "bLt" = (
 /obj/effect/decal/cleanable/oil{
@@ -20376,8 +20383,7 @@
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical)
 "bMM" = (
-/obj/effect/spawner/random/structure/table_or_rack,
-/obj/machinery/light/cold/dim/directional/north,
+/obj/effect/spawner/random/structure/girder,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "bMN" = (
@@ -24647,11 +24653,6 @@
 /obj/structure/cable,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden/monastery)
-"cgl" = (
-/obj/effect/turf_decal/tile/pine_green,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
 "cgm" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/watermelon/holy,
@@ -25408,8 +25409,8 @@
 /turf/closed/wall/r_wall,
 /area/station/tcommsat/computer)
 "clA" = (
-/obj/effect/landmark/start/medical_doctor,
-/obj/machinery/holopad,
+/obj/structure/closet/secure_closet/medical2,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/treatment_center)
 "clC" = (
@@ -25418,11 +25419,12 @@
 /turf/open/floor/plating,
 /area/station/tcommsat/computer)
 "clD" = (
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/flora/bush/flowers_br/style_random,
-/turf/open/floor/grass,
-/area/station/medical/paramedic)
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/obj/effect/spawner/random/trash/crushed_can,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/maintenance/department/medical)
 "clG" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -25435,8 +25437,8 @@
 /turf/open/floor/plating,
 /area/station/tcommsat/computer)
 "clJ" = (
-/obj/effect/spawner/random/glass_debris,
-/turf/open/floor/plating,
+/obj/effect/spawner/random/trash/food_packaging,
+/turf/open/floor/iron/white/smooth_large,
 /area/station/maintenance/department/medical)
 "clL" = (
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -25447,12 +25449,12 @@
 /turf/open/floor/plating,
 /area/station/tcommsat/computer)
 "clM" = (
-/obj/effect/spawner/random/engineering/tank,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/medical/treatment_center)
 "clN" = (
-/obj/effect/turf_decal/tile/yellow/full,
-/obj/effect/spawner/random/trash/bucket,
+/obj/effect/spawner/random/trash/grime,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/maintenance/department/medical)
 "clO" = (
@@ -25474,12 +25476,22 @@
 /turf/open/floor/iron,
 /area/station/tcommsat/computer)
 "clU" = (
-/obj/structure/cable,
+/obj/machinery/power/port_gen/pacman,
 /turf/open/floor/plating,
 /area/station/tcommsat/computer)
 "clV" = (
-/turf/open/floor/plating,
-/area/station/tcommsat/computer)
+/obj/structure/table,
+/obj/item/ph_booklet{
+	pixel_x = 0;
+	pixel_y = -3
+	},
+/obj/item/storage/test_tube_rack/full{
+	pixel_x = 1;
+	pixel_y = 12
+	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/chem_storage)
 "clY" = (
 /obj/item/beacon,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -25491,15 +25503,14 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/heads_quarters/ce)
 "cmb" = (
-/obj/effect/turf_decal/tile/yellow/half{
-	dir = 1
-	},
-/obj/effect/spawner/random/trash/ghetto_containers,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/maintenance/department/medical)
+/obj/item/wrench,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/tcommsat/computer)
 "cmc" = (
-/turf/closed/wall/r_wall,
-/area/station/medical/pharmacy)
+/obj/effect/spawner/random/structure/table_or_rack,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "cmf" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical,
@@ -28076,12 +28087,11 @@
 /turf/open/floor/iron/white/smooth_corner,
 /area/station/science/lab)
 "cLB" = (
-/obj/structure/cable,
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/tcommsat/computer)
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/medical/treatment_center)
 "cMa" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
@@ -28112,6 +28122,16 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
 /area/station/service/library/lounge)
+"cOB" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/medical/chemistry,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "cOG" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -28292,6 +28312,13 @@
 "cWk" = (
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
+"cWA" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Paramedic Dispatch Room"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/turf/open/floor/plating,
+/area/station/medical/paramedic)
 "cXd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -28373,9 +28400,11 @@
 /turf/open/floor/iron,
 /area/station/security/office)
 "dcN" = (
-/obj/effect/spawner/random/epic_loot/random_supply_crate,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/obj/effect/turf_decal/tile/pine_green{
+	dir = 4
+	},
+/turf/open/floor/iron/white/smooth_edge,
+/area/station/medical/medbay)
 "dcQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
@@ -28635,9 +28664,10 @@
 /turf/open/floor/plating,
 /area/station/science/ordnance/burnchamber)
 "dpV" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/departmental,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/yellow/half,
+/obj/effect/spawner/random/medical/patient_stretcher,
+/obj/effect/spawner/random/medical/organs,
+/turf/open/floor/iron/white/smooth_large,
 /area/station/maintenance/department/medical)
 "dqa" = (
 /obj/structure/reagent_dispensers/watertank,
@@ -29322,6 +29352,9 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal)
+"dSC" = (
+/turf/open/floor/iron,
+/area/station/tcommsat/computer)
 "dSI" = (
 /obj/structure/sign/poster/contraband/random/directional/west,
 /obj/effect/decal/cleanable/dirt,
@@ -30217,13 +30250,6 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
-"eGl" = (
-/obj/effect/turf_decal/tile/yellow/half{
-	dir = 1
-	},
-/obj/effect/spawner/random/structure/chair_maintenance,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/maintenance/department/medical)
 "eGF" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/window/reinforced/spawner/directional/east,
@@ -30625,18 +30651,9 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "eXa" = (
-/obj/effect/turf_decal/tile/pine_green/fourcorners,
-/obj/machinery/door/airlock/multi_tile/public/glass{
-	name = "Medbay Lobby";
-	red_alert_access = 1
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/machinery/door/poddoor/shutters/colony_fabricator/preopen{
-	id_tag = "exam"
-	},
-/obj/machinery/door/firedoor,
+/obj/effect/spawner/random/epic_loot/random_supply_crate,
 /turf/open/floor/plating,
-/area/station/medical/treatment_center)
+/area/station/maintenance/department/medical)
 "eXo" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/engine,
@@ -31002,9 +31019,10 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "fhH" = (
-/obj/machinery/power/port_gen/pacman,
-/turf/open/floor/plating,
-/area/station/tcommsat/computer)
+/obj/effect/landmark/start/medical_doctor,
+/obj/machinery/holopad,
+/turf/open/floor/iron/white/textured_large,
+/area/station/medical/treatment_center)
 "fhM" = (
 /obj/structure/secure_safe{
 	pixel_x = -22
@@ -31282,11 +31300,15 @@
 /turf/open/floor/iron/terracotta/small,
 /area/station/service/kitchen)
 "ftW" = (
-/obj/structure/table,
-/obj/item/hand_labeler,
-/obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/chem_storage)
+/obj/structure/closet/crate/freezer/blood,
+/obj/structure/window/spawner/directional/west,
+/obj/machinery/camera/autoname/motion/directional/north,
+/obj/machinery/button/door/directional/north{
+	id_tag = "exam";
+	name = "Entrance Lockdown"
+	},
+/turf/open/floor/iron/white/textured_large,
+/area/station/medical/treatment_center)
 "ftY" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -31688,6 +31710,11 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
+"fKv" = (
+/obj/item/stack/cable_coil,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/tcommsat/computer)
 "fLd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -31731,19 +31758,6 @@
 	dir = 8
 	},
 /area/station/medical/surgery/theatre)
-"fMv" = (
-/obj/structure/table,
-/obj/item/ph_booklet{
-	pixel_x = 0;
-	pixel_y = -3
-	},
-/obj/item/storage/test_tube_rack/full{
-	pixel_x = 1;
-	pixel_y = 12
-	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/chem_storage)
 "fMw" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4
@@ -32513,12 +32527,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
-"gwR" = (
-/obj/effect/turf_decal/tile/yellow/half,
-/obj/effect/spawner/random/medical/patient_stretcher,
-/obj/effect/spawner/random/medical/organs,
+"gwJ" = (
+/obj/structure/table,
+/obj/item/hand_labeler,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
 /turf/open/floor/iron/white/smooth_large,
-/area/station/maintenance/department/medical)
+/area/station/medical/chem_storage)
 "gwZ" = (
 /turf/closed/wall,
 /area/station/security/range)
@@ -32834,16 +32848,6 @@
 	},
 /turf/open/floor/iron/terracotta/small,
 /area/station/service/kitchen)
-"gIy" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/any/medical/chemistry,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
 "gIC" = (
 /obj/machinery/light/small/directional/west,
 /obj/effect/decal/cleanable/dirt,
@@ -34369,6 +34373,7 @@
 /obj/effect/turf_decal/tile/yellow/half{
 	dir = 1
 	},
+/obj/effect/spawner/random/trash/ghetto_containers,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/maintenance/department/medical)
 "hXt" = (
@@ -35029,10 +35034,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "iDT" = (
-/obj/machinery/iv_drip,
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/white/textured_large,
-/area/station/medical/treatment_center)
+/obj/effect/turf_decal/tile/yellow/half,
+/obj/effect/spawner/random/medical/patient_stretcher,
+/obj/effect/spawner/random/medical/surgery_tool,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/maintenance/department/medical)
 "iDV" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Cargo Bay"
@@ -35408,8 +35414,9 @@
 /turf/open/floor/wood/large,
 /area/station/command/bridge)
 "iWQ" = (
-/obj/effect/spawner/random/trash/mess,
-/turf/open/floor/iron/white/smooth_large,
+/obj/effect/spawner/random/structure/table_or_rack,
+/obj/machinery/light/cold/dim/directional/north,
+/turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "iWV" = (
 /obj/machinery/light/directional/east,
@@ -35481,6 +35488,11 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/exit)
+"jal" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/medical/chemistry,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "jat" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -35495,11 +35507,6 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/exit/departure_lounge)
-"jaJ" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/any/medical/chemistry,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
 "jaS" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/plasma{
 	dir = 1
@@ -35617,9 +35624,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "jfg" = (
-/obj/effect/spawner/random/structure/girder,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/east,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "jgr" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Library"
@@ -35772,12 +35782,14 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/storage_shared)
 "jlc" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/colony_fabricator/preopen{
-	id_tag = "exam"
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/station/medical/treatment_center)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/yellow/full,
+/obj/effect/spawner/random/medical/patient_stretcher,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/maintenance/department/medical)
 "jmr" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -37410,6 +37422,11 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/carpet/black,
 /area/station/service/chapel/office)
+"kDw" = (
+/obj/effect/turf_decal/tile/pine_green,
+/obj/effect/turf_decal/caution/stand_clear/red,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "kDJ" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/conveyor_switch/oneway{
@@ -37794,6 +37811,13 @@
 /obj/effect/spawner/random/structure/tank_holder,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
+"kUL" = (
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 1
+	},
+/obj/effect/spawner/random/structure/chair_maintenance,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/maintenance/department/medical)
 "kVc" = (
 /obj/machinery/light/directional/north,
 /obj/structure/cable,
@@ -38253,8 +38277,9 @@
 	},
 /area/station/medical/pharmacy)
 "lnn" = (
-/turf/open/space/basic,
-/area/station/tcommsat/computer)
+/obj/effect/spawner/random/trash/crushed_can,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/maintenance/department/medical)
 "lnw" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/machinery/requests_console/directional/north{
@@ -38293,11 +38318,10 @@
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
 "lou" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Paramedic Dispatch Room"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/turf/open/floor/plating,
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/floor/grass,
 /area/station/medical/paramedic)
 "lpW" = (
 /obj/machinery/door/firedoor,
@@ -38328,15 +38352,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/ordnance)
-"lql" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/yellow/full,
-/obj/effect/spawner/random/medical/patient_stretcher,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/maintenance/department/medical)
 "lqy" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Library"
@@ -38661,10 +38676,8 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/medical)
 "lFb" = (
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/treatment_center)
+/turf/closed/wall/r_wall,
+/area/station/medical/pharmacy)
 "lFh" = (
 /obj/machinery/holopad,
 /obj/structure/cable,
@@ -38903,10 +38916,6 @@
 	dir = 8
 	},
 /area/station/engineering/atmos)
-"lQY" = (
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/plating,
-/area/station/tcommsat/computer)
 "lRh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
 	dir = 1
@@ -38978,6 +38987,12 @@
 /obj/effect/turf_decal/tile/dark/diagonal_edge,
 /turf/open/floor/iron/white/diagonal,
 /area/station/ai_monitored/turret_protected/ai_upload)
+"lUc" = (
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 1
+	},
+/turf/open/floor/iron/white/smooth_large,
+/area/station/maintenance/department/medical)
 "lUC" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -39389,6 +39404,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/supply)
+"mmq" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/tcommsat/computer)
 "mmu" = (
 /obj/structure/table,
 /obj/structure/maintenance_loot_structure/computer_tower/random,
@@ -40029,6 +40048,12 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/command/bridge)
+"mOh" = (
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/medical/treatment_center)
 "mOt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -40199,13 +40224,6 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"mVs" = (
-/obj/structure/cable,
-/obj/structure/sign/departments/telecomms/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "mVM" = (
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
@@ -40533,12 +40551,6 @@
 /obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/space/basic,
 /area/space/nearstation)
-"njZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/treatment_center)
 "nkj" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
@@ -41110,8 +41122,9 @@
 	},
 /area/station/science/xenobiology)
 "nKE" = (
+/obj/effect/spawner/random/trash/cigbutt,
 /turf/open/floor/iron/white/smooth_large,
-/area/station/medical/chem_storage)
+/area/station/maintenance/department/medical)
 "nKU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -41190,16 +41203,6 @@
 /obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/grass,
 /area/station/medical/storage)
-"nOy" = (
-/obj/effect/turf_decal/tile/pine_green/fourcorners,
-/obj/machinery/door/poddoor/shutters/colony_fabricator/preopen{
-	id_tag = "exam"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/treatment_center)
 "nOJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -41268,6 +41271,10 @@
 /obj/structure/sign/poster/official/there_is_no_gas_giant/directional/north,
 /turf/open/floor/engine,
 /area/station/science/ordnance/storage)
+"nRE" = (
+/obj/effect/spawner/random/trash/mess,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/maintenance/department/medical)
 "nSe" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/paramedic,
@@ -42836,11 +42843,9 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/medbay)
 "oXV" = (
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/treatment_center)
+/obj/effect/spawner/random/structure/crate_abandoned,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "oYc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -43355,7 +43360,6 @@
 /area/station/hallway/primary/aft)
 "prD" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
-/obj/effect/spawner/random/trash/crushed_can,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1
 	},
@@ -43564,7 +43568,8 @@
 /turf/open/floor/plating,
 /area/station/engineering/storage_shared)
 "pAo" = (
-/obj/effect/spawner/random/structure/table_or_rack,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/departmental,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "pAM" = (
@@ -43670,11 +43675,11 @@
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/medical/morgue)
 "pEK" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/maintenance/department/medical)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "pFy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -44439,6 +44444,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"qho" = (
+/obj/effect/turf_decal/tile/pine_green,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "qhH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -44905,13 +44915,9 @@
 	},
 /area/station/cargo/storage)
 "qwJ" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 8
-	},
-/area/station/maintenance/department/medical)
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/chem_storage)
 "qwS" = (
 /obj/effect/turf_decal/siding{
 	dir = 4
@@ -44941,8 +44947,13 @@
 /turf/open/floor/carpet/black,
 /area/station/service/chapel/office)
 "qxq" = (
-/turf/open/floor/iron,
-/area/station/tcommsat/computer)
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/right/directional/south{
+	name = "Security Checkpoint";
+	req_access = list("brig_entrance")
+	},
+/turf/open/floor/plating,
+/area/station/security/checkpoint/medical)
 "qxE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -44978,13 +44989,6 @@
 	},
 /turf/open/floor/iron/terracotta/small,
 /area/station/service/kitchen)
-"qzh" = (
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/flora/bush/flowers_br/style_random,
-/turf/open/floor/grass,
-/area/station/medical/paramedic)
 "qzm" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -45281,6 +45285,10 @@
 	},
 /turf/open/floor/iron/white/small,
 /area/station/medical/virology)
+"qNi" = (
+/obj/effect/turf_decal/tile/yellow/full,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/maintenance/department/medical)
 "qNy" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/left/directional/south{
@@ -45626,12 +45634,8 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "rcF" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/machinery/computer/security/telescreen/entertainment/directional/east,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/turf/closed/wall/r_wall,
+/area/station/medical/paramedic)
 "rdU" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
@@ -47487,17 +47491,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
-"svr" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/external{
-	name = "Telecommunications External Access"
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/tcommsat/computer)
 "svD" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/engine/o2,
@@ -48471,8 +48464,8 @@
 /area/station/commons/dorms)
 "teJ" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "teN" = (
@@ -49829,8 +49822,12 @@
 /turf/open/floor/plating,
 /area/station/cargo/bitrunning/den)
 "udS" = (
-/obj/effect/spawner/random/trash/grime,
-/turf/open/floor/iron/white/smooth_large,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 8
+	},
 /area/station/maintenance/department/medical)
 "uea" = (
 /obj/machinery/door/airlock/public/glass{
@@ -50003,11 +50000,8 @@
 /turf/open/floor/wood,
 /area/station/science/lab)
 "uik" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/turf/open/floor/plating,
+/area/station/tcommsat/computer)
 "uiP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -50641,6 +50635,13 @@
 /obj/item/beacon,
 /turf/open/floor/iron,
 /area/station/security/eva)
+"uEh" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/floor/grass,
+/area/station/medical/paramedic)
 "uEr" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -50829,12 +50830,6 @@
 /obj/effect/turf_decal/tile/pine_green/anticorner/contrasted,
 /turf/open/floor/iron/white,
 /area/station/medical/psychology)
-"uPd" = (
-/obj/effect/turf_decal/tile/pine_green{
-	dir = 4
-	},
-/turf/open/floor/iron/white/smooth_edge,
-/area/station/medical/medbay)
 "uPz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -51280,7 +51275,7 @@
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
 "veb" = (
-/obj/effect/spawner/random/structure/crate_abandoned,
+/obj/effect/spawner/random/trash/grime,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "vek" = (
@@ -51296,11 +51291,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
-"vey" = (
-/obj/item/wrench,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/tcommsat/computer)
 "veB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/wood/corner,
@@ -51576,12 +51566,6 @@
 "vpC" = (
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/funeral)
-"vrq" = (
-/obj/effect/turf_decal/tile/yellow/half,
-/obj/effect/spawner/random/medical/patient_stretcher,
-/obj/effect/spawner/random/medical/surgery_tool,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/maintenance/department/medical)
 "vrw" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
@@ -52119,6 +52103,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/library)
+"vOk" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/colony_fabricator/preopen{
+	id_tag = "exam"
+	},
+/turf/open/floor/plating,
+/area/station/medical/treatment_center)
 "vOB" = (
 /obj/effect/landmark/start/paramedic,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -54438,10 +54429,9 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "xnm" = (
-/obj/effect/turf_decal/tile/pine_green,
-/obj/effect/turf_decal/caution/stand_clear/red,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
+/obj/effect/spawner/random/engineering/tank,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "xnp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -54469,6 +54459,10 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
+"xpq" = (
+/obj/effect/spawner/random/trash/caution_sign,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/maintenance/department/medical)
 "xpw" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -55306,6 +55300,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
+"xUQ" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/turf/open/floor/grass,
+/area/station/medical/paramedic)
 "xUU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -55420,6 +55421,12 @@
 	},
 /turf/open/floor/iron/white/textured_edge,
 /area/station/medical/pharmacy)
+"yam" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/turf/open/floor/grass,
+/area/station/medical/paramedic)
 "yat" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -55533,13 +55540,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
-"yem" = (
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/flora/bush/flowers_yw/style_random,
-/turf/open/floor/grass,
-/area/station/medical/paramedic)
 "yet" = (
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
@@ -81811,9 +81811,9 @@ bfk
 bdm
 dyg
 sMg
-cgl
+qho
 dYh
-iDT
+bjW
 blc
 tgT
 mDN
@@ -82326,7 +82326,7 @@ bdm
 dyg
 sMg
 bik
-jlc
+vOk
 bjS
 tgd
 nUo
@@ -82582,9 +82582,9 @@ bfm
 xPQ
 dyg
 sMg
-xnm
-eXa
-bjU
+kDw
+blf
+bjT
 hfw
 gnS
 gnS
@@ -82839,13 +82839,13 @@ bfn
 bdm
 dyg
 sMg
-xnm
-nOy
-bjU
-lFb
-njZ
-lFb
-oXV
+kDw
+bzX
+bjT
+clM
+cLB
+clM
+mOh
 xsa
 xUU
 uFc
@@ -83097,13 +83097,13 @@ aRL
 dyg
 sMg
 bik
-jlc
+vOk
 bjV
 qwS
 jJm
 aFM
 uQu
-uPd
+dcN
 ktU
 uFc
 buc
@@ -83355,8 +83355,8 @@ eZv
 sMg
 bik
 dYh
-bjW
-clA
+ftW
+fhH
 idj
 tCi
 xQO
@@ -83612,7 +83612,7 @@ aDm
 sMg
 rkq
 dYh
-iDT
+bjW
 tgT
 cRi
 bny
@@ -83869,7 +83869,7 @@ tWc
 sMg
 bin
 dYh
-awW
+clA
 tgT
 pku
 qib
@@ -83921,54 +83921,54 @@ dWp
 njS
 njS
 njS
-teJ
-teJ
-teJ
-teJ
-teJ
-teJ
-teJ
-teJ
-teJ
-teJ
-teJ
-teJ
-teJ
-teJ
-teJ
-teJ
-teJ
-teJ
-teJ
-teJ
-teJ
-teJ
-teJ
-teJ
-teJ
-teJ
-teJ
-teJ
-teJ
-teJ
-teJ
-teJ
-teJ
-teJ
-teJ
-teJ
-teJ
-teJ
-teJ
-teJ
-teJ
-teJ
-teJ
-teJ
-teJ
-teJ
-teJ
-mVs
+pEK
+pEK
+pEK
+pEK
+pEK
+pEK
+pEK
+pEK
+pEK
+pEK
+pEK
+pEK
+pEK
+pEK
+pEK
+pEK
+pEK
+pEK
+pEK
+pEK
+pEK
+pEK
+pEK
+pEK
+pEK
+pEK
+pEK
+pEK
+pEK
+pEK
+pEK
+pEK
+pEK
+pEK
+pEK
+pEK
+pEK
+pEK
+pEK
+pEK
+pEK
+pEK
+pEK
+pEK
+pEK
+pEK
+pEK
+bnB
 clw
 clw
 clw
@@ -84142,8 +84142,8 @@ gKB
 tli
 peY
 bjc
-jfg
-bjT
+bMM
+nKE
 egX
 tcX
 egX
@@ -84178,7 +84178,7 @@ rCm
 cgs
 cgQ
 chv
-uik
+teJ
 aht
 aaa
 aht
@@ -84225,11 +84225,11 @@ aaa
 aaa
 aaa
 aaa
-uik
-svr
-avo
-bli
-cLB
+teJ
+bFS
+bjY
+aZc
+awW
 clY
 gmH
 cmh
@@ -84387,7 +84387,7 @@ bjZ
 vaR
 eus
 bnD
-bgl
+bli
 brg
 sgD
 cqd
@@ -84399,14 +84399,14 @@ cqd
 bIi
 wLW
 bjc
-jfg
+bMM
 drQ
 sMx
 tcX
 sMx
 dLb
 bwV
-jfg
+bMM
 oJj
 eMp
 lRN
@@ -84487,7 +84487,7 @@ clw
 hQz
 nTk
 jCr
-qxq
+dSC
 kCI
 nTk
 nMG
@@ -84639,7 +84639,7 @@ bgk
 dyg
 sMg
 fih
-bCp
+qxq
 bka
 tLk
 bmv
@@ -84655,13 +84655,13 @@ jze
 jze
 qnJ
 jze
-bll
+rcF
 oPH
 hEF
 tKY
-clN
-blf
-hXk
+bjU
+bCp
+lUc
 eeb
 oJj
 oJj
@@ -84739,7 +84739,7 @@ aaa
 aaa
 aaa
 aaa
-lnn
+bll
 clw
 nTk
 nTk
@@ -84908,17 +84908,17 @@ hZH
 hZH
 bvl
 bwO
-clD
+lou
 bzZ
 bsJ
 bCr
-bll
+rcF
 tta
-gwR
-bjY
+dpV
+qNi
 eeW
-blf
-cmb
+bCp
+hXk
 bAg
 oJj
 bNV
@@ -84996,12 +84996,12 @@ aaa
 aaa
 aaa
 aaa
-lnn
+bll
 clw
-fhH
-clV
-vey
-clV
+clU
+uik
+cmb
+uik
 mxy
 nTk
 qPu
@@ -85165,17 +85165,17 @@ jWH
 nYu
 oSa
 gfH
-yem
+xUQ
 fgs
 xmg
 buk
-bll
-ayC
-vrq
-bLs
+rcF
+veb
+iDT
+clJ
 eeW
 kHD
-eGl
+kUL
 bLL
 oJj
 bNW
@@ -85255,10 +85255,10 @@ aaa
 aaa
 abI
 clw
-clV
-lQY
-clU
-bFQ
+uik
+bgl
+mmq
+fKv
 mDW
 nTk
 cml
@@ -85422,17 +85422,17 @@ frX
 dRU
 gzG
 brh
-lou
+cWA
 brl
 bsL
 bFl
-bll
-veb
+rcF
+oXV
 sAE
-udS
-udS
+clN
+clN
 kHD
-clM
+xnm
 anH
 oJj
 oxA
@@ -85679,18 +85679,18 @@ bsH
 blo
 crd
 gfH
-qzh
+uEh
 hjy
 nSe
 xsT
-bll
-bMM
+rcF
+iWQ
 sAE
-udS
-udS
-blf
-dcN
-pEK
+clN
+clN
+bCp
+eXa
+prD
 oJj
 oJj
 eMp
@@ -85936,16 +85936,16 @@ mZi
 wEl
 bvp
 xTf
-bFS
+yam
 brm
 bsN
 bCv
-bll
-pAo
+rcF
+cmc
 sAE
-clJ
-clJ
-lql
+bLs
+bLs
+jlc
 mFY
 bLM
 bMN
@@ -86189,15 +86189,15 @@ ufo
 boL
 bpY
 fms
-cmc
-cmc
+lFb
+lFb
 qgA
-cmc
-bll
+lFb
+rcF
 jze
 jze
 jze
-bll
+rcF
 lRN
 eGL
 iZl
@@ -86456,12 +86456,12 @@ uqf
 bCx
 byw
 lRN
-iWQ
-dcN
+nRE
+eXa
 eeW
 oPH
 ipz
-qwJ
+udS
 bAh
 oJj
 eMp
@@ -86709,15 +86709,15 @@ xHJ
 bwT
 eBd
 bsK
-nKE
-nKE
-bzX
-jaJ
 bJc
-udS
-iWQ
-bnB
-prD
+bJc
+qwJ
+jal
+xpq
+clN
+nRE
+lnn
+clD
 byz
 ooh
 oJj
@@ -86971,8 +86971,8 @@ jyJ
 bDy
 rIm
 frn
-qwJ
-qwJ
+udS
+udS
 mqg
 eWa
 byA
@@ -87223,15 +87223,15 @@ pxw
 dRj
 hEC
 vTg
-nKE
-fMv
+bJc
+clV
 lRN
 lRN
 oJj
 oJj
 oJj
 oJj
-dpV
+pAo
 oJj
 oJj
 oJj
@@ -87482,7 +87482,7 @@ hEC
 ipu
 phx
 azR
-gIy
+cOB
 eMp
 eMp
 eMp
@@ -87738,7 +87738,7 @@ lRN
 hEC
 cIe
 fby
-ftW
+gwJ
 lRN
 eMp
 oJj
@@ -91560,7 +91560,7 @@ swT
 swT
 swT
 aXr
-rcF
+jfg
 mvJ
 swT
 swT

--- a/_maps/map_files/Pubbystation/pubbystation.dmm
+++ b/_maps/map_files/Pubbystation/pubbystation.dmm
@@ -36660,6 +36660,10 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/station/hallway/primary/aft)
+"jXz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos)
 "jXA" = (
 /obj/structure/table,
 /obj/item/stack/ore/iron,
@@ -37648,16 +37652,6 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
-"kKQ" = (
-/obj/machinery/light/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
 "kLp" = (
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
@@ -51743,10 +51737,6 @@
 "vpC" = (
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/funeral)
-"vrw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/turf/closed/wall/r_wall,
-/area/station/engineering/atmos)
 "vrx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
@@ -74790,7 +74780,7 @@ aaa
 enF
 pMh
 mKd
-kKQ
+tqd
 jsa
 rrI
 aZx
@@ -75047,7 +75037,7 @@ aaa
 aZx
 hXW
 hXW
-bop
+ntG
 jsa
 uib
 aZx
@@ -91787,7 +91777,7 @@ bOk
 wCz
 mvA
 qIz
-vrw
+jXz
 bZL
 bJP
 bJP

--- a/_maps/map_files/Pubbystation/pubbystation.dmm
+++ b/_maps/map_files/Pubbystation/pubbystation.dmm
@@ -4922,9 +4922,11 @@
 /turf/closed/wall,
 /area/station/command/heads_quarters/captain)
 "auI" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/iron/white/textured_edge,
 /area/station/engineering/atmos/hfr_room)
 "auJ" = (
 /obj/structure/disposalpipe/segment,
@@ -30091,6 +30093,11 @@
 	},
 /turf/open/floor/grass,
 /area/station/medical/storage)
+"ezB" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/cyan/visible,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "ezC" = (
 /obj/effect/spawner/random/trash/moisture,
 /turf/open/floor/iron/white/smooth_large,
@@ -36044,12 +36051,6 @@
 	},
 /turf/open/floor/iron/white/smooth_half,
 /area/station/science/xenobiology)
-"jxT" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/engineering/atmos/hfr_room)
 "jyJ" = (
 /obj/structure/table,
 /obj/structure/chem_separator,
@@ -36207,11 +36208,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "jFQ" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted,
 /obj/structure/cable,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 8
 	},
+/obj/machinery/light/dim/directional/west,
+/turf/open/floor/iron/white/textured,
 /area/station/engineering/atmos/hfr_room)
 "jFW" = (
 /obj/structure/maintenance_loot_structure/grenade_box/random,
@@ -37087,6 +37089,10 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/medbay/central)
+"koY" = (
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/engineering/atmos/hfr_room)
 "kpp" = (
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /obj/effect/landmark/start/atmospheric_technician,
@@ -37345,15 +37351,6 @@
 /obj/structure/sign/poster/official/walk/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"kyr" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white/textured_edge{
-	dir = 4
-	},
-/area/station/engineering/atmos/hfr_room)
 "kyJ" = (
 /obj/structure/chair{
 	dir = 4
@@ -37633,12 +37630,10 @@
 /turf/open/floor/plating,
 /area/station/security/range)
 "kJU" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/maintenance/disposal/incinerator)
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/engineering/atmos/hfr_room)
 "kKf" = (
 /obj/item/kirbyplants/organic/plant8,
 /turf/open/floor/iron/dark,
@@ -38322,6 +38317,12 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/storage_shared)
+"lnK" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/engineering/atmos/hfr_room)
 "loc" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Recreation Room"
@@ -39691,6 +39692,13 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/science/ordnance/storage)
+"mtW" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/structure/cable,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/engineering/atmos/hfr_room)
 "muO" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
@@ -40313,10 +40321,10 @@
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
 "mYX" = (
+/obj/structure/cable,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/white/textured_edge{
 	dir = 4
 	},
@@ -43792,6 +43800,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
+/obj/machinery/atmospherics/pipe/layer_manifold/yellow/visible{
+	dir = 4
+	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
@@ -46487,6 +46498,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
+"rDt" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/maintenance/disposal/incinerator)
 "rDw" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=4";
@@ -47427,13 +47445,6 @@
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
-/area/station/engineering/atmos/hfr_room)
-"sqa" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white/textured_edge,
 /area/station/engineering/atmos/hfr_room)
 "sqe" = (
 /obj/structure/cable,
@@ -49703,12 +49714,9 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "tSV" = (
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 1
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/obj/machinery/light/dim/directional/west,
-/turf/open/floor/iron/white/textured,
+/turf/open/floor/plating,
 /area/station/engineering/atmos/hfr_room)
 "tTB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -50586,14 +50594,6 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/service/library/artgallery)
-"uya" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 8
-	},
-/obj/machinery/light/dim/directional/west,
-/turf/open/floor/iron/white/textured,
-/area/station/engineering/atmos/hfr_room)
 "uyg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -52145,11 +52145,11 @@
 /turf/open/floor/iron/dark,
 /area/station/service/library/artgallery)
 "vJD" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
+/obj/machinery/atmospherics/pipe/layer_manifold/dark/visible,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "vJH" = (
@@ -53762,9 +53762,13 @@
 /turf/open/floor/carpet/red,
 /area/station/medical/psychology)
 "wQE" = (
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
 /obj/structure/cable,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white/textured_edge{
+	dir = 4
+	},
 /area/station/engineering/atmos/hfr_room)
 "wQU" = (
 /obj/effect/spawner/random/maintenance,
@@ -54137,11 +54141,11 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/engineering/atmos)
 "xca" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/layer_manifold/cyan/visible,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "xci" = (
@@ -55007,10 +55011,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/command)
-"xDU" = (
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/engineering/atmos/hfr_room)
 "xEt" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -55038,6 +55038,14 @@
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal)
+"xFj" = (
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/light/dim/directional/west,
+/turf/open/floor/iron/white/textured,
+/area/station/engineering/atmos/hfr_room)
 "xFo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -91501,7 +91509,7 @@ osD
 eVD
 qsH
 qFJ
-rGo
+ezB
 fda
 caB
 oOo
@@ -92281,11 +92289,11 @@ svD
 bJP
 hzr
 hzr
-auI
-auI
-auI
-auI
-auI
+tSV
+tSV
+tSV
+tSV
+tSV
 hzr
 hzr
 aaa
@@ -92537,13 +92545,13 @@ cbu
 cbu
 bJP
 hzr
-tSV
+xFj
+wQE
+xJb
+xJb
+xJb
 mYX
-xJb
-xJb
-xJb
-kyr
-uya
+jFQ
 hzr
 pDW
 pDW
@@ -92793,15 +92801,15 @@ bJP
 bJP
 bJP
 bJP
+tSV
 auI
-sqa
 jQB
 jQB
 jQB
 jQB
 jQB
 uTc
-auI
+tSV
 aaa
 aaa
 aaa
@@ -93050,7 +93058,7 @@ gGn
 cby
 afp
 bJP
-auI
+tSV
 iGR
 jQB
 azm
@@ -93058,7 +93066,7 @@ azN
 evU
 jQB
 ijt
-auI
+tSV
 aaa
 aaa
 aaa
@@ -93307,7 +93315,7 @@ cbx
 cco
 lag
 bJP
-auI
+tSV
 iGR
 jQB
 rsy
@@ -93315,7 +93323,7 @@ rjl
 syt
 jQB
 ijt
-auI
+tSV
 aaa
 aaa
 aaa
@@ -93564,7 +93572,7 @@ oCb
 cby
 cby
 bJP
-auI
+tSV
 iGR
 jQB
 evU
@@ -93572,7 +93580,7 @@ ssU
 azm
 jQB
 ijt
-auI
+tSV
 aaa
 aaa
 aaa
@@ -93821,15 +93829,15 @@ bJP
 bJP
 bJP
 bJP
+tSV
 auI
-sqa
 jQB
 jQB
 jQB
 jQB
 jQB
 ijt
-auI
+tSV
 aaa
 aaa
 aaa
@@ -94086,7 +94094,7 @@ pjM
 pjM
 pjM
 hCg
-auI
+tSV
 aaa
 aaa
 aaa
@@ -94343,7 +94351,7 @@ pjM
 pjM
 pjM
 wfp
-jxT
+lnK
 aaa
 aaa
 aaa
@@ -94599,8 +94607,8 @@ pjM
 pjM
 pjM
 pjM
-jFQ
-auI
+mtW
+tSV
 aaa
 aaa
 aaa
@@ -94855,8 +94863,8 @@ rfm
 sxs
 tlU
 wMm
-xDU
-wQE
+koY
+kJU
 hzr
 aaa
 aaa
@@ -95621,7 +95629,7 @@ usl
 fDM
 usl
 jKs
-kJU
+rDt
 bYw
 bYw
 bYw

--- a/_maps/map_files/Pubbystation/pubbystation.dmm
+++ b/_maps/map_files/Pubbystation/pubbystation.dmm
@@ -19619,9 +19619,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "bJc" = (
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
+/turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "bJd" = (
 /obj/structure/chair/comfy/black,
@@ -23083,6 +23081,10 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white/smooth_large,
+/area/station/engineering/atmos)
+"bXx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
 "bXy" = (
 /obj/effect/decal/cleanable/dirt,
@@ -29258,9 +29260,7 @@
 /area/station/service/chapel/dock)
 "dQh" = (
 /obj/machinery/door/firedoor,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
+/turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "dQq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -42911,7 +42911,9 @@
 /obj/effect/turf_decal/tile/pine_green{
 	dir = 4
 	},
-/turf/open/floor/iron/white/smooth_edge,
+/turf/open/floor/iron/white/smooth_corner{
+	dir = 4
+	},
 /area/station/medical/medbay)
 "oXp" = (
 /obj/machinery/requests_console/directional/east{
@@ -46566,10 +46568,6 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/maintenance/disposal/incinerator)
-"rGo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/turf/closed/wall/r_wall,
-/area/station/engineering/atmos)
 "rGD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/effect/spawner/structure/window/reinforced,
@@ -46587,9 +46585,7 @@
 /area/station/medical/psychology)
 "rHA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
+/turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "rHJ" = (
 /obj/structure/cable,
@@ -54720,9 +54716,7 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "xsa" = (
-/turf/open/floor/iron/white/smooth_corner{
-	dir = 4
-	},
+/turf/open/floor/iron/white/smooth_edge,
 /area/station/medical/medbay)
 "xsm" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -55828,9 +55822,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/iron/white/smooth_half{
-	dir = 1
-	},
+/turf/open/floor/iron/white/smooth_edge,
 /area/station/medical/medbay)
 "yiF" = (
 /obj/structure/cable,
@@ -91805,7 +91797,7 @@ bOk
 wCz
 mvA
 qIz
-rGo
+bXx
 bZL
 bJP
 bJP

--- a/_maps/map_files/Pubbystation/pubbystation.dmm
+++ b/_maps/map_files/Pubbystation/pubbystation.dmm
@@ -4923,6 +4923,7 @@
 /area/station/command/heads_quarters/captain)
 "auI" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/atmos/hfr_room)
 "auJ" = (
@@ -5952,6 +5953,7 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white/textured,
 /area/station/engineering/atmos/hfr_room)
 "ayI" = (
@@ -20900,6 +20902,7 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white/smooth_edge,
 /area/station/engineering/atmos/hfr_room)
 "bPc" = (
@@ -27927,6 +27930,12 @@
 	dir = 8
 	},
 /area/station/engineering/main)
+"cDx" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/engineering/atmos/hfr_room)
 "cEI" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/cup/soda_cans/dr_gibb,
@@ -28229,6 +28238,13 @@
 	},
 /turf/open/floor/iron/white/small,
 /area/station/science/research)
+"cTn" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/turf/open/floor/iron/white/textured_edge{
+	dir = 1
+	},
+/area/station/engineering/atmos/hfr_room)
 "cTr" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -36197,8 +36213,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "jFQ" = (
-/obj/machinery/holopad,
-/turf/open/floor/iron/white/smooth_large,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/light/dim/directional/west,
+/turf/open/floor/iron/white/textured,
 /area/station/engineering/atmos/hfr_room)
 "jFW" = (
 /obj/structure/maintenance_loot_structure/grenade_box/random,
@@ -37611,10 +37631,9 @@
 /turf/open/floor/plating,
 /area/station/security/range)
 "kJU" = (
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/white/textured,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
 /area/station/engineering/atmos/hfr_room)
 "kKf" = (
 /obj/item/kirbyplants/organic/plant8,
@@ -39059,6 +39078,15 @@
 "lWy" = (
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
+"lWD" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white/textured_edge{
+	dir = 4
+	},
+/area/station/engineering/atmos/hfr_room)
 "lWJ" = (
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/storage_shared)
@@ -45028,6 +45056,13 @@
 /obj/structure/flora/bush/grassy/style_random,
 /turf/open/floor/grass,
 /area/station/hallway/primary/central/fore)
+"qyg" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white/textured_edge,
+/area/station/engineering/atmos/hfr_room)
 "qyz" = (
 /obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 8;
@@ -45766,6 +45801,7 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 8
 	},
@@ -45794,6 +45830,13 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
 /area/station/maintenance/department/engine)
+"ric" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/structure/cable,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/engineering/atmos/hfr_room)
 "rie" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -47654,6 +47697,7 @@
 	},
 /obj/structure/table/reinforced/rglass,
 /obj/item/stack/sheet/plasteel/fifty,
+/obj/structure/cable,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 8
 	},
@@ -48815,6 +48859,7 @@
 	dir = 4
 	},
 /obj/structure/table/reinforced/rglass,
+/obj/structure/cable,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 8
 	},
@@ -49667,9 +49712,11 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "tSV" = (
+/obj/structure/cable,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 8
 	},
+/obj/machinery/light/dim/directional/west,
 /turf/open/floor/iron/white/textured,
 /area/station/engineering/atmos/hfr_room)
 "tTB" = (
@@ -51011,9 +51058,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "uTc" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white/textured_edge{
+	dir = 4
 	},
 /area/station/engineering/atmos/hfr_room)
 "uTt" = (
@@ -53586,7 +53636,8 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "wMm" = (
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted,
+/obj/structure/cable,
+/obj/machinery/holopad,
 /turf/open/floor/iron/white,
 /area/station/engineering/atmos/hfr_room)
 "wMn" = (
@@ -53714,9 +53765,8 @@
 /turf/open/floor/carpet/red,
 /area/station/medical/psychology)
 "wQE" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
 /area/station/engineering/atmos/hfr_room)
 "wQU" = (
 /obj/effect/spawner/random/maintenance,
@@ -92227,15 +92277,15 @@ cbv
 ccn
 svD
 bJP
-aaa
-abI
-fon
-aaa
-aht
-aaa
-aht
-aaa
-aaa
+hzr
+hzr
+auI
+auI
+auI
+auI
+auI
+hzr
+hzr
 aaa
 aht
 aaa
@@ -92484,15 +92534,15 @@ egk
 cbu
 cbu
 bJP
-aaa
-aht
-aaa
-aaa
-aht
-aaa
-aht
-aaa
-aaa
+hzr
+jFQ
+lWD
+xJb
+xJb
+xJb
+uTc
+tSV
+hzr
 pDW
 pDW
 pDW
@@ -92741,15 +92791,15 @@ bJP
 bJP
 bJP
 bJP
-hzr
 auI
+qyg
+jQB
+jQB
+jQB
+jQB
+jQB
+cTn
 auI
-auI
-auI
-auI
-hzr
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -92999,14 +93049,14 @@ cby
 afp
 bJP
 auI
-kJU
-xJb
-xJb
-xJb
-tSV
+iGR
+jQB
+azm
+azN
+evU
+jQB
+ijt
 auI
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -93257,13 +93307,13 @@ lag
 bJP
 auI
 iGR
-azm
-azN
-evU
+jQB
+rsy
+rjl
+syt
+jQB
 ijt
 auI
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -93514,13 +93564,13 @@ cby
 bJP
 auI
 iGR
-rsy
-rjl
-syt
+jQB
+evU
+ssU
+azm
+jQB
 ijt
 auI
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -93770,14 +93820,14 @@ bJP
 bJP
 bJP
 auI
-iGR
-evU
-ssU
-azm
+qyg
+jQB
+jQB
+jQB
+jQB
+jQB
 ijt
 auI
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -94028,13 +94078,13 @@ hzr
 hzr
 hzr
 ayG
-jQB
-jQB
-jQB
+pjM
+pjM
+pjM
+pjM
+pjM
 hCg
 auI
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -94288,10 +94338,10 @@ bOZ
 pGV
 pjM
 pjM
+pjM
+pjM
 wfp
-wQE
-imB
-aaa
+cDx
 aaa
 aaa
 aaa
@@ -94543,12 +94593,12 @@ yeD
 iiP
 opJ
 rgF
-jFQ
 pjM
-uTc
+pjM
+pjM
+pjM
+ric
 auI
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -94803,9 +94853,9 @@ rfm
 sxs
 tlU
 wMm
-auI
-aaa
-aaa
+wQE
+kJU
+hzr
 aaa
 aaa
 aaa
@@ -95061,8 +95111,8 @@ hzr
 hzr
 hzr
 hzr
-aaa
-aaa
+hzr
+hzr
 aaa
 aaa
 aaa

--- a/_maps/map_files/Pubbystation/pubbystation.dmm
+++ b/_maps/map_files/Pubbystation/pubbystation.dmm
@@ -42,6 +42,7 @@
 /area/station/science/lab)
 "aao" = (
 /obj/structure/table/reinforced,
+/obj/item/xenoarch/strange_rock,
 /turf/open/floor/engine,
 /area/station/science/lab)
 "aap" = (
@@ -118,7 +119,6 @@
 /turf/open/floor/engine,
 /area/station/science/lab)
 "aaC" = (
-/obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -127,6 +127,7 @@
 	name = "EVA Shutters Control";
 	req_access = list("eva")
 	},
+/obj/structure/closet/l3closet,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
 "aaF" = (
@@ -492,16 +493,11 @@
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai)
 "acI" = (
-/obj/structure/rack,
-/obj/item/clothing/shoes/magboots{
-	pixel_x = -4;
-	pixel_y = 3
-	},
-/obj/item/clothing/shoes/magboots,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/item/radio/intercom/directional/west,
+/obj/structure/closet/l3closet,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
 "acJ" = (
@@ -3385,7 +3381,7 @@
 /obj/effect/landmark/start/warden,
 /obj/machinery/button/door/directional/west{
 	id = "Prison Gate";
-	name = "Permabrig Lockdown";
+	name = "EVA Lockdown";
 	pixel_y = 6;
 	req_access = list("armory")
 	},
@@ -5604,8 +5600,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "awW" = (
-/turf/closed/wall/r_wall,
-/area/station/medical/paramedic)
+/obj/structure/closet/secure_closet/chemical,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/chem_storage)
 "awY" = (
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -8423,6 +8423,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
+"aIr" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/floor/grass,
+/area/station/medical/paramedic)
 "aIX" = (
 /obj/effect/landmark/observer_start,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -9026,7 +9032,6 @@
 /turf/open/floor/iron,
 /area/station/command/teleporter)
 "aMa" = (
-/obj/structure/closet/crate,
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/button/door/directional/east{
 	req_access = list("teleporter");
@@ -9063,7 +9068,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/obj/effect/spawner/random/vending/snackvend,
+/obj/machinery/computer/order_console/stationery_supplies,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "aMg" = (
@@ -9290,11 +9295,10 @@
 /area/station/engineering/main)
 "aNq" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/table,
-/obj/machinery/cell_charger,
 /obj/effect/turf_decal/stripes/end{
 	dir = 1
 	},
+/obj/structure/closet/radiation,
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
 "aNt" = (
@@ -9315,8 +9319,6 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
 "aNu" = (
-/obj/structure/closet/crate,
-/obj/item/melee/flyswatter,
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/firealarm/directional/west,
 /obj/structure/cable,
@@ -9595,10 +9597,6 @@
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/north,
-/obj/item/clipboard{
-	pixel_y = 5;
-	pixel_x = -8
-	},
 /obj/structure/maintenance_loot_structure/file_cabinet/random,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/qm)
@@ -13620,12 +13618,10 @@
 /turf/open/floor/plating,
 /area/station/service/kitchen)
 "bgl" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/colony_fabricator/preopen{
-	id_tag = "exam"
-	},
-/turf/open/floor/plating,
-/area/station/medical/treatment_center)
+/obj/effect/turf_decal/tile/yellow/full,
+/obj/effect/spawner/random/trash/bucket,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/maintenance/department/medical)
 "bgn" = (
 /obj/structure/chair{
 	dir = 4
@@ -14351,6 +14347,19 @@
 /turf/open/floor/iron/white/smooth_corner,
 /area/station/medical/treatment_center)
 "bjT" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/airlock/external{
+	name = "Telecommunications External Access"
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/tcommsat/computer)
+"bjU" = (
 /obj/effect/turf_decal/tile/pine_green/half{
 	dir = 1
 	},
@@ -14359,10 +14368,6 @@
 	dir = 1
 	},
 /area/station/medical/treatment_center)
-"bjU" = (
-/obj/effect/turf_decal/tile/yellow/half,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/maintenance/department/medical)
 "bjV" = (
 /obj/effect/turf_decal/siding/corner,
 /obj/effect/turf_decal/tile/pine_green/anticorner{
@@ -14383,12 +14388,10 @@
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/treatment_center)
 "bjY" = (
-/obj/effect/turf_decal/tile/yellow/half{
-	dir = 1
-	},
-/obj/effect/spawner/random/trash/ghetto_containers,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/maintenance/department/medical)
+/obj/structure/closet/secure_closet/medical2,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/white/textured_large,
+/area/station/medical/treatment_center)
 "bjZ" = (
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 1
@@ -14658,22 +14661,19 @@
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/treatment_center)
 "blf" = (
-/obj/effect/turf_decal/tile/pine_green{
-	dir = 4
-	},
-/turf/open/floor/iron/white/smooth_edge,
-/area/station/medical/medbay)
+/obj/structure/cable,
+/obj/structure/sign/departments/telecomms/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "bli" = (
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/plating,
-/area/station/tcommsat/computer)
+/turf/closed/wall/r_wall,
+/area/station/medical/pharmacy)
 "bll" = (
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/flora/bush/flowers_br/style_random,
-/turf/open/floor/grass,
-/area/station/medical/paramedic)
+/obj/effect/spawner/random/trash/caution_sign,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/maintenance/department/medical)
 "blo" = (
 /obj/effect/turf_decal/trimline/pine_green/line{
 	dir = 8
@@ -14901,13 +14901,6 @@
 /obj/structure/bed/medical,
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/treatment_center)
-"bmp" = (
-/obj/effect/turf_decal/tile/yellow/half{
-	dir = 1
-	},
-/obj/effect/spawner/random/structure/chair_maintenance,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/maintenance/department/medical)
 "bmv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -15089,12 +15082,11 @@
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/treatment_center)
 "bnB" = (
-/obj/structure/cable,
-/obj/structure/sign/departments/telecomms/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/obj/machinery/atmospherics/components/unary/airlock_pump/silent{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/service/library)
 "bnC" = (
 /obj/machinery/requests_console/auto_name/directional/north,
 /turf/open/floor/iron,
@@ -15227,9 +15219,13 @@
 /turf/open/floor/grass,
 /area/station/medical/treatment_center)
 "boF" = (
-/obj/effect/spawner/random/glass_debris,
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/right/directional/south{
+	name = "Security Checkpoint";
+	req_access = list("brig_entrance")
+	},
 /turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/area/station/security/checkpoint/medical)
 "boH" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
@@ -16389,10 +16385,12 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "btK" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/machinery/rnd/production/colony_lathe,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
+/obj/machinery/light/small/directional/west,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/tcommsat/computer)
 "btL" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -17836,12 +17834,12 @@
 /turf/open/floor/iron/terracotta,
 /area/station/medical/medbay)
 "bzX" = (
-/obj/structure/cable,
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/electric_yellow{
+	dir = 8
+	},
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron,
-/area/station/tcommsat/computer)
+/area/station/hallway/primary/aft)
 "bzZ" = (
 /obj/machinery/airalarm/directional/west,
 /obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted{
@@ -18379,10 +18377,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "bCp" = (
-/obj/item/wrench,
-/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/medical/chemistry,
 /turf/open/floor/plating,
-/area/station/tcommsat/computer)
+/area/station/maintenance/department/medical)
 "bCr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -19058,9 +19056,11 @@
 /turf/open/floor/iron/white/small,
 /area/station/medical/virology)
 "bFS" = (
-/obj/effect/spawner/random/engineering/tank,
+/obj/machinery/atmospherics/components/unary/airlock_pump/silent{
+	dir = 4
+	},
 /turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/area/station/service/library)
 "bGb" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Research Security Post"
@@ -19620,9 +19620,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "bJc" = (
-/obj/effect/spawner/random/structure/crate_abandoned,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/medical/treatment_center)
 "bJd" = (
 /obj/structure/chair/comfy/black,
 /obj/item/stack/spacecash/c100,
@@ -19994,10 +19995,9 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/dock)
 "bLs" = (
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/treatment_center)
+/obj/machinery/rnd/production/colony_lathe,
+/turf/open/floor/iron,
+/area/station/cargo/sorting)
 "bLt" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor6"
@@ -20332,10 +20332,10 @@
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical)
 "bMM" = (
-/obj/structure/closet/secure_closet/medical2,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/white/textured_large,
-/area/station/medical/treatment_center)
+/obj/item/stack/cable_coil,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/tcommsat/computer)
 "bMN" = (
 /obj/effect/turf_decal/tile/electric_yellow/anticorner/contrasted{
 	dir = 8
@@ -23161,7 +23161,10 @@
 "bXM" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/airlock_pump/silent{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -23174,6 +23177,12 @@
 /obj/effect/mapping_helpers/airlock/access/any/service/chapel_office,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/external,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/service/chapel/asteroid/monastery)
 "bXO" = (
@@ -24108,19 +24117,6 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/main)
-"cdk" = (
-/obj/structure/table,
-/obj/item/ph_booklet{
-	pixel_x = 0;
-	pixel_y = -3
-	},
-/obj/item/storage/test_tube_rack/full{
-	pixel_x = 1;
-	pixel_y = 12
-	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/chem_storage)
 "cdm" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
@@ -25232,13 +25228,9 @@
 /turf/open/misc/asteroid/airless,
 /area/centcom/asteroid/nearstation/bomb_site)
 "ckv" = (
-/obj/machinery/mass_driver/chapelgun,
-/obj/machinery/door/window/left/directional/west{
-	name = "Mass Driver";
-	req_access = list("chapel_office")
-	},
-/turf/open/floor/iron/dark,
-/area/station/service/chapel/funeral)
+/obj/effect/spawner/random/trash/grime,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/maintenance/department/medical)
 "ckw" = (
 /obj/machinery/mass_driver/chapelgun,
 /turf/open/floor/iron/dark,
@@ -25277,9 +25269,8 @@
 /turf/open/floor/plating/airless,
 /area/centcom/asteroid/nearstation/bomb_site)
 "ckM" = (
-/obj/structure/window/reinforced/spawner/directional/west,
-/turf/open/floor/iron/dark,
-/area/station/service/chapel/funeral)
+/turf/open/floor/plating,
+/area/station/tcommsat/computer)
 "ckO" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -25321,6 +25312,7 @@
 /area/station/service/library/lounge)
 "clb" = (
 /obj/machinery/door/poddoor/massdriver_chapel,
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/station/service/chapel/funeral)
 "clf" = (
@@ -25372,25 +25364,18 @@
 /turf/closed/wall/r_wall,
 /area/station/tcommsat/computer)
 "clA" = (
-/obj/structure/table,
-/obj/item/hand_labeler,
-/obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/chem_storage)
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/departmental,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "clC" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/transit_tube,
 /turf/open/floor/plating,
 /area/station/tcommsat/computer)
 "clD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/yellow/full,
-/obj/effect/spawner/random/medical/patient_stretcher,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/maintenance/department/medical)
+/turf/open/floor/iron,
+/area/station/tcommsat/computer)
 "clG" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -25403,10 +25388,12 @@
 /turf/open/floor/plating,
 /area/station/tcommsat/computer)
 "clJ" = (
-/obj/effect/turf_decal/tile/yellow/full,
-/obj/effect/spawner/random/trash/bucket,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/maintenance/department/medical)
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/service/library)
 "clL" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Telecommunications Maintenance"
@@ -25416,14 +25403,10 @@
 /turf/open/floor/plating,
 /area/station/tcommsat/computer)
 "clM" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 1
 	},
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/any/medical/chemistry,
-/turf/open/floor/plating,
+/turf/open/floor/iron/white/smooth_large,
 /area/station/maintenance/department/medical)
 "clN" = (
 /obj/effect/spawner/random/trash/grime,
@@ -25448,13 +25431,17 @@
 /turf/open/floor/iron,
 /area/station/tcommsat/computer)
 "clU" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/service/library)
+"clV" = (
 /obj/effect/landmark/start/medical_doctor,
 /obj/machinery/holopad,
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/treatment_center)
-"clV" = (
-/turf/open/floor/plating,
-/area/station/tcommsat/computer)
 "clY" = (
 /obj/item/beacon,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -25466,12 +25453,16 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/heads_quarters/ce)
 "cmb" = (
-/obj/item/stack/cable_coil,
-/obj/structure/cable,
+/obj/effect/spawner/random/epic_loot/random_supply_crate,
 /turf/open/floor/plating,
-/area/station/tcommsat/computer)
+/area/station/maintenance/department/medical)
 "cmc" = (
-/obj/effect/spawner/random/trash/mess,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/yellow/full,
+/obj/effect/spawner/random/trash/grime,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/maintenance/department/medical)
 "cmf" = (
@@ -26496,6 +26487,12 @@
 	dir = 5
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/space,
 /area/space/nearstation)
 "crz" = (
@@ -26508,6 +26505,12 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/external,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "crA" = (
@@ -26516,8 +26519,11 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/airlock_pump/silent{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
@@ -27542,10 +27548,6 @@
 /area/station/science/robotics/mechbay)
 "cAr" = (
 /obj/machinery/light/small/directional/west,
-/obj/machinery/door/window/right/directional/south{
-	name = "Curator Desk Door";
-	req_access = list("library")
-	},
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/service/library)
@@ -27566,6 +27568,9 @@
 "cAu" = (
 /obj/structure/table/wood,
 /obj/item/clothing/head/costume/pharaoh,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/service/library)
 "cAv" = (
@@ -27575,10 +27580,6 @@
 /area/station/service/library)
 "cAy" = (
 /obj/machinery/light/small/directional/east,
-/obj/machinery/door/window/right/directional/south{
-	name = "Curator Desk Door";
-	req_access = list("library")
-	},
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/service/library)
@@ -27591,6 +27592,12 @@
 "cAC" = (
 /obj/structure/chair/wood/wings{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/library)
@@ -27640,9 +27647,9 @@
 /turf/open/floor/iron/dark,
 /area/station/service/library)
 "cAT" = (
-/obj/structure/destructible/cult/item_dispenser/archives/library,
-/turf/open/floor/iron/dark,
-/area/station/service/library)
+/obj/effect/spawner/random/trash/crushed_can,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/maintenance/department/medical)
 "cAU" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Monastery Archives Aft";
@@ -28050,9 +28057,14 @@
 /turf/open/floor/iron/white/smooth_corner,
 /area/station/science/lab)
 "cLB" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
-/area/station/tcommsat/computer)
+/area/station/maintenance/department/medical)
 "cMa" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
@@ -28310,6 +28322,10 @@
 /area/station/service/kitchen)
 "daO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/closet/radiation,
+/obj/effect/turf_decal/stripes/end{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
 "dbI" = (
@@ -28344,19 +28360,8 @@
 /turf/open/floor/iron,
 /area/station/security/office)
 "dcN" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
-/obj/machinery/door/airlock/security/glass{
-	name = "Medbay Security Post"
-	},
-/obj/effect/turf_decal/tile/dark_blue/fourcorners,
-/turf/open/floor/iron,
-/area/station/security/checkpoint/medical)
+/turf/open/space/basic,
+/area/station/tcommsat/computer)
 "dcQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
@@ -28616,11 +28621,10 @@
 /turf/open/floor/plating,
 /area/station/science/ordnance/burnchamber)
 "dpV" = (
-/obj/effect/turf_decal/tile/yellow/half{
-	dir = 1
-	},
-/turf/open/floor/iron/white/smooth_large,
-/area/station/maintenance/department/medical)
+/obj/effect/turf_decal/tile/pine_green,
+/obj/effect/turf_decal/caution/stand_clear/red,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "dqa" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -29039,6 +29043,17 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/bar)
+"dGT" = (
+/obj/machinery/door/airlock/external,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/station/service/library)
 "dHc" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1;
@@ -29236,6 +29251,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/dock)
+"dQh" = (
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/medical/treatment_center)
 "dQq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/electric_yellow,
@@ -29444,6 +29465,10 @@
 /obj/machinery/vending/imported/nt,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"dYf" = (
+/obj/effect/spawner/random/structure/crate_abandoned,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "dYh" = (
 /turf/closed/wall,
 /area/station/medical/treatment_center)
@@ -29599,8 +29624,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "eeW" = (
-/obj/effect/spawner/random/trash/food_packaging,
-/turf/open/floor/iron/white/smooth_large,
+/obj/effect/spawner/random/glass_debris,
+/turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "efu" = (
 /obj/effect/landmark/start/scientist,
@@ -29761,10 +29786,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
-"elU" = (
-/obj/effect/turf_decal/tile/yellow/full,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/maintenance/department/medical)
 "ema" = (
 /obj/structure/plasticflaps/opaque,
 /turf/open/floor/plating,
@@ -30028,9 +30049,6 @@
 /area/station/maintenance/department/engine)
 "eyL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/item/wallframe/telescreen/entertainment{
-	pixel_x = 32
-	},
 /turf/open/floor/iron/terracotta,
 /area/station/medical/medbay)
 "ezk" = (
@@ -30551,10 +30569,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/server)
-"eVp" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/chem_storage)
 "eVv" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -30581,6 +30595,10 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/engineering/atmos)
+"eVG" = (
+/obj/effect/spawner/random/structure/table_or_rack,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "eVW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -30976,18 +30994,12 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "fhH" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+/obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 4
-	},
-/area/station/maintenance/department/medical)
+/obj/machinery/computer/security/telescreen/entertainment/directional/east,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "fhM" = (
 /obj/structure/secure_safe{
 	pixel_x = -22
@@ -31163,6 +31175,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"fri" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/chem_storage)
 "frn" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
@@ -31265,15 +31281,14 @@
 /turf/open/floor/iron/terracotta/small,
 /area/station/service/kitchen)
 "ftW" = (
-/obj/effect/turf_decal/tile/pine_green/fourcorners,
-/obj/machinery/door/poddoor/shutters/colony_fabricator/preopen{
-	id_tag = "exam"
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/area/station/medical/treatment_center)
+/turf/open/floor/carpet,
+/area/station/service/library)
 "ftY" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -31830,12 +31845,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
-"fTD" = (
-/obj/effect/turf_decal/tile/yellow/half,
-/obj/effect/spawner/random/medical/patient_stretcher,
-/obj/effect/spawner/random/medical/organs,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/maintenance/department/medical)
 "fTY" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -32125,6 +32134,13 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/station/service/chapel/office)
+"gjd" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/service/library)
 "gjp" = (
 /obj/structure/table/wood,
 /obj/structure/bedsheetbin,
@@ -32948,12 +32964,6 @@
 /mob/living/carbon/human/species/monkey,
 /turf/open/floor/grass,
 /area/station/science/genetics)
-"gPn" = (
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/flora/bush/flowers_pp/style_random,
-/turf/open/floor/grass,
-/area/station/medical/paramedic)
 "gQa" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -33968,9 +33978,6 @@
 	},
 /turf/open/floor/iron/white/small,
 /area/station/medical/virology)
-"hIG" = (
-/turf/open/floor/iron,
-/area/station/tcommsat/computer)
 "hIQ" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/airalarm/directional/south,
@@ -34339,7 +34346,7 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "hXk" = (
-/obj/effect/spawner/random/epic_loot/random_supply_crate,
+/obj/effect/spawner/random/engineering/tank,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "hXt" = (
@@ -34459,11 +34466,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/captain)
-"ieL" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/departmental,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
 "ieU" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -34480,9 +34482,18 @@
 /turf/open/floor/carpet,
 /area/station/service/library/lounge)
 "igj" = (
-/obj/structure/window/reinforced/spawner/directional/south,
-/turf/open/floor/iron,
-/area/station/command/teleporter)
+/obj/structure/table,
+/obj/item/ph_booklet{
+	pixel_x = 0;
+	pixel_y = -3
+	},
+/obj/item/storage/test_tube_rack/full{
+	pixel_x = 1;
+	pixel_y = 12
+	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/chem_storage)
 "igu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -34551,6 +34562,12 @@
 "iiy" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/space,
 /area/space/nearstation)
 "iiP" = (
@@ -34928,13 +34945,6 @@
 	},
 /turf/closed/wall,
 /area/station/hallway/secondary/entry)
-"iAH" = (
-/obj/effect/turf_decal/tile/electric_yellow{
-	dir = 8
-	},
-/obj/machinery/camera/autoname/directional/west,
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
 "iBi" = (
 /obj/machinery/light/directional/north,
 /obj/structure/table,
@@ -35011,6 +35021,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
+"iDg" = (
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 1
+	},
+/obj/effect/spawner/random/structure/chair_maintenance,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/maintenance/department/medical)
 "iDT" = (
 /obj/machinery/iv_drip,
 /obj/machinery/light/directional/north,
@@ -35325,19 +35342,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
-"iPy" = (
-/obj/effect/turf_decal/tile/pine_green/fourcorners,
-/obj/machinery/door/airlock/multi_tile/public/glass{
-	name = "Medbay Lobby";
-	red_alert_access = 1
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/machinery/door/poddoor/shutters/colony_fabricator/preopen{
-	id_tag = "exam"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/station/medical/treatment_center)
 "iQR" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
@@ -35404,11 +35408,12 @@
 /turf/open/floor/wood/large,
 /area/station/command/bridge)
 "iWQ" = (
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/flora/bush/flowers_br/style_random,
-/turf/open/floor/grass,
-/area/station/medical/paramedic)
+/obj/structure/cable,
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/tcommsat/computer)
 "iWV" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -35469,6 +35474,16 @@
 /obj/structure/fireaxecabinet/mechremoval/directional/east,
 /turf/open/floor/iron/dark/small,
 /area/station/science/robotics/lab)
+"iZP" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/medical/chemistry,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "iZW" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -35765,12 +35780,12 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/storage_shared)
 "jlc" = (
-/obj/structure/closet/secure_closet/chemical,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
+/obj/effect/turf_decal/tile/yellow/half{
 	dir = 1
 	},
+/obj/effect/spawner/random/trash/ghetto_containers,
 /turf/open/floor/iron/white/smooth_large,
-/area/station/medical/chem_storage)
+/area/station/maintenance/department/medical)
 "jmr" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -37535,6 +37550,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/yellow/full,
+/obj/effect/spawner/random/medical/patient_stretcher,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/maintenance/department/medical)
 "kHO" = (
@@ -37948,6 +37964,17 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/commons/lounge)
+"lci" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/external{
+	name = "Telecommunications External Access"
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/tcommsat/computer)
 "lct" = (
 /obj/structure/disposalpipe/junction{
 	dir = 8
@@ -38030,12 +38057,6 @@
 /obj/effect/mapping_helpers/airalarm/unlocked,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
-"leL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/treatment_center)
 "lfc" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -38203,6 +38224,10 @@
 /mob/living/carbon/human/species/monkey,
 /turf/open/floor/grass,
 /area/station/science/genetics)
+"llV" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/tcommsat/computer)
 "lmU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -38251,11 +38276,11 @@
 	},
 /area/station/medical/pharmacy)
 "lnn" = (
-/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1
 	},
-/area/station/medical/treatment_center)
+/area/station/maintenance/department/medical)
 "lnw" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/machinery/requests_console/directional/north{
@@ -38294,12 +38319,9 @@
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
 "lou" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/machinery/computer/security/telescreen/entertainment/directional/east,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/obj/machinery/power/port_gen/pacman,
+/turf/open/floor/plating,
+/area/station/tcommsat/computer)
 "lpW" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -38652,9 +38674,27 @@
 /obj/effect/landmark/start/depsec/medical,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/medical)
+"lEX" = (
+/obj/effect/turf_decal/tile/pine_green/fourcorners,
+/obj/machinery/door/poddoor/shutters/colony_fabricator/preopen{
+	id_tag = "exam"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/medical/treatment_center)
 "lFb" = (
-/turf/open/space/basic,
-/area/station/tcommsat/computer)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/effect/turf_decal/stripes/end,
+/turf/open/floor/iron,
+/area/station/ai_monitored/command/storage/eva)
 "lFh" = (
 /obj/machinery/holopad,
 /obj/structure/cable,
@@ -39716,13 +39756,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/command/bridge)
-"myz" = (
-/obj/machinery/light/small/directional/west,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/tcommsat/computer)
 "mzp" = (
 /obj/effect/turf_decal/siding/dark_blue{
 	dir = 5
@@ -40053,6 +40086,11 @@
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
 /turf/open/space,
 /area/space/nearstation)
+"mOL" = (
+/obj/item/wrench,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/tcommsat/computer)
 "mPv" = (
 /obj/effect/turf_decal/tile/pine_green/half/contrasted,
 /obj/structure/disposalpipe/segment{
@@ -40195,6 +40233,25 @@
 "mVM" = (
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"mWs" = (
+/obj/machinery/door/airlock/external,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/service/library)
+"mWJ" = (
+/obj/effect/turf_decal/tile/yellow/half,
+/obj/effect/spawner/random/medical/patient_stretcher,
+/obj/effect/spawner/random/medical/organs,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/maintenance/department/medical)
 "mWQ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -41046,6 +41103,10 @@
 	},
 /turf/open/floor/iron/white/small,
 /area/station/science/research)
+"nIW" = (
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/maintenance/department/medical)
 "nJc" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -41090,7 +41151,7 @@
 	},
 /area/station/science/xenobiology)
 "nKE" = (
-/obj/effect/spawner/random/trash/cigbutt,
+/obj/effect/spawner/random/trash/mess,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/maintenance/department/medical)
 "nKU" = (
@@ -41974,6 +42035,13 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/medbay)
+"orK" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Paramedic Dispatch Room"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/turf/open/floor/plating,
+/area/station/medical/paramedic)
 "orZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -42064,6 +42132,20 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"ouX" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
+/obj/machinery/door/airlock/security/glass{
+	name = "Medbay Security Post"
+	},
+/obj/effect/turf_decal/tile/dark_blue/fourcorners,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/medical)
 "ovd" = (
 /obj/structure/table,
 /turf/open/floor/iron,
@@ -42775,14 +42857,11 @@
 /turf/open/floor/iron/dark,
 /area/station/service/abandoned_gambling_den/gaming)
 "oWN" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+/obj/effect/turf_decal/tile/pine_green{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/turf/open/floor/iron/white/smooth_edge,
+/area/station/medical/medbay)
 "oXp" = (
 /obj/machinery/requests_console/directional/east{
 	department = "Medical";
@@ -42807,9 +42886,12 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/medbay)
 "oXV" = (
-/obj/effect/spawner/random/trash/crushed_can,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/maintenance/department/medical)
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/floor/grass,
+/area/station/medical/paramedic)
 "oYc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -43101,6 +43183,10 @@
 "piM" = (
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
+"piO" = (
+/obj/effect/spawner/random/trash/food_packaging,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/maintenance/department/medical)
 "piR" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/records/medical/laptop{
@@ -43324,6 +43410,7 @@
 /area/station/hallway/primary/aft)
 "prD" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
+/obj/effect/spawner/random/trash/crushed_can,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1
 	},
@@ -43532,10 +43619,13 @@
 /turf/open/floor/plating,
 /area/station/engineering/storage_shared)
 "pAo" = (
-/obj/effect/turf_decal/tile/pine_green,
-/obj/effect/turf_decal/caution/stand_clear/red,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/yellow/full,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/maintenance/department/medical)
 "pAM" = (
 /obj/structure/chair/stool/bar/directional/west,
 /turf/open/floor/plating,
@@ -43896,6 +43986,12 @@
 "pNe" = (
 /obj/item/kirbyplants/organic/plant22,
 /obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/service/library)
 "pNf" = (
@@ -44874,11 +44970,7 @@
 	},
 /area/station/cargo/storage)
 "qwJ" = (
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/flora/bush/flowers_yw/style_random,
-/turf/open/floor/grass,
+/turf/closed/wall/r_wall,
 /area/station/medical/paramedic)
 "qwS" = (
 /obj/effect/turf_decal/siding{
@@ -44909,9 +45001,14 @@
 /turf/open/floor/carpet/black,
 /area/station/service/chapel/office)
 "qxq" = (
-/obj/effect/spawner/random/structure/table_or_rack,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/service/library)
 "qxE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -44947,10 +45044,6 @@
 	},
 /turf/open/floor/iron/terracotta/small,
 /area/station/service/kitchen)
-"qyV" = (
-/obj/machinery/power/port_gen/pacman,
-/turf/open/floor/plating,
-/area/station/tcommsat/computer)
 "qzm" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -45592,10 +45685,18 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "rcF" = (
-/obj/effect/turf_decal/tile/pine_green,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
+/obj/effect/turf_decal/tile/pine_green/fourcorners,
+/obj/machinery/door/airlock/multi_tile/public/glass{
+	name = "Medbay Lobby";
+	red_alert_access = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/machinery/door/poddoor/shutters/colony_fabricator/preopen{
+	id_tag = "exam"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/station/medical/treatment_center)
 "rdU" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
@@ -45755,6 +45856,12 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/maintenance/department/engine)
+"rlh" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/turf/open/floor/grass,
+/area/station/medical/paramedic)
 "rli" = (
 /obj/structure/sink{
 	dir = 8;
@@ -46406,6 +46513,12 @@
 /obj/structure/flora/bush/ferny/style_random,
 /turf/open/floor/grass,
 /area/station/medical/psychology)
+"rHA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/medical/treatment_center)
 "rHJ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -47019,15 +47132,6 @@
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
-"sdY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/yellow/full,
-/obj/effect/spawner/random/trash/grime,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/maintenance/department/medical)
 "sea" = (
 /obj/structure/flora/bush/lavendergrass/style_random,
 /obj/structure/flora/bush/sparsegrass/style_random,
@@ -47272,6 +47376,13 @@
 /obj/effect/mapping_helpers/airlock/access/any/medical/psychology,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"sor" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/turf/open/floor/grass,
+/area/station/medical/paramedic)
 "soA" = (
 /obj/structure/sign/directions/dorms/directional/east,
 /turf/closed/wall,
@@ -47659,8 +47770,6 @@
 /area/station/cargo/storage)
 "sAE" = (
 /obj/effect/turf_decal/tile/yellow/half,
-/obj/effect/spawner/random/medical/patient_stretcher,
-/obj/effect/spawner/random/medical/surgery_tool,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/maintenance/department/medical)
 "sAK" = (
@@ -48708,14 +48817,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
-"tnI" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/right/directional/south{
-	name = "Security Checkpoint";
-	req_access = list("brig_entrance")
-	},
-/turf/open/floor/plating,
-/area/station/security/checkpoint/medical)
 "tnY" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -48779,11 +48880,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark,
 /area/station/service/library)
-"tqK" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/any/medical/chemistry,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
 "tqO" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/line{
@@ -49026,8 +49122,17 @@
 /turf/open/floor/iron/dark,
 /area/station/service/library/lounge)
 "txK" = (
-/obj/effect/spawner/random/trash/grime,
-/turf/open/floor/iron/white/smooth_large,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 4
+	},
 /area/station/maintenance/department/medical)
 "txZ" = (
 /obj/structure/cable,
@@ -49180,6 +49285,12 @@
 "tBP" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/space/basic,
 /area/space/nearstation)
 "tCi" = (
@@ -49975,16 +50086,18 @@
 /turf/open/floor/wood,
 /area/station/science/lab)
 "uik" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/external{
-	name = "Telecommunications External Access"
+/obj/machinery/door/airlock/external,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
 /turf/open/floor/plating,
-/area/station/tcommsat/computer)
+/area/station/service/library)
 "uiP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -50146,12 +50259,9 @@
 /turf/open/floor/iron/white/airless,
 /area/station/science/ordnance/freezerchamber)
 "umO" = (
-/obj/machinery/door/morgue{
-	name = "Private Exhibit";
-	req_access = list("library")
-	},
-/turf/open/floor/iron/dark,
-/area/station/service/library/artgallery)
+/obj/effect/turf_decal/tile/yellow/full,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/maintenance/department/medical)
 "und" = (
 /obj/machinery/door/window/left/directional/east{
 	name = "Monkey Pen";
@@ -50677,6 +50787,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/psychology)
+"uFT" = (
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plating,
+/area/station/tcommsat/computer)
 "uGx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -50776,19 +50890,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/storage_shared)
-"uMq" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/door/airlock/external{
-	name = "Telecommunications External Access"
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/tcommsat/computer)
 "uMr" = (
 /obj/machinery/power/supermatter_crystal/engine,
 /obj/effect/turf_decal/bot,
@@ -51118,6 +51219,11 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
+"uYd" = (
+/obj/effect/turf_decal/tile/pine_green,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "uYF" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -51684,13 +51790,6 @@
 /obj/structure/rack,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
-"vvd" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Paramedic Dispatch Room"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/turf/open/floor/plating,
-/area/station/medical/paramedic)
 "vvn" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -51730,6 +51829,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/library/artgallery)
+"vvZ" = (
+/obj/effect/turf_decal/tile/yellow/half,
+/obj/effect/spawner/random/medical/patient_stretcher,
+/obj/effect/spawner/random/medical/surgery_tool,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/maintenance/department/medical)
 "vwa" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/kitchen/diagonal,
@@ -53424,18 +53529,12 @@
 /turf/open/floor/plating,
 /area/station/service/library/artgallery)
 "wJL" = (
-/obj/structure/sign/painting/library{
-	pixel_x = 32
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/colony_fabricator/preopen{
+	id_tag = "exam"
 	},
-/turf/open/floor/iron/dark,
-/area/station/service/library/artgallery)
-"wJO" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted,
-/obj/effect/spawner/random/trash/crushed_can,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/maintenance/department/medical)
+/turf/open/floor/plating,
+/area/station/medical/treatment_center)
 "wJT" = (
 /obj/structure/chair/wood,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -53689,6 +53788,12 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/security/range)
+"wSP" = (
+/obj/structure/table,
+/obj/item/hand_labeler,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/chem_storage)
 "wSR" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
@@ -53889,10 +53994,6 @@
 /obj/effect/landmark/atmospheric_sanity/ignore_area,
 /turf/open/floor/carpet,
 /area/station/service/chapel)
-"xaw" = (
-/obj/effect/spawner/random/trash/caution_sign,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/maintenance/department/medical)
 "xay" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -54426,8 +54527,11 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "xnm" = (
-/turf/closed/wall/r_wall,
-/area/station/medical/pharmacy)
+/obj/machinery/atmospherics/components/unary/airlock_pump/silent{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/service/library)
 "xnp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -66957,8 +67061,8 @@ cvT
 cwk
 rNH
 aQM
-ckv
-ckM
+ckw
+vpC
 clb
 aaa
 aaa
@@ -67998,17 +68102,17 @@ aaa
 aaa
 aaa
 aaa
-cfN
-cfN
-cfN
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-cfN
-cfN
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -68252,22 +68356,22 @@ aaa
 aaa
 aaa
 aaa
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
 aaa
 aaa
 aaa
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -68507,26 +68611,26 @@ aaa
 aaa
 aaa
 aaa
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-aht
 aaa
 aaa
 aaa
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -68764,26 +68868,26 @@ aaa
 aaa
 aaa
 aaa
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-aaa
-aht
 aaa
 aaa
 aaa
 aaa
-aht
 aaa
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -69021,26 +69125,26 @@ aaa
 aaa
 aaa
 aaa
-cfN
-cfN
-cfN
-aht
+aaa
+aaa
+aaa
+cjp
+gjd
+cjp
 aaa
 aht
-aaa
-aht
 aht
 aht
 aht
 aht
 aht
 aaa
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -69279,24 +69383,24 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aht
-aaa
 aht
-aaa
-aht
-aaa
-aaa
-aaa
+cyU
+bFS
+cyU
 aaa
 aht
 aaa
 aaa
 aaa
+aaa
 aht
-cfN
-cfN
+aaa
+aaa
+aaa
+aht
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -69536,10 +69640,10 @@ cfN
 aaa
 aaa
 aaa
-aaa
+aht
 aaa
 cjp
-cyU
+mWs
 cjp
 cyU
 cjp
@@ -69796,7 +69900,7 @@ aht
 aht
 cjp
 cjp
-cAK
+iBp
 cyY
 cAK
 nAF
@@ -70053,7 +70157,7 @@ aaa
 aaa
 cjp
 cCW
-cAK
+iBp
 cyZ
 cAK
 czl
@@ -70310,7 +70414,7 @@ aht
 aht
 cjp
 ckW
-cAK
+iBp
 cAK
 cAK
 czl
@@ -70567,7 +70671,7 @@ aaa
 aaa
 cjp
 cyP
-cAK
+iBp
 cyZ
 cAK
 czl
@@ -70585,7 +70689,7 @@ aaa
 aaa
 aaa
 aaa
-cfN
+aaa
 aaa
 aaa
 aaa
@@ -70824,7 +70928,7 @@ cxM
 cyB
 cjp
 cyQ
-cAK
+iBp
 cAK
 cAK
 cAK
@@ -70837,13 +70941,13 @@ pGZ
 xBB
 syW
 cAS
+cjp
 cyU
-aht
-aht
-aht
-cfN
-cfN
-cfN
+cjp
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -71081,7 +71185,7 @@ dFU
 try
 jgr
 cjQ
-cjQ
+ftW
 cjQ
 cjQ
 cjQ
@@ -71089,18 +71193,18 @@ cjQ
 jMS
 vNF
 vNF
-xBB
+iBp
 cAu
 cAC
-cAK
-cAT
-cyU
+iBp
+iBp
+dGT
+xnm
+clJ
 aaa
 aaa
 aaa
-cfN
-cfN
-cfN
+aaa
 aaa
 aaa
 aaa
@@ -71351,13 +71455,13 @@ cAv
 cAD
 cAK
 cAU
+cjp
 cyU
+cjp
 aaa
 aaa
 aaa
-cfN
-cfN
-cfN
+aaa
 aaa
 aaa
 aaa
@@ -71603,7 +71707,7 @@ cAK
 cAK
 cAK
 vNF
-cAK
+xBB
 cAt
 cAK
 cAK
@@ -71611,10 +71715,10 @@ cAV
 cyU
 aaa
 aaa
-cfN
-cfN
-cfN
-cfN
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -71860,7 +71964,7 @@ czu
 czD
 czN
 vNF
-vNF
+qxq
 qit
 vNF
 uUf
@@ -71868,10 +71972,10 @@ cjp
 cyU
 aaa
 aaa
-cfN
-cfN
-cfN
-cfN
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -72117,18 +72221,18 @@ czv
 czv
 czO
 ctZ
-cAK
+iBp
 cAy
 cAB
 cyU
 cjp
 aht
-aht
-aht
-cfN
-cfN
-cfN
-cfN
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -72374,7 +72478,7 @@ cAK
 cAK
 czP
 cAK
-cAK
+iBp
 cjp
 cjp
 cyU
@@ -72382,10 +72486,10 @@ aht
 aaa
 aaa
 aaa
-cfN
-cfN
-cfN
-cfN
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -72638,11 +72742,11 @@ aaa
 aht
 aaa
 aaa
-cfN
-cfN
-cfN
-cfN
-cfN
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -72875,10 +72979,10 @@ whJ
 whJ
 whJ
 cfN
+aht
 aaa
 aaa
 aaa
-aht
 cjp
 cyU
 cjp
@@ -72887,18 +72991,18 @@ cjp
 cjp
 cyU
 cjp
-cyU
 cjp
-cyU
+uik
+cjp
 aht
 aht
 aht
 aht
-cfN
-cfN
-cfN
-cfN
-cfN
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -73132,30 +73236,30 @@ fAe
 kZU
 whJ
 cfN
-aaa
-aaa
-aaa
 aht
 aaa
 aaa
-aht
 aaa
 aaa
 aht
 aaa
 aht
 aaa
+aaa
 aht
 aaa
+cyU
+bnB
+cyU
 aaa
 aaa
 aaa
 aaa
-cfN
-cfN
 aaa
-cfN
-cfN
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -73389,23 +73493,23 @@ tqW
 fwx
 whJ
 cfN
-cfN
-aaa
-aaa
 aht
 aht
 aht
-aht
-aaa
-aaa
 aht
 aht
 aht
 aaa
 aht
+aht
+aht
+aht
 aaa
-cfN
-cfN
+cjp
+clU
+cjp
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -73646,23 +73750,23 @@ tqW
 woX
 whJ
 cfN
-cfN
-aaa
-aaa
 aht
 aaa
 aaa
-aht
-cfN
-cfN
-cfN
-cfN
-aht
 aaa
-aht
-cfN
-cfN
-cfN
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -73903,24 +74007,24 @@ fAe
 jOw
 whJ
 cfN
-cfN
-aaa
-aaa
 aht
 aaa
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -74152,7 +74256,7 @@ kzj
 gMG
 whJ
 ebp
-wJL
+roy
 mFu
 roy
 vJu
@@ -74163,21 +74267,21 @@ cfN
 aaa
 aaa
 aaa
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -74408,8 +74512,8 @@ whJ
 whJ
 whJ
 whJ
-umO
-whJ
+roy
+roy
 whJ
 whJ
 whJ
@@ -74419,22 +74523,22 @@ cfN
 cfN
 aaa
 aaa
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -74676,22 +74780,22 @@ cfN
 aaa
 aaa
 aaa
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
 aaa
 aaa
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
-cfN
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -74935,19 +75039,19 @@ aaa
 aaa
 aaa
 aaa
-cfN
-cfN
-cfN
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-cfN
-cfN
-cfN
-cfN
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -81790,7 +81894,7 @@ bfk
 bdm
 dyg
 sMg
-rcF
+uYd
 dYh
 iDT
 blc
@@ -82305,7 +82409,7 @@ bdm
 dyg
 sMg
 bik
-bgl
+wJL
 bjS
 tgd
 nUo
@@ -82561,9 +82665,9 @@ bfm
 xPQ
 dyg
 sMg
-pAo
-iPy
-bjT
+dpV
+rcF
+bjU
 hfw
 gnS
 gnS
@@ -82818,13 +82922,13 @@ bfn
 bdm
 dyg
 sMg
-pAo
-ftW
-bjT
-bLs
-leL
-bLs
-lnn
+dpV
+lEX
+bjU
+bJc
+rHA
+bJc
+dQh
 xsa
 xUU
 uFc
@@ -83076,13 +83180,13 @@ aRL
 dyg
 sMg
 bik
-bgl
+wJL
 bjV
 qwS
 jJm
 aFM
 uQu
-blf
+oWN
 ktU
 uFc
 buc
@@ -83335,7 +83439,7 @@ sMg
 bik
 dYh
 bjW
-clU
+clV
 idj
 tCi
 xQO
@@ -83848,7 +83952,7 @@ tWc
 sMg
 bin
 dYh
-bMM
+bjY
 tgT
 pku
 qib
@@ -83865,12 +83969,12 @@ fbc
 bCn
 bDs
 mOx
-fhH
-fhH
-fhH
-fhH
-fhH
-fhH
+txK
+txK
+txK
+txK
+txK
+txK
 bMK
 oJj
 eMp
@@ -83947,7 +84051,7 @@ pEK
 pEK
 pEK
 pEK
-bnB
+blf
 clw
 clw
 clw
@@ -84122,7 +84226,7 @@ tli
 peY
 bjc
 jfg
-nKE
+nIW
 egX
 tcX
 egX
@@ -84205,10 +84309,10 @@ aaa
 aaa
 aaa
 teJ
-uik
-myz
-uMq
-bzX
+lci
+btK
+bjT
+iWQ
 clY
 gmH
 cmh
@@ -84366,7 +84470,7 @@ bjZ
 vaR
 eus
 bnD
-dcN
+ouX
 brg
 sgD
 cqd
@@ -84466,7 +84570,7 @@ clw
 hQz
 nTk
 jCr
-hIG
+clD
 kCI
 nTk
 nMG
@@ -84618,7 +84722,7 @@ bgk
 dyg
 sMg
 fih
-tnI
+boF
 bka
 tLk
 bmv
@@ -84634,13 +84738,13 @@ jze
 jze
 qnJ
 jze
-awW
+qwJ
 oPH
 hEF
 tKY
-clJ
-kHD
-dpV
+bgl
+pAo
+clM
 eeb
 oJj
 oJj
@@ -84718,7 +84822,7 @@ aaa
 aaa
 aaa
 aaa
-lFb
+dcN
 clw
 nTk
 nTk
@@ -84887,17 +84991,17 @@ hZH
 hZH
 bvl
 bwO
-iWQ
+aIr
 bzZ
 bsJ
 bCr
-awW
+qwJ
 tta
-fTD
-elU
+mWJ
+umO
 eXa
-kHD
-bjY
+pAo
+jlc
 bAg
 oJj
 bNV
@@ -84975,12 +85079,12 @@ aaa
 aaa
 aaa
 aaa
-lFb
+dcN
 clw
-qyV
-clV
-bCp
-clV
+lou
+ckM
+mOL
+ckM
 mxy
 nTk
 qPu
@@ -85144,17 +85248,17 @@ jWH
 nYu
 oSa
 gfH
-qwJ
+sor
 fgs
 xmg
 buk
-awW
+qwJ
 clN
-sAE
-eeW
+vvZ
+piO
 eXa
-sdY
-bmp
+cmc
+iDg
 bLL
 oJj
 bNW
@@ -85234,10 +85338,10 @@ aaa
 aaa
 abI
 clw
-clV
-bli
-cLB
-cmb
+ckM
+uFT
+llV
+bMM
 mDW
 nTk
 cml
@@ -85401,17 +85505,17 @@ frX
 dRU
 gzG
 brh
-vvd
+orK
 brl
 bsL
 bFl
-awW
-bJc
-bjU
-txK
-txK
-sdY
-bFS
+qwJ
+dYf
+sAE
+ckv
+ckv
+cmc
+hXk
 anH
 oJj
 oxA
@@ -85658,18 +85762,18 @@ bsH
 blo
 crd
 gfH
-bll
+oXV
 hjy
 nSe
 xsT
-awW
+qwJ
 veb
-bjU
-txK
-txK
-kHD
-hXk
-prD
+sAE
+ckv
+ckv
+pAo
+cmb
+lnn
 oJj
 oJj
 eMp
@@ -85915,16 +86019,16 @@ mZi
 wEl
 bvp
 xTf
-gPn
+rlh
 brm
 bsN
 bCv
-awW
-qxq
-bjU
-boF
-boF
-clD
+qwJ
+eVG
+sAE
+eeW
+eeW
+kHD
 mFY
 bLM
 bMN
@@ -86168,15 +86272,15 @@ ufo
 boL
 bpY
 fms
-xnm
-xnm
+bli
+bli
 qgA
-xnm
-awW
+bli
+qwJ
 jze
 jze
 jze
-awW
+qwJ
 lRN
 eGL
 iZl
@@ -86435,8 +86539,8 @@ uqf
 bCx
 byw
 lRN
-cmc
-hXk
+nKE
+cmb
 eXa
 oPH
 ipz
@@ -86690,13 +86794,13 @@ eBd
 bsK
 vTg
 vTg
-eVp
-tqK
-xaw
-txK
-cmc
-oXV
-wJO
+fri
+bCp
+bll
+ckv
+nKE
+cAT
+prD
 byz
 ooh
 oJj
@@ -87201,16 +87305,16 @@ qHa
 pxw
 dRj
 hEC
-jlc
+awW
 vTg
-cdk
+igj
 lRN
 lRN
 oJj
 oJj
 oJj
 oJj
-ieL
+clA
 oJj
 oJj
 oJj
@@ -87461,7 +87565,7 @@ hEC
 ipu
 phx
 azR
-clM
+iZP
 eMp
 eMp
 eMp
@@ -87717,7 +87821,7 @@ lRN
 hEC
 cIe
 fby
-clA
+wSP
 lRN
 eMp
 oJj
@@ -87980,7 +88084,7 @@ hop
 oJj
 jCv
 bOK
-iAH
+bzX
 ery
 sAC
 bIT
@@ -88232,8 +88336,8 @@ gVk
 gVk
 gVk
 uQB
-oWN
-oWN
+cLB
+cLB
 bFq
 gmv
 bIt
@@ -88452,7 +88556,7 @@ riB
 aKZ
 aLS
 daO
-tCk
+lFb
 aPJ
 aRa
 aRX
@@ -90249,7 +90353,7 @@ jrV
 trf
 uYV
 aLc
-igj
+aNx
 nzP
 aOH
 aPP
@@ -91539,7 +91643,7 @@ swT
 swT
 swT
 aXr
-lou
+fhH
 mvJ
 swT
 swT
@@ -94371,7 +94475,7 @@ cay
 dTT
 xIM
 aWw
-bat
+bLs
 oxM
 gND
 aZn
@@ -96424,7 +96528,7 @@ aTo
 aTo
 aTo
 aTo
-btK
+cyT
 rvO
 ney
 gvi
@@ -96681,7 +96785,7 @@ bgy
 aRq
 tYu
 aTp
-cyT
+aUz
 wkM
 sAD
 cCB

--- a/_maps/map_files/Pubbystation/pubbystation.dmm
+++ b/_maps/map_files/Pubbystation/pubbystation.dmm
@@ -14197,11 +14197,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
-"biA" = (
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/engineering/atmos/hfr_room)
 "biC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -36049,6 +36044,12 @@
 	},
 /turf/open/floor/iron/white/smooth_half,
 /area/station/science/xenobiology)
+"jxT" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/engineering/atmos/hfr_room)
 "jyJ" = (
 /obj/structure/table,
 /obj/structure/chem_separator,
@@ -36206,10 +36207,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "jFQ" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers,
-/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/turf_decal/tile/blue/half/contrasted,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
 /area/station/engineering/atmos/hfr_room)
 "jFW" = (
 /obj/structure/maintenance_loot_structure/grenade_box/random,
@@ -37343,6 +37345,15 @@
 /obj/structure/sign/poster/official/walk/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"kyr" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white/textured_edge{
+	dir = 4
+	},
+/area/station/engineering/atmos/hfr_room)
 "kyJ" = (
 /obj/structure/chair{
 	dir = 4
@@ -37622,12 +37633,12 @@
 /turf/open/floor/plating,
 /area/station/security/range)
 "kJU" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/white/smooth_edge{
 	dir = 1
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/white/textured_edge,
-/area/station/engineering/atmos/hfr_room)
+/area/station/maintenance/disposal/incinerator)
 "kKf" = (
 /obj/item/kirbyplants/organic/plant8,
 /turf/open/floor/iron/dark,
@@ -40302,12 +40313,14 @@
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
 "mYX" = (
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/tile/blue/half/contrasted,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
 	},
-/area/station/maintenance/disposal/incinerator)
+/obj/structure/cable,
+/turf/open/floor/iron/white/textured_edge{
+	dir = 4
+	},
+/area/station/engineering/atmos/hfr_room)
 "mZi" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -40392,14 +40405,6 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/engineering/atmos)
-"ncu" = (
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/light/dim/directional/west,
-/turf/open/floor/iron/white/textured,
-/area/station/engineering/atmos/hfr_room)
 "ndc" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door{
@@ -42066,6 +42071,7 @@
 	name = "Paramedic Dispatch Room"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/station/medical/paramedic)
 "orZ" = (
@@ -42159,7 +42165,6 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "ouX" = (
-/obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -42170,6 +42175,7 @@
 	name = "Medbay Security Post"
 	},
 /obj/effect/turf_decal/tile/dark_blue/fourcorners,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/medical)
 "ovd" = (
@@ -44763,15 +44769,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
-"qoF" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white/textured_edge{
-	dir = 4
-	},
-/area/station/engineering/atmos/hfr_room)
 "qoW" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
@@ -47431,6 +47428,13 @@
 	dir = 4
 	},
 /area/station/engineering/atmos/hfr_room)
+"sqa" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white/textured_edge,
+/area/station/engineering/atmos/hfr_room)
 "sqe" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -49699,13 +49703,12 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "tSV" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 1
 	},
 /obj/structure/cable,
-/turf/open/floor/iron/white/textured_edge{
-	dir = 4
-	},
+/obj/machinery/light/dim/directional/west,
+/turf/open/floor/iron/white/textured,
 /area/station/engineering/atmos/hfr_room)
 "tTB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -50583,6 +50586,14 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/service/library/artgallery)
+"uya" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 8
+	},
+/obj/machinery/light/dim/directional/west,
+/turf/open/floor/iron/white/textured,
+/area/station/engineering/atmos/hfr_room)
 "uyg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -51380,10 +51391,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
-"vdb" = (
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/engineering/atmos/hfr_room)
 "vdg" = (
 /obj/machinery/light/directional/south,
 /obj/structure/extinguisher_cabinet/directional/south,
@@ -53525,13 +53532,6 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
 /area/station/cargo/office)
-"wGD" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted,
-/obj/structure/cable,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/engineering/atmos/hfr_room)
 "wGM" = (
 /obj/effect/turf_decal/tile/pine_green/half/contrasted,
 /turf/open/floor/iron/white,
@@ -53762,12 +53762,9 @@
 /turf/open/floor/carpet/red,
 /area/station/medical/psychology)
 "wQE" = (
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 8
-	},
-/obj/machinery/light/dim/directional/west,
-/turf/open/floor/iron/white/textured,
+/turf/open/floor/iron/white,
 /area/station/engineering/atmos/hfr_room)
 "wQU" = (
 /obj/effect/spawner/random/maintenance,
@@ -55010,6 +55007,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/command)
+"xDU" = (
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/engineering/atmos/hfr_room)
 "xEt" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -92536,13 +92537,13 @@ cbu
 cbu
 bJP
 hzr
-ncu
 tSV
+mYX
 xJb
 xJb
 xJb
-qoF
-wQE
+kyr
+uya
 hzr
 pDW
 pDW
@@ -92793,7 +92794,7 @@ bJP
 bJP
 bJP
 auI
-kJU
+sqa
 jQB
 jQB
 jQB
@@ -93821,7 +93822,7 @@ bJP
 bJP
 bJP
 auI
-kJU
+sqa
 jQB
 jQB
 jQB
@@ -94342,7 +94343,7 @@ pjM
 pjM
 pjM
 wfp
-jFQ
+jxT
 aaa
 aaa
 aaa
@@ -94598,7 +94599,7 @@ pjM
 pjM
 pjM
 pjM
-wGD
+jFQ
 auI
 aaa
 aaa
@@ -94854,8 +94855,8 @@ rfm
 sxs
 tlU
 wMm
-vdb
-biA
+xDU
+wQE
 hzr
 aaa
 aaa
@@ -95620,7 +95621,7 @@ usl
 fDM
 usl
 jKs
-yjt
+kJU
 bYw
 bYw
 bYw
@@ -95877,7 +95878,7 @@ vfj
 vfj
 vfj
 oib
-mYX
+yjt
 mHK
 mEz
 xXi

--- a/_maps/map_files/Pubbystation/pubbystation.dmm
+++ b/_maps/map_files/Pubbystation/pubbystation.dmm
@@ -918,6 +918,15 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay)
+"aex" = (
+/obj/effect/turf_decal/tile/pine_green/half/contrasted{
+	dir = 8
+	},
+/obj/structure/bed/medical/emergency,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 4
+	},
+/area/station/medical/medbay/lobby)
 "aey" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/iron,
@@ -6508,7 +6517,7 @@
 /area/station/maintenance/solars/port)
 "aAY" = (
 /obj/structure/cable,
-/obj/machinery/power/smes/super,
+/obj/machinery/power/smes/battery_pack,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port)
 "aBd" = (
@@ -8508,7 +8517,7 @@
 /area/station/commons/toilet/restrooms)
 "aJp" = (
 /obj/structure/cable,
-/obj/machinery/power/smes/super,
+/obj/machinery/power/smes/battery_pack,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard)
 "aJq" = (
@@ -13304,6 +13313,13 @@
 "beI" = (
 /turf/closed/wall/r_wall,
 /area/station/science/robotics/mechbay)
+"beM" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "beP" = (
 /obj/machinery/computer/order_console/mining,
 /obj/effect/turf_decal/trimline/brown/filled/end{
@@ -16440,7 +16456,6 @@
 "bua" = (
 /obj/effect/turf_decal/tile/pine_green/fourcorners,
 /obj/structure/table/wood,
-/obj/item/food/spacetwinkie,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "bub" = (
@@ -25989,7 +26004,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/item/storage/box/coffeepack,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
@@ -26759,6 +26773,21 @@
 /obj/machinery/vending/wardrobe/chap_wardrobe,
 /turf/open/floor/carpet,
 /area/station/service/chapel/office)
+"ctY" = (
+/obj/machinery/door/window/right/directional/north{
+	name = "Medbay Front Desk";
+	req_access = list("medical")
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
+/obj/structure/table/reinforced,
+/obj/item/storage/medkit/civil_defense/comfort/stocked,
+/obj/item/storage/medkit/civil_defense/comfort/stocked{
+	pixel_x = 8;
+	pixel_y = 0
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "ctZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -27931,7 +27960,7 @@
 /area/station/engineering/main)
 "cEI" = (
 /obj/structure/table/wood,
-/obj/item/reagent_containers/cup/soda_cans/dr_gibb,
+/obj/item/reagent_containers/cup/glass/waterbottle/large,
 /turf/open/floor/iron/terracotta,
 /area/station/medical/medbay)
 "cEJ" = (
@@ -29080,6 +29109,13 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"dIU" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 5
+	},
+/turf/open/space,
+/area/space/nearstation)
 "dJm" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Research Pit"
@@ -29238,6 +29274,13 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/station/science/ordnance/burnchamber)
+"dPr" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 6
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "dPO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -30787,6 +30830,10 @@
 /obj/structure/table,
 /obj/item/clothing/glasses/science,
 /obj/item/clothing/glasses/science,
+/obj/item/reagent_containers/cup/soda_cans/dr_gibb{
+	pixel_x = -8;
+	pixel_y = 12
+	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/chem_storage)
 "fcK" = (
@@ -32349,6 +32396,14 @@
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
+"gsA" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
+/turf/open/space/basic,
+/area/space/nearstation)
 "gsB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -33776,6 +33831,11 @@
 /obj/structure/girder,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
+"hBl" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/turf/open/space/basic,
+/area/space/nearstation)
 "hBn" = (
 /obj/effect/turf_decal/tile/pine_green{
 	dir = 4
@@ -34236,14 +34296,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine,
 /area/station/science/lab)
-"hTs" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/turf/open/space,
-/area/space/nearstation)
 "hUx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -35559,6 +35611,12 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden/monastery)
+"jci" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/obj/structure/transit_tube/crossing,
+/turf/open/space/basic,
+/area/space/nearstation)
 "jcT" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -36404,6 +36462,13 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/closed/wall,
 /area/station/commons/fitness)
+"jNJ" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
+/turf/open/space,
+/area/space/nearstation)
 "jNZ" = (
 /obj/item/flashlight/lantern,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -37402,13 +37467,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/medbay)
-"kAR" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 5
-	},
-/turf/open/space,
-/area/space/nearstation)
 "kCc" = (
 /obj/structure/plasticflaps/opaque,
 /obj/machinery/conveyor{
@@ -37795,21 +37853,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/commons/dorms)
-"kTv" = (
-/obj/machinery/door/window/right/directional/north{
-	name = "Medbay Front Desk";
-	req_access = list("medical")
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
-/obj/structure/table/reinforced,
-/obj/item/storage/medkit/civil_defense/comfort/stocked,
-/obj/item/storage/medkit/civil_defense/comfort/stocked{
-	pixel_x = 8;
-	pixel_y = 0
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
 "kUj" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -38561,8 +38604,10 @@
 /area/station/service/library/lounge)
 "lxx" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/turf/open/space/basic,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 9
+	},
+/turf/open/space,
 /area/space/nearstation)
 "lyd" = (
 /obj/effect/landmark/start/security_officer,
@@ -39154,14 +39199,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark/small,
 /area/station/science/lab)
-"lZZ" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
-/turf/open/space/basic,
-/area/space/nearstation)
 "maH" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -39835,13 +39872,6 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/wood/large,
 /area/station/science/breakroom)
-"mBn" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 9
-	},
-/turf/open/space,
-/area/space/nearstation)
 "mBu" = (
 /obj/item/book/bible,
 /obj/structure/altar_of_gods,
@@ -41551,13 +41581,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/station/science/ordnance/burnchamber)
-"nXj" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/turf/open/space,
-/area/space/nearstation)
 "nXy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -41678,13 +41701,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
-"ocA" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 10
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "ocZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -45134,15 +45150,13 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
-"qAG" = (
-/obj/effect/turf_decal/tile/pine_green/half/contrasted{
-	dir = 8
+"qAI" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 10
 	},
-/obj/structure/bed/medical/emergency,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 4
-	},
-/area/station/medical/medbay/lobby)
+/turf/open/space/basic,
+/area/space/nearstation)
 "qAQ" = (
 /obj/structure/cable,
 /obj/machinery/holopad,
@@ -46587,12 +46601,13 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/maintenance/disposal/incinerator)
 "rGo" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
+/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
+/turf/open/space/basic,
+/area/space/nearstation)
 "rGD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/effect/spawner/structure/window/reinforced,
@@ -46625,6 +46640,13 @@
 /obj/effect/landmark/start/bitrunner,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/cargo/bitrunning/den)
+"rHM" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "rIm" = (
 /obj/machinery/newscaster/directional/east,
 /turf/closed/wall/r_wall,
@@ -47660,6 +47682,14 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white/smooth_half,
 /area/station/medical/medbay/central)
+"suZ" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
+/turf/open/space,
+/area/space/nearstation)
 "svb" = (
 /obj/structure/chair/office/tactical{
 	dir = 1
@@ -50930,6 +50960,13 @@
 /obj/structure/chair/stool/bar/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"uJb" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "uKD" = (
 /obj/structure/chair,
 /obj/machinery/light/directional/north,
@@ -51632,13 +51669,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/science/lab)
-"vjO" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 6
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
 "vkt" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark/textured,
@@ -51741,13 +51771,6 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
-"vph" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "vpr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -53046,10 +53069,9 @@
 /turf/closed/wall,
 /area/station/maintenance/department/crew_quarters/dorms)
 "wnh" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 9
-	},
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/obj/structure/transit_tube,
 /turf/open/space/basic,
 /area/space/nearstation)
 "wns" = (
@@ -54185,10 +54207,9 @@
 /area/station/engineering/atmos)
 "xca" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
 /turf/open/space/basic,
 /area/space/nearstation)
 "xci" = (
@@ -55506,13 +55527,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/storage_shared)
-"xTA" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "xTH" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/cup/glass/bottle/wine{
@@ -85109,10 +85123,10 @@ lEs
 gMY
 xIP
 vPE
-kTv
+ctY
 lOw
-qAG
-qAG
+aex
+aex
 bvl
 bwO
 aIr
@@ -86313,13 +86327,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 acO
 aby
 aby
@@ -86328,6 +86335,13 @@ aby
 aby
 aaa
 aby
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -86561,13 +86575,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aby
 aby
 aby
@@ -86585,6 +86592,13 @@ aaa
 abI
 aaa
 aby
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -86803,13 +86817,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aby
 aby
 aby
@@ -86842,6 +86849,13 @@ acP
 acP
 abI
 aby
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -87062,13 +87076,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 abI
 aaa
 aaa
@@ -87099,6 +87106,13 @@ afK
 acP
 aaa
 aby
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -87309,13 +87323,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 cdm
 aht
 fon
@@ -87356,6 +87363,13 @@ afL
 acP
 abI
 aby
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -87566,13 +87580,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aht
 aaa
 aht
@@ -87611,6 +87618,13 @@ afa
 afv
 afM
 acP
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -87823,13 +87837,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 fon
 aaa
 aht
@@ -87870,6 +87877,13 @@ acP
 acP
 agq
 adX
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -88080,13 +88094,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 fon
 aaa
 aht
@@ -88127,6 +88134,13 @@ afN
 age
 agr
 adX
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -88337,13 +88351,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 fon
 aaa
 aht
@@ -88386,6 +88393,13 @@ hQc
 adX
 adX
 adX
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -88594,13 +88608,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 fon
 aaa
 aht
@@ -88643,6 +88650,13 @@ adX
 adX
 adX
 ahh
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -88851,13 +88865,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 fon
 aeT
 avz
@@ -88900,6 +88907,13 @@ agR
 agD
 agR
 ahi
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -89108,13 +89122,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 fon
 aaa
 aht
@@ -89157,6 +89164,13 @@ adX
 adX
 adX
 ahh
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -89365,13 +89379,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 fon
 aaa
 aht
@@ -89415,6 +89422,13 @@ adX
 adX
 adX
 ahr
+aht
+aht
+aht
+aht
+aht
+aht
+aht
 aht
 aht
 aht
@@ -89622,13 +89636,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 fon
 aaa
 aht
@@ -89672,6 +89679,13 @@ agE
 agS
 agS
 ahs
+wnh
+wnh
+jci
+wnh
+wnh
+wnh
+wnh
 ahR
 ahs
 ahs
@@ -89879,13 +89893,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 fon
 aaa
 aht
@@ -89928,6 +89935,13 @@ agq
 adX
 abI
 abI
+aht
+aht
+aht
+aht
+aht
+aht
+aht
 aht
 aht
 aht
@@ -90136,13 +90150,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aht
 aaa
 aht
@@ -90181,6 +90188,13 @@ afk
 nlE
 afS
 acU
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -90393,13 +90407,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 cdm
 aht
 fon
@@ -90440,6 +90447,13 @@ afS
 acU
 abI
 aby
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -90660,13 +90674,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 abI
 aaa
 aaa
@@ -90697,6 +90704,13 @@ afT
 acU
 aaa
 aby
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -90915,13 +90929,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aby
 aby
 aby
@@ -90954,6 +90961,13 @@ acU
 acU
 abI
 aby
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -91186,13 +91200,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 nge
 aby
 aby
@@ -91211,6 +91218,13 @@ aaa
 abI
 aaa
 aby
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -91454,13 +91468,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aby
 aby
 aby
@@ -91469,8 +91476,15 @@ aby
 aaa
 aby
 aaa
-fon
-fon
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 fon
 fon
@@ -92339,7 +92353,7 @@ wCz
 wwr
 sEx
 vrw
-kAR
+dIU
 mkf
 cbv
 ccn
@@ -92852,8 +92866,8 @@ pyH
 wCz
 pyH
 uWA
-vjO
-mBn
+dPr
+lxx
 bJP
 bJP
 bJP
@@ -94898,15 +94912,15 @@ xgG
 wWR
 pFG
 vzg
-rGo
+rHM
 fBp
 pFG
 vzg
-rGo
+rHM
 iQR
 pFG
 vzg
-rGo
+rHM
 vLx
 hzr
 ssZ
@@ -95152,7 +95166,7 @@ fBp
 avD
 abI
 mDo
-nXj
+jNJ
 avD
 abI
 mDo
@@ -95164,7 +95178,7 @@ wLU
 oln
 cAO
 mOH
-hTs
+suZ
 aor
 eTY
 aqp
@@ -95406,22 +95420,22 @@ buz
 seI
 mBU
 aht
-vph
+beM
 aht
-xTA
-ocA
+uJb
+qAI
+rGo
+hBl
+gsA
+hBl
+rGo
+hBl
+gsA
+hBl
+rGo
+hBl
+gsA
 xca
-lxx
-lZZ
-lxx
-xca
-lxx
-lZZ
-lxx
-xca
-lxx
-lZZ
-wnh
 bYw
 tfh
 aAu

--- a/_maps/map_files/Pubbystation/pubbystation.dmm
+++ b/_maps/map_files/Pubbystation/pubbystation.dmm
@@ -1009,15 +1009,23 @@
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/ai_sat_ext_ap)
 "afb" = (
-/obj/structure/table,
-/obj/item/stack/sheet/plasteel{
-	amount = 10
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
+/obj/structure/closet/secure_closet{
+	name = "Civilian-Issue Gear";
+	access_locked = 1;
+	req_access = list("brig_entrance");
+	anchored = 1
+	},
+/obj/item/gun/energy/e_gun/mini,
+/obj/item/gun/energy/e_gun/mini,
+/obj/item/clothing/suit/frontier_colonist_flak,
+/obj/item/clothing/suit/frontier_colonist_flak,
+/obj/item/clothing/head/frontier_colonist_helmet,
+/obj/item/clothing/head/frontier_colonist_helmet,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
 "afc" = (
@@ -5115,6 +5123,13 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/commons/fitness/recreation)
+"avo" = (
+/obj/machinery/light/small/directional/west,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/tcommsat/computer)
 "avp" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -5609,13 +5624,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "awW" = (
-/obj/structure/closet/crate/freezer/blood,
-/obj/structure/window/spawner/directional/west,
-/obj/machinery/camera/autoname/motion/directional/north,
-/obj/machinery/button/door/directional/north{
-	id_tag = "exam";
-	name = "Entrance Lockdown"
-	},
+/obj/structure/closet/secure_closet/medical2,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/treatment_center)
 "awY" = (
@@ -5933,6 +5943,10 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port)
+"ayC" = (
+/obj/effect/spawner/random/trash/grime,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "ayD" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
@@ -6222,18 +6236,12 @@
 /turf/open/space,
 /area/station/solars/port)
 "azK" = (
-/obj/structure/closet/secure_closet{
-	name = "Civilian-Issue Gear";
-	access_locked = 1;
-	req_access = list("brig_entrance");
-	anchored = 1
+/obj/structure/table,
+/obj/item/gun/grenadelauncher{
+	pixel_x = -1;
+	pixel_y = 10
 	},
-/obj/item/gun/energy/e_gun/mini,
-/obj/item/gun/energy/e_gun/mini,
-/obj/item/clothing/suit/frontier_colonist_flak,
-/obj/item/clothing/suit/frontier_colonist_flak,
-/obj/item/clothing/head/frontier_colonist_helmet,
-/obj/item/clothing/head/frontier_colonist_helmet,
+/obj/item/storage/belt/grenade,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "azN" = (
@@ -6248,6 +6256,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/chem_storage)
 "azS" = (
@@ -10065,11 +10074,25 @@
 /turf/open/floor/wood,
 /area/station/service/bar)
 "aQY" = (
-/obj/structure/table,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/crowbar,
 /obj/structure/cable,
+/obj/structure/closet/secure_closet{
+	name = "Civilian-Issue Gear";
+	access_locked = 1;
+	req_access = list("brig_entrance");
+	anchored = 1
+	},
+/obj/structure/closet/secure_closet{
+	name = "Civilian-Issue Gear";
+	access_locked = 1;
+	req_access = list("brig_entrance");
+	anchored = 1
+	},
+/obj/item/gun/energy/e_gun/mini,
+/obj/item/gun/energy/e_gun/mini,
+/obj/item/clothing/suit/frontier_colonist_flak,
+/obj/item/clothing/suit/frontier_colonist_flak,
+/obj/item/clothing/head/frontier_colonist_helmet,
+/obj/item/clothing/head/frontier_colonist_helmet,
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
 "aQZ" = (
@@ -10087,27 +10110,37 @@
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
 "aRb" = (
-/obj/structure/table,
-/obj/item/stack/sheet/rglass{
-	amount = 50
-	},
-/obj/item/stack/sheet/rglass{
-	amount = 50
-	},
-/obj/item/stack/rods/fifty,
-/obj/item/stack/rods/fifty,
 /obj/machinery/airalarm/directional/south,
+/obj/structure/closet/secure_closet{
+	name = "Civilian-Issue Gear";
+	access_locked = 1;
+	req_access = list("brig_entrance");
+	anchored = 1
+	},
+/obj/item/gun/energy/e_gun/mini,
+/obj/item/gun/energy/e_gun/mini,
+/obj/item/clothing/suit/frontier_colonist_flak,
+/obj/item/clothing/suit/frontier_colonist_flak,
+/obj/item/clothing/head/frontier_colonist_helmet,
+/obj/item/clothing/head/frontier_colonist_helmet,
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
 "aRc" = (
-/obj/structure/table,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/rglass{
-	amount = 50
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/closet/secure_closet{
+	name = "Civilian-Issue Gear";
+	access_locked = 1;
+	req_access = list("brig_entrance");
+	anchored = 1
+	},
+/obj/item/gun/energy/e_gun/mini,
+/obj/item/gun/energy/e_gun/mini,
+/obj/item/clothing/suit/frontier_colonist_flak,
+/obj/item/clothing/suit/frontier_colonist_flak,
+/obj/item/clothing/head/frontier_colonist_helmet,
+/obj/item/clothing/head/frontier_colonist_helmet,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
 "aRd" = (
@@ -13621,12 +13654,19 @@
 /turf/open/floor/plating,
 /area/station/service/kitchen)
 "bgl" = (
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/flora/bush/flowers_yw/style_random,
-/turf/open/floor/grass,
-/area/station/medical/paramedic)
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
+/obj/machinery/door/airlock/security/glass{
+	name = "Medbay Security Post"
+	},
+/obj/effect/turf_decal/tile/dark_blue/fourcorners,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/medical)
 "bgn" = (
 /obj/structure/chair{
 	dir = 4
@@ -14352,6 +14392,10 @@
 /turf/open/floor/iron/white/smooth_corner,
 /area/station/medical/treatment_center)
 "bjT" = (
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/maintenance/department/medical)
+"bjU" = (
 /obj/effect/turf_decal/tile/pine_green/half{
 	dir = 1
 	},
@@ -14360,20 +14404,6 @@
 	dir = 1
 	},
 /area/station/medical/treatment_center)
-"bjU" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
-/obj/machinery/door/airlock/security/glass{
-	name = "Medbay Security Post"
-	},
-/obj/effect/turf_decal/tile/dark_blue/fourcorners,
-/turf/open/floor/iron,
-/area/station/security/checkpoint/medical)
 "bjV" = (
 /obj/effect/turf_decal/siding/corner,
 /obj/effect/turf_decal/tile/pine_green/anticorner{
@@ -14384,17 +14414,19 @@
 	},
 /area/station/medical/treatment_center)
 "bjW" = (
-/obj/machinery/iv_drip,
-/obj/machinery/light/directional/north,
+/obj/structure/closet/crate/freezer/blood,
+/obj/structure/window/spawner/directional/west,
+/obj/machinery/camera/autoname/motion/directional/north,
+/obj/machinery/button/door/directional/north{
+	id_tag = "exam";
+	name = "Entrance Lockdown"
+	},
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/treatment_center)
 "bjY" = (
-/obj/structure/cable,
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/tcommsat/computer)
+/obj/effect/turf_decal/tile/yellow/full,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/maintenance/department/medical)
 "bjZ" = (
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 1
@@ -14664,23 +14696,29 @@
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/treatment_center)
 "blf" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Paramedic Dispatch Room"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/turf/open/floor/plating,
-/area/station/medical/paramedic)
-"bli" = (
-/obj/effect/turf_decal/tile/pine_green{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron/white/smooth_edge,
-/area/station/medical/medbay)
-"bll" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/departmental,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/yellow/full,
+/turf/open/floor/iron/white/smooth_large,
 /area/station/maintenance/department/medical)
+"bli" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/airlock/external{
+	name = "Telecommunications External Access"
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/tcommsat/computer)
+"bll" = (
+/turf/closed/wall/r_wall,
+/area/station/medical/paramedic)
 "blo" = (
 /obj/effect/turf_decal/trimline/pine_green/line{
 	dir = 8
@@ -15089,12 +15127,9 @@
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/treatment_center)
 "bnB" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/machinery/computer/security/telescreen/entertainment/directional/east,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/obj/effect/spawner/random/trash/crushed_can,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/maintenance/department/medical)
 "bnC" = (
 /obj/machinery/requests_console/auto_name/directional/north,
 /turf/open/floor/iron,
@@ -15227,16 +15262,12 @@
 /turf/open/floor/grass,
 /area/station/medical/treatment_center)
 "boF" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/external{
-	name = "Telecommunications External Access"
+/obj/effect/turf_decal/tile/electric_yellow{
+	dir = 8
 	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/tcommsat/computer)
+/obj/machinery/camera/autoname/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "boH" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
@@ -16996,6 +17027,7 @@
 "bwV" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/siding,
+/obj/effect/spawner/random/trash/soap,
 /turf/open/floor/iron/white/smooth_corner,
 /area/station/maintenance/department/medical)
 "bxa" = (
@@ -17467,16 +17499,15 @@
 	dir = 8
 	},
 /obj/machinery/vending/wardrobe/chem_wardrobe,
+/obj/machinery/camera/directional/south{
+	c_tag = "Chemistry South";
+	network = list("ss13","medbay")
+	},
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 4
 	},
 /area/station/medical/chem_storage)
 "byz" = (
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/machinery/door/window/right/directional/north{
-	name = "Chemistry Testing";
-	req_access = list("plumbing")
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
@@ -17492,6 +17523,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/effect/spawner/random/trash/hobo_squat,
 /turf/open/floor/engine,
 /area/station/maintenance/department/medical)
 "byD" = (
@@ -17842,10 +17874,9 @@
 /turf/open/floor/iron/terracotta,
 /area/station/medical/medbay)
 "bzX" = (
-/obj/effect/turf_decal/tile/pine_green,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/chem_storage)
 "bzZ" = (
 /obj/machinery/airalarm/directional/west,
 /obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted{
@@ -17866,20 +17897,16 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chem_storage)
 "bAg" = (
-/obj/machinery/light/directional/south,
 /obj/item/book/manual/wiki/chemistry,
-/obj/item/book/manual/wiki/grenades{
-	pixel_x = -4;
-	pixel_y = 4
-	},
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /obj/structure/table,
+/obj/effect/spawner/random/contraband/narcotics,
+/obj/effect/spawner/random/maintenance/four,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1
 	},
 /area/station/maintenance/department/medical)
 "bAh" = (
-/obj/machinery/chem_heater/withbuffer,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical)
@@ -18387,10 +18414,13 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "bCp" = (
-/obj/structure/closet/secure_closet/medical2,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/white/textured_large,
-/area/station/medical/treatment_center)
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/right/directional/south{
+	name = "Security Checkpoint";
+	req_access = list("brig_entrance")
+	},
+/turf/open/floor/plating,
+/area/station/security/checkpoint/medical)
 "bCr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -18413,6 +18443,18 @@
 	dir = 8
 	},
 /obj/structure/table,
+/obj/item/reagent_containers/chem_pack/spawns_sealed/acetone{
+	pixel_x = 0;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/chem_pack/spawns_sealed/stable_plasma{
+	pixel_x = -7;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/chem_pack/spawns_sealed/hydrogen_peroxide{
+	pixel_x = 1;
+	pixel_y = 0
+	},
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 4
 	},
@@ -18588,6 +18630,7 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Medbay Maintenance"
 	},
+/obj/effect/mapping_helpers/airlock/access/any/medical/general,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "bDw" = (
@@ -18611,6 +18654,15 @@
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
 /obj/structure/table,
+/obj/item/burner/fuel,
+/obj/item/burner/fuel{
+	pixel_x = -8;
+	pixel_y = 10
+	},
+/obj/item/burner/fuel{
+	pixel_x = 7;
+	pixel_y = 9
+	},
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 8
 	},
@@ -19043,21 +19095,17 @@
 /mob/living/carbon/human/species/monkey,
 /turf/open/floor/iron/white/small,
 /area/station/medical/virology)
-"bFS" = (
+"bFQ" = (
+/obj/item/stack/cable_coil,
 /obj/structure/cable,
-/obj/machinery/newscaster/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 4
-	},
-/area/station/maintenance/department/medical)
+/turf/open/floor/plating,
+/area/station/tcommsat/computer)
+"bFS" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/turf/open/floor/grass,
+/area/station/medical/paramedic)
 "bGb" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Research Security Post"
@@ -19617,11 +19665,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "bJc" = (
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/flora/bush/flowers_br/style_random,
-/turf/open/floor/grass,
-/area/station/medical/paramedic)
+/obj/effect/spawner/random/trash/caution_sign,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/maintenance/department/medical)
 "bJd" = (
 /obj/structure/chair/comfy/black,
 /obj/item/stack/spacecash/c100,
@@ -19993,8 +20039,8 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/dock)
 "bLs" = (
-/obj/structure/sign/poster/official/moth_meth/directional/north,
-/turf/open/space/basic,
+/obj/effect/spawner/random/trash/food_packaging,
+/turf/open/floor/iron/white/smooth_large,
 /area/station/maintenance/department/medical)
 "bLt" = (
 /obj/effect/decal/cleanable/oil{
@@ -20037,13 +20083,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "bLL" = (
-/obj/machinery/camera/directional/south{
-	c_tag = "Chemistry South";
-	network = list("ss13","medbay")
-	},
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /obj/structure/table,
 /obj/structure/sign/poster/official/pda_ad/directional/south,
+/obj/effect/spawner/random/contraband/narcotics,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1
 	},
@@ -20326,26 +20369,22 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/disposal/bin,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 8
 	},
+/obj/machinery/light/small/dim/directional/south,
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical)
 "bMM" = (
-/obj/structure/fluff/shower_drain,
-/obj/machinery/shower/directional/north,
-/obj/effect/turf_decal/tile/yellow/full,
-/turf/open/floor/iron/white/smooth_large,
+/obj/effect/spawner/random/structure/table_or_rack,
+/obj/machinery/light/cold/dim/directional/north,
+/turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "bMN" = (
-/obj/machinery/chem_master,
 /obj/effect/turf_decal/tile/electric_yellow/anticorner/contrasted{
 	dir = 8
 	},
+/obj/effect/spawner/random/engineering/material_cheap,
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical)
 "bMT" = (
@@ -24608,6 +24647,11 @@
 /obj/structure/cable,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden/monastery)
+"cgl" = (
+/obj/effect/turf_decal/tile/pine_green,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "cgm" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/watermelon/holy,
@@ -25374,18 +25418,11 @@
 /turf/open/floor/plating,
 /area/station/tcommsat/computer)
 "clD" = (
-/obj/effect/turf_decal/tile/pine_green/fourcorners,
-/obj/machinery/door/airlock/multi_tile/public/glass{
-	name = "Medbay Lobby";
-	red_alert_access = 1
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/machinery/door/poddoor/shutters/colony_fabricator/preopen{
-	id_tag = "exam"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/station/medical/treatment_center)
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/floor/grass,
+/area/station/medical/paramedic)
 "clG" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -25398,9 +25435,9 @@
 /turf/open/floor/plating,
 /area/station/tcommsat/computer)
 "clJ" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/chem_storage)
+/obj/effect/spawner/random/glass_debris,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "clL" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Telecommunications Maintenance"
@@ -25410,16 +25447,14 @@
 /turf/open/floor/plating,
 /area/station/tcommsat/computer)
 "clM" = (
-/obj/effect/turf_decal/tile/electric_yellow{
-	dir = 8
-	},
-/obj/machinery/camera/autoname/directional/west,
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
-"clN" = (
-/obj/machinery/power/port_gen/pacman,
+/obj/effect/spawner/random/engineering/tank,
 /turf/open/floor/plating,
-/area/station/tcommsat/computer)
+/area/station/maintenance/department/medical)
+"clN" = (
+/obj/effect/turf_decal/tile/yellow/full,
+/obj/effect/spawner/random/trash/bucket,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/maintenance/department/medical)
 "clO" = (
 /obj/effect/landmark/start/hangover,
 /obj/machinery/door/firedoor,
@@ -25440,17 +25475,9 @@
 /area/station/tcommsat/computer)
 "clU" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/any/medical/chemistry,
 /turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/area/station/tcommsat/computer)
 "clV" = (
-/obj/item/stack/cable_coil,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/tcommsat/computer)
 "clY" = (
@@ -25464,14 +25491,15 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/heads_quarters/ce)
 "cmb" = (
-/turf/open/floor/iron,
-/area/station/tcommsat/computer)
-"cmc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/smooth_edge{
+/obj/effect/turf_decal/tile/yellow/half{
 	dir = 1
 	},
-/area/station/medical/treatment_center)
+/obj/effect/spawner/random/trash/ghetto_containers,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/maintenance/department/medical)
+"cmc" = (
+/turf/closed/wall/r_wall,
+/area/station/medical/pharmacy)
 "cmf" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical,
@@ -28012,9 +28040,7 @@
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 4
 	},
-/obj/structure/closet/secure_closet/medical1{
-	pixel_x = -3
-	},
+/obj/structure/closet/secure_closet/chemical,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/chem_storage)
 "cIt" = (
@@ -28050,14 +28076,12 @@
 /turf/open/floor/iron/white/smooth_corner,
 /area/station/science/lab)
 "cLB" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/tcommsat/computer)
 "cMa" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
@@ -28349,11 +28373,9 @@
 /turf/open/floor/iron,
 /area/station/security/office)
 "dcN" = (
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/treatment_center)
+/obj/effect/spawner/random/epic_loot/random_supply_crate,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "dcQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
@@ -28613,15 +28635,10 @@
 /turf/open/floor/plating,
 /area/station/science/ordnance/burnchamber)
 "dpV" = (
-/obj/effect/turf_decal/tile/pine_green/fourcorners,
-/obj/machinery/door/poddoor/shutters/colony_fabricator/preopen{
-	id_tag = "exam"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/treatment_center)
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/departmental,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "dqa" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -29131,6 +29148,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/effect/spawner/random/maintenance/four,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/maintenance/department/medical)
 "dLY" = (
@@ -29576,7 +29594,6 @@
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "eeb" = (
-/obj/structure/extinguisher_cabinet/directional/south,
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /obj/effect/turf_decal/siding/corner{
 	dir = 8
@@ -29600,7 +29617,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "eeW" = (
-/obj/effect/turf_decal/tile/yellow/full,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/maintenance/department/medical)
 "efu" = (
@@ -30062,7 +30078,7 @@
 /turf/open/floor/grass,
 /area/station/medical/storage)
 "ezC" = (
-/obj/structure/chair/office/light,
+/obj/effect/spawner/random/trash/moisture,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/maintenance/department/medical)
 "ezF" = (
@@ -30201,6 +30217,13 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
+"eGl" = (
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 1
+	},
+/obj/effect/spawner/random/structure/chair_maintenance,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/maintenance/department/medical)
 "eGF" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/window/reinforced/spawner/directional/east,
@@ -30582,6 +30605,7 @@
 /area/station/engineering/storage_shared)
 "eWa" = (
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
+/obj/effect/spawner/random/trash/crushed_can,
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical)
 "eWl" = (
@@ -30601,13 +30625,18 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "eXa" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/right/directional/south{
-	name = "Security Checkpoint";
-	req_access = list("brig_entrance")
+/obj/effect/turf_decal/tile/pine_green/fourcorners,
+/obj/machinery/door/airlock/multi_tile/public/glass{
+	name = "Medbay Lobby";
+	red_alert_access = 1
 	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/machinery/door/poddoor/shutters/colony_fabricator/preopen{
+	id_tag = "exam"
+	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/station/security/checkpoint/medical)
+/area/station/medical/treatment_center)
 "eXo" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/engine,
@@ -30973,24 +31002,9 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "fhH" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Chemistry West";
-	network = list("ss13","medbay")
-	},
-/obj/structure/cable,
-/obj/item/radio/intercom/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 4
-	},
-/area/station/maintenance/department/medical)
+/obj/machinery/power/port_gen/pacman,
+/turf/open/floor/plating,
+/area/station/tcommsat/computer)
 "fhM" = (
 /obj/structure/secure_safe{
 	pixel_x = -22
@@ -31065,7 +31079,7 @@
 /turf/open/floor/wood,
 /area/station/maintenance/department/engine)
 "fms" = (
-/obj/effect/spawner/structure/window,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/medical/pharmacy)
 "fmu" = (
@@ -31167,10 +31181,10 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "frn" = (
-/obj/machinery/firealarm/directional/east,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
 	},
+/obj/structure/closet/mini_fridge/grimy,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 8
 	},
@@ -31268,6 +31282,9 @@
 /turf/open/floor/iron/terracotta/small,
 /area/station/service/kitchen)
 "ftW" = (
+/obj/structure/table,
+/obj/item/hand_labeler,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/chem_storage)
 "ftY" = (
@@ -31519,12 +31536,6 @@
 /obj/item/storage/box/alchemist_chemistry_kit,
 /turf/open/floor/iron/white/textured,
 /area/station/medical/pharmacy)
-"fEV" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "fFF" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
@@ -31720,6 +31731,19 @@
 	dir = 8
 	},
 /area/station/medical/surgery/theatre)
+"fMv" = (
+/obj/structure/table,
+/obj/item/ph_booklet{
+	pixel_x = 0;
+	pixel_y = -3
+	},
+/obj/item/storage/test_tube_rack/full{
+	pixel_x = 1;
+	pixel_y = 12
+	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/chem_storage)
 "fMw" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4
@@ -32489,6 +32513,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"gwR" = (
+/obj/effect/turf_decal/tile/yellow/half,
+/obj/effect/spawner/random/medical/patient_stretcher,
+/obj/effect/spawner/random/medical/organs,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/maintenance/department/medical)
 "gwZ" = (
 /turf/closed/wall,
 /area/station/security/range)
@@ -32804,6 +32834,16 @@
 	},
 /turf/open/floor/iron/terracotta/small,
 /area/station/service/kitchen)
+"gIy" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/medical/chemistry,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "gIC" = (
 /obj/machinery/light/small/directional/west,
 /obj/effect/decal/cleanable/dirt,
@@ -34658,6 +34698,9 @@
 "ipu" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/chem_storage)
 "ipz" = (
@@ -34986,11 +35029,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "iDT" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/colony_fabricator/preopen{
-	id_tag = "exam"
-	},
-/turf/open/floor/plating,
+/obj/machinery/iv_drip,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/white/textured_large,
 /area/station/medical/treatment_center)
 "iDV" = (
 /obj/machinery/camera/directional/east{
@@ -35367,8 +35408,9 @@
 /turf/open/floor/wood/large,
 /area/station/command/bridge)
 "iWQ" = (
-/turf/open/space/basic,
-/area/station/tcommsat/computer)
+/obj/effect/spawner/random/trash/mess,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/maintenance/department/medical)
 "iWV" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -35453,6 +35495,11 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/exit/departure_lounge)
+"jaJ" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/medical/chemistry,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "jaS" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/plasma{
 	dir = 1
@@ -35570,7 +35617,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "jfg" = (
-/turf/open/space/basic,
+/obj/effect/spawner/random/structure/girder,
+/turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "jgr" = (
 /obj/machinery/door/airlock/grunge{
@@ -35724,12 +35772,12 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/storage_shared)
 "jlc" = (
-/obj/structure/cable,
-/obj/structure/sign/departments/telecomms/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/colony_fabricator/preopen{
+	id_tag = "exam"
+	},
+/turf/open/floor/plating,
+/area/station/medical/treatment_center)
 "jmr" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -35980,6 +36028,8 @@
 /area/station/science/xenobiology)
 "jyJ" = (
 /obj/structure/table,
+/obj/structure/chem_separator,
+/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 8
 	},
@@ -36077,9 +36127,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "jCw" = (
-/obj/machinery/light/directional/south,
-/obj/machinery/chem_dispenser/fullupgrade,
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
+/obj/machinery/light/cold/dim/directional/south,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1
 	},
@@ -37493,6 +37542,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/yellow/full,
+/obj/effect/spawner/random/trash/grime,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/maintenance/department/medical)
 "kHO" = (
@@ -38203,24 +38253,8 @@
 	},
 /area/station/medical/pharmacy)
 "lnn" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/button/door/directional/west{
-	id = "plumbing_shutters";
-	name = "Plumbing Shutter Control";
-	req_access = list("plumbing")
-	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 4
-	},
-/area/station/maintenance/department/medical)
+/turf/open/space/basic,
+/area/station/tcommsat/computer)
 "lnw" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/machinery/requests_console/directional/north{
@@ -38259,14 +38293,12 @@
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
 "lou" = (
-/obj/item/radio/intercom/directional/east,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 4
+/obj/machinery/door/airlock/command/glass{
+	name = "Paramedic Dispatch Room"
 	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 8
-	},
-/area/station/maintenance/department/medical)
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/turf/open/floor/plating,
+/area/station/medical/paramedic)
 "lpW" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -38296,6 +38328,15 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/ordnance)
+"lql" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/yellow/full,
+/obj/effect/spawner/random/medical/patient_stretcher,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/maintenance/department/medical)
 "lqy" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Library"
@@ -38620,20 +38661,10 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/medical)
 "lFb" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 8
-	},
 /turf/open/floor/iron/white/smooth_edge{
-	dir = 4
+	dir = 1
 	},
-/area/station/maintenance/department/medical)
+/area/station/medical/treatment_center)
 "lFh" = (
 /obj/machinery/holopad,
 /obj/structure/cable,
@@ -38872,6 +38903,10 @@
 	dir = 8
 	},
 /area/station/engineering/atmos)
+"lQY" = (
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plating,
+/area/station/tcommsat/computer)
 "lRh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
 	dir = 1
@@ -39461,10 +39496,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "mqg" = (
-/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
 	},
+/obj/effect/spawner/random/structure/chair_maintenance,
+/obj/machinery/light/small/broken/directional/east,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 8
 	},
@@ -39630,6 +39666,7 @@
 /area/station/medical/morgue)
 "mwc" = (
 /obj/effect/turf_decal/siding/corner,
+/obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/maintenance/department/medical)
 "mwg" = (
@@ -39839,10 +39876,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow/half{
-	dir = 1
-	},
-/turf/open/floor/iron/white/smooth_large,
+/turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "mGK" = (
 /obj/structure/table,
@@ -40006,17 +40040,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "mOx" = (
-/obj/machinery/light/directional/west,
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 1
 	},
+/obj/effect/spawner/random/glass_debris,
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical)
 "mOH" = (
@@ -40166,6 +40199,13 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"mVs" = (
+/obj/structure/cable,
+/obj/structure/sign/departments/telecomms/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "mVM" = (
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
@@ -40493,6 +40533,12 @@
 /obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/space/basic,
 /area/space/nearstation)
+"njZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/medical/treatment_center)
 "nkj" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
@@ -41065,11 +41111,6 @@
 /area/station/science/xenobiology)
 "nKE" = (
 /turf/open/floor/iron/white/smooth_large,
-/area/station/maintenance/department/medical)
-"nKM" = (
-/obj/structure/table,
-/obj/item/hand_labeler,
-/turf/open/floor/iron/white/smooth_large,
 /area/station/medical/chem_storage)
 "nKU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -41149,6 +41190,16 @@
 /obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/grass,
 /area/station/medical/storage)
+"nOy" = (
+/obj/effect/turf_decal/tile/pine_green/fourcorners,
+/obj/machinery/door/poddoor/shutters/colony_fabricator/preopen{
+	id_tag = "exam"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/medical/treatment_center)
 "nOJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -42753,9 +42804,14 @@
 /turf/open/floor/iron/dark,
 /area/station/service/abandoned_gambling_den/gaming)
 "oWN" = (
-/obj/structure/table,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/chem_storage)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "oXp" = (
 /obj/machinery/requests_console/directional/east{
 	department = "Medical";
@@ -42780,8 +42836,11 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/medbay)
 "oXV" = (
-/turf/open/floor/plating,
-/area/station/tcommsat/computer)
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/medical/treatment_center)
 "oYc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -43296,6 +43355,7 @@
 /area/station/hallway/primary/aft)
 "prD" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
+/obj/effect/spawner/random/trash/crushed_can,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1
 	},
@@ -43504,10 +43564,9 @@
 /turf/open/floor/plating,
 /area/station/engineering/storage_shared)
 "pAo" = (
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/treatment_center)
+/obj/effect/spawner/random/structure/table_or_rack,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "pAM" = (
 /obj/structure/chair/stool/bar/directional/west,
 /turf/open/floor/plating,
@@ -43611,10 +43670,11 @@
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/medical/morgue)
 "pEK" = (
-/obj/effect/turf_decal/tile/pine_green,
-/obj/effect/turf_decal/caution/stand_clear/red,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/maintenance/department/medical)
 "pFy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -43661,26 +43721,24 @@
 "pGi" = (
 /obj/item/reagent_containers/cup/beaker/large,
 /obj/item/reagent_containers/cup/beaker/large,
-/obj/item/reagent_containers/cup/beaker/large,
-/obj/item/reagent_containers/cup/beaker/large,
+/obj/item/reagent_containers/cup/beaker/large{
+	pixel_x = 9;
+	pixel_y = 0
+	},
+/obj/item/reagent_containers/cup/beaker/large{
+	pixel_x = -8;
+	pixel_y = 0
+	},
 /obj/item/reagent_containers/dropper,
 /obj/item/reagent_containers/dropper,
-/obj/item/storage/pill_bottle/painkiller{
-	pixel_x = 10;
-	pixel_y = 14
-	},
-/obj/item/storage/pill_bottle/prescription_stimulant{
-	pixel_x = -12;
-	pixel_y = 17
-	},
-/obj/item/storage/pill_bottle/prescription_stimulant{
-	pixel_x = -5;
-	pixel_y = 16
-	},
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
 	},
 /obj/structure/table,
+/obj/item/storage/test_tube_rack/full{
+	pixel_x = 0;
+	pixel_y = 15
+	},
 /turf/open/floor/iron/white/textured_edge,
 /area/station/medical/pharmacy)
 "pGD" = (
@@ -43995,7 +44053,7 @@
 	id = "chemistry_shutters";
 	name = "Chemistry Shutters"
 	},
-/obj/effect/spawner/structure/window,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/medical/pharmacy)
 "pSC" = (
@@ -44079,18 +44137,6 @@
 	c_tag = "Armory Motion Sensor"
 	},
 /obj/machinery/airalarm/directional/north,
-/obj/structure/closet/secure_closet{
-	name = "Civilian-Issue Gear";
-	access_locked = 1;
-	req_access = list("brig_entrance");
-	anchored = 1
-	},
-/obj/item/gun/energy/e_gun/mini,
-/obj/item/gun/energy/e_gun/mini,
-/obj/item/clothing/suit/frontier_colonist_flak,
-/obj/item/clothing/suit/frontier_colonist_flak,
-/obj/item/clothing/head/frontier_colonist_helmet,
-/obj/item/clothing/head/frontier_colonist_helmet,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "pWK" = (
@@ -44895,17 +44941,7 @@
 /turf/open/floor/carpet/black,
 /area/station/service/chapel/office)
 "qxq" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/door/airlock/external{
-	name = "Telecommunications External Access"
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/station/tcommsat/computer)
 "qxE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -44942,6 +44978,13 @@
 	},
 /turf/open/floor/iron/terracotta/small,
 /area/station/service/kitchen)
+"qzh" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/floor/grass,
+/area/station/medical/paramedic)
 "qzm" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -45583,12 +45626,12 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "rcF" = (
-/obj/machinery/light/small/directional/west,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/tcommsat/computer)
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/east,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "rdU" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
@@ -46412,7 +46455,7 @@
 /area/station/cargo/bitrunning/den)
 "rIm" = (
 /obj/machinery/newscaster/directional/east,
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/station/maintenance/department/medical)
 "rIZ" = (
 /obj/machinery/airalarm/directional/north,
@@ -46626,6 +46669,15 @@
 	req_access = list("armory")
 	},
 /obj/structure/table,
+/obj/item/storage/belt/bandolier,
+/obj/item/storage/belt/bandolier{
+	pixel_x = -7;
+	pixel_y = 0
+	},
+/obj/item/storage/belt/bandolier{
+	pixel_x = 8;
+	pixel_y = 0
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "rPu" = (
@@ -47334,6 +47386,8 @@
 /obj/effect/turf_decal/tile/yellow/half{
 	dir = 8
 	},
+/obj/effect/spawner/random/medical/patient_stretcher,
+/obj/effect/spawner/random/epic_loot/pocket_medical,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/maintenance/department/medical)
 "ssk" = (
@@ -47433,6 +47487,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
+"svr" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/external{
+	name = "Telecommunications External Access"
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/tcommsat/computer)
 "svD" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/engine/o2,
@@ -47917,11 +47982,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"sOb" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/any/medical/chemistry,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
 "sOB" = (
 /turf/closed/wall,
 /area/station/medical/psychology)
@@ -48024,10 +48084,6 @@
 "sSA" = (
 /obj/machinery/reagentgrinder{
 	pixel_y = 11
-	},
-/obj/item/storage/pill_bottle/painkiller{
-	pixel_x = 3;
-	pixel_y = 80
 	},
 /obj/structure/table,
 /turf/open/floor/iron/white/textured_large,
@@ -48334,10 +48390,8 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/medical)
 "tcX" = (
-/obj/effect/turf_decal/tile/yellow/half{
-	dir = 4
-	},
-/turf/open/floor/iron/white/smooth_large,
+/obj/effect/spawner/random/trash/grille_or_waste,
+/turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "tcY" = (
 /obj/structure/disposalpipe/segment{
@@ -48832,9 +48886,9 @@
 /turf/open/floor/iron,
 /area/station/security/eva)
 "tta" = (
-/obj/structure/cable,
+/obj/effect/spawner/random/structure/crate_loot,
 /turf/open/floor/plating,
-/area/station/tcommsat/computer)
+/area/station/maintenance/department/medical)
 "ttA" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/incinerator_input{
 	dir = 8
@@ -48995,13 +49049,11 @@
 /turf/open/floor/iron/dark,
 /area/station/service/library/lounge)
 "txK" = (
-/obj/machinery/light/directional/west,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
 	},
@@ -49295,14 +49347,11 @@
 /obj/item/storage/toolbox/mechanical,
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/clothing/head/utility/welding,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/chem_storage)
-"tIK" = (
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/flora/bush/flowers_pp/style_random,
-/turf/open/floor/grass,
-/area/station/medical/paramedic)
 "tIQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -49538,11 +49587,6 @@
 	},
 /turf/open/floor/iron/white/textured,
 /area/station/engineering/atmos/hfr_room)
-"tTd" = (
-/obj/item/wrench,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/tcommsat/computer)
 "tTB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -49785,16 +49829,8 @@
 /turf/open/floor/plating,
 /area/station/cargo/bitrunning/den)
 "udS" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Chemistry East";
-	network = list("ss13","medbay")
-	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 8
-	},
+/obj/effect/spawner/random/trash/grime,
+/turf/open/floor/iron/white/smooth_large,
 /area/station/maintenance/department/medical)
 "uea" = (
 /obj/machinery/door/airlock/public/glass{
@@ -49968,19 +50004,10 @@
 /area/station/science/lab)
 "uik" = (
 /obj/structure/cable,
-/obj/machinery/firealarm/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 4
-	},
-/area/station/maintenance/department/medical)
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "uiP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -50192,6 +50219,18 @@
 /obj/item/reagent_containers/cup/bottle/random_buffer{
 	pixel_x = -9;
 	pixel_y = 12
+	},
+/obj/item/reagent_containers/chem_pack/spawns_sealed/sterilizine{
+	pixel_x = -9;
+	pixel_y = 0
+	},
+/obj/item/reagent_containers/chem_pack/spawns_sealed/palladium_catalyst{
+	pixel_x = 2;
+	pixel_y = 0
+	},
+/obj/item/reagent_containers/chem_pack/spawns_sealed/purity_tester{
+	pixel_x = 8;
+	pixel_y = 0
 	},
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 4
@@ -50790,6 +50829,12 @@
 /obj/effect/turf_decal/tile/pine_green/anticorner/contrasted,
 /turf/open/floor/iron/white,
 /area/station/medical/psychology)
+"uPd" = (
+/obj/effect/turf_decal/tile/pine_green{
+	dir = 4
+	},
+/turf/open/floor/iron/white/smooth_edge,
+/area/station/medical/medbay)
 "uPz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -51235,12 +51280,9 @@
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
 "veb" = (
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/flora/bush/flowers_br/style_random,
-/turf/open/floor/grass,
-/area/station/medical/paramedic)
+/obj/effect/spawner/random/structure/crate_abandoned,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "vek" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -51254,6 +51296,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"vey" = (
+/obj/item/wrench,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/tcommsat/computer)
 "veB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/wood/corner,
@@ -51529,6 +51576,12 @@
 "vpC" = (
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/funeral)
+"vrq" = (
+/obj/effect/turf_decal/tile/yellow/half,
+/obj/effect/spawner/random/medical/patient_stretcher,
+/obj/effect/spawner/random/medical/surgery_tool,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/maintenance/department/medical)
 "vrw" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
@@ -52267,6 +52320,9 @@
 /area/station/maintenance/department/medical)
 "vTg" = (
 /obj/structure/closet/secure_closet/chemical,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/chem_storage)
 "vTL" = (
@@ -52921,7 +52977,7 @@
 /area/station/security/brig)
 "wqF" = (
 /obj/effect/mapping_helpers/engraving,
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/station/maintenance/department/medical)
 "wrA" = (
 /obj/effect/turf_decal/stripes/line{
@@ -54382,9 +54438,10 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "xnm" = (
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/plating,
-/area/station/tcommsat/computer)
+/obj/effect/turf_decal/tile/pine_green,
+/obj/effect/turf_decal/caution/stand_clear/red,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "xnp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -55476,6 +55533,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
+"yem" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/turf/open/floor/grass,
+/area/station/medical/paramedic)
 "yet" = (
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
@@ -55534,6 +55598,7 @@
 /obj/effect/turf_decal/siding{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1
 	},
@@ -78348,7 +78413,7 @@ aaa
 aby
 abI
 ahL
-azK
+akM
 akM
 akM
 fBZ
@@ -81746,9 +81811,9 @@ bfk
 bdm
 dyg
 sMg
-bzX
+cgl
 dYh
-bjW
+iDT
 blc
 tgT
 mDN
@@ -82261,7 +82326,7 @@ bdm
 dyg
 sMg
 bik
-iDT
+jlc
 bjS
 tgd
 nUo
@@ -82517,9 +82582,9 @@ bfm
 xPQ
 dyg
 sMg
-pEK
-clD
-bjT
+xnm
+eXa
+bjU
 hfw
 gnS
 gnS
@@ -82774,13 +82839,13 @@ bfn
 bdm
 dyg
 sMg
-pEK
-dpV
-bjT
-pAo
-cmc
-pAo
-dcN
+xnm
+nOy
+bjU
+lFb
+njZ
+lFb
+oXV
 xsa
 xUU
 uFc
@@ -83032,13 +83097,13 @@ aRL
 dyg
 sMg
 bik
-iDT
+jlc
 bjV
 qwS
 jJm
 aFM
 uQu
-bli
+uPd
 ktU
 uFc
 buc
@@ -83290,7 +83355,7 @@ eZv
 sMg
 bik
 dYh
-awW
+bjW
 clA
 idj
 tCi
@@ -83547,7 +83612,7 @@ aDm
 sMg
 rkq
 dYh
-bjW
+iDT
 tgT
 cRi
 bny
@@ -83804,7 +83869,7 @@ tWc
 sMg
 bin
 dYh
-bCp
+awW
 tgT
 pku
 qib
@@ -83821,11 +83886,11 @@ fbc
 bCn
 bDs
 mOx
-bFS
-lnn
-fhH
-lFb
-uik
+txK
+txK
+txK
+txK
+txK
 txK
 bMK
 oJj
@@ -83903,7 +83968,7 @@ teJ
 teJ
 teJ
 teJ
-jlc
+mVs
 clw
 clw
 clw
@@ -84078,11 +84143,11 @@ tli
 peY
 bjc
 jfg
-nKE
+bjT
 egX
-nKE
+tcX
 egX
-nKE
+eeW
 mwc
 ygx
 cBL
@@ -84113,7 +84178,7 @@ rCm
 cgs
 cgQ
 chv
-fEV
+uik
 aht
 aaa
 aht
@@ -84160,11 +84225,11 @@ aaa
 aaa
 aaa
 aaa
-fEV
-boF
-rcF
-qxq
-bjY
+uik
+svr
+avo
+bli
+cLB
 clY
 gmH
 cmh
@@ -84322,7 +84387,7 @@ bjZ
 vaR
 eus
 bnD
-bjU
+bgl
 brg
 sgD
 cqd
@@ -84341,7 +84406,7 @@ tcX
 sMx
 dLb
 bwV
-bMM
+jfg
 oJj
 eMp
 lRN
@@ -84422,7 +84487,7 @@ clw
 hQz
 nTk
 jCr
-cmb
+qxq
 kCI
 nTk
 nMG
@@ -84574,7 +84639,7 @@ bgk
 dyg
 sMg
 fih
-eXa
+bCp
 bka
 tLk
 bmv
@@ -84590,12 +84655,12 @@ jze
 jze
 qnJ
 jze
-jze
-bLs
+bll
+oPH
 hEF
 tKY
-eeW
-kHD
+clN
+blf
 hXk
 eeb
 oJj
@@ -84674,7 +84739,7 @@ aaa
 aaa
 aaa
 aaa
-iWQ
+lnn
 clw
 nTk
 nTk
@@ -84843,17 +84908,17 @@ hZH
 hZH
 bvl
 bwO
-bJc
+clD
 bzZ
 bsJ
 bCr
-jze
-jfg
-sAE
+bll
+tta
+gwR
+bjY
 eeW
-eeW
-kHD
-hXk
+blf
+cmb
 bAg
 oJj
 bNV
@@ -84931,12 +84996,12 @@ aaa
 aaa
 aaa
 aaa
-iWQ
+lnn
 clw
-clN
-oXV
-tTd
-oXV
+fhH
+clV
+vey
+clV
 mxy
 nTk
 qPu
@@ -85100,17 +85165,17 @@ jWH
 nYu
 oSa
 gfH
-bgl
+yem
 fgs
 xmg
 buk
-jze
-jfg
-sAE
-eeW
+bll
+ayC
+vrq
+bLs
 eeW
 kHD
-hXk
+eGl
 bLL
 oJj
 bNW
@@ -85190,10 +85255,10 @@ aaa
 aaa
 abI
 clw
-oXV
-xnm
-tta
 clV
+lQY
+clU
+bFQ
 mDW
 nTk
 cml
@@ -85357,17 +85422,17 @@ frX
 dRU
 gzG
 brh
-blf
+lou
 brl
 bsL
 bFl
-jze
-jfg
+bll
+veb
 sAE
-eeW
-eeW
+udS
+udS
 kHD
-hXk
+clM
 anH
 oJj
 oxA
@@ -85614,18 +85679,18 @@ bsH
 blo
 crd
 gfH
-veb
+qzh
 hjy
 nSe
 xsT
-jze
-jfg
+bll
+bMM
 sAE
-eeW
-eeW
-kHD
-hXk
-prD
+udS
+udS
+blf
+dcN
+pEK
 oJj
 oJj
 eMp
@@ -85871,16 +85936,16 @@ mZi
 wEl
 bvp
 xTf
-tIK
+bFS
 brm
 bsN
 bCv
-jze
-jfg
+bll
+pAo
 sAE
-eeW
-eeW
-kHD
+clJ
+clJ
+lql
 mFY
 bLM
 bMN
@@ -86124,16 +86189,16 @@ ufo
 boL
 bpY
 fms
-bpY
-bpY
+cmc
+cmc
 qgA
-bpY
+cmc
+bll
 jze
 jze
 jze
-jze
-jze
-jfg
+bll
+lRN
 eGL
 iZl
 iZl
@@ -86390,11 +86455,11 @@ bAe
 uqf
 bCx
 byw
-oJj
-nKE
-nKE
-nKE
-nKE
+lRN
+iWQ
+dcN
+eeW
+oPH
 ipz
 qwJ
 bAh
@@ -86644,14 +86709,14 @@ xHJ
 bwT
 eBd
 bsK
-ftW
-ftW
-clJ
-sOb
 nKE
 nKE
-nKE
-nKE
+bzX
+jaJ
+bJc
+udS
+iWQ
+bnB
 prD
 byz
 ooh
@@ -86906,8 +86971,8 @@ jyJ
 bDy
 rIm
 frn
-udS
-lou
+qwJ
+qwJ
 mqg
 eWa
 byA
@@ -87158,15 +87223,15 @@ pxw
 dRj
 hEC
 vTg
-ftW
-oWN
+nKE
+fMv
+lRN
+lRN
 oJj
 oJj
 oJj
 oJj
-oJj
-oJj
-bll
+dpV
 oJj
 oJj
 oJj
@@ -87417,7 +87482,7 @@ hEC
 ipu
 phx
 azR
-clU
+gIy
 eMp
 eMp
 eMp
@@ -87664,7 +87729,7 @@ cQN
 xOq
 bmA
 cQN
-oJj
+lRN
 lRN
 lRN
 lRN
@@ -87673,8 +87738,8 @@ lRN
 hEC
 cIe
 fby
-nKM
-oJj
+ftW
+lRN
 eMp
 oJj
 oJj
@@ -87927,16 +87992,16 @@ oPH
 oPH
 eMp
 bNV
-oJj
-oJj
-oJj
+lRN
+lRN
+lRN
 wqF
-oJj
+lRN
 hop
 oJj
 jCv
 bOK
-clM
+boF
 ery
 sAC
 bIT
@@ -88188,8 +88253,8 @@ gVk
 gVk
 gVk
 uQB
-cLB
-cLB
+oWN
+oWN
 bFq
 gmv
 bIt
@@ -91495,7 +91560,7 @@ swT
 swT
 swT
 aXr
-bnB
+rcF
 mvJ
 swT
 swT

--- a/_maps/map_files/Pubbystation/pubbystation.dmm
+++ b/_maps/map_files/Pubbystation/pubbystation.dmm
@@ -677,7 +677,6 @@
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/ai_sat_ext_as)
 "ads" = (
-/obj/machinery/suit_storage_unit/standard_unit,
 /obj/machinery/light/directional/west,
 /obj/machinery/camera/directional/west{
 	c_tag = "EVA Storage"
@@ -685,6 +684,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/suit_storage_unit/standard_unit,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
 "adt" = (
@@ -851,11 +851,11 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "aec" = (
-/obj/machinery/suit_storage_unit/standard_unit,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet/directional/west,
+/obj/machinery/suit_storage_unit/standard_unit,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
 "aed" = (
@@ -1012,20 +1012,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
-/obj/structure/closet/secure_closet{
-	name = "Civilian-Issue Gear";
-	access_locked = 1;
-	req_access = list("brig_entrance");
-	anchored = 1
-	},
-/obj/item/gun/energy/e_gun/mini,
-/obj/item/gun/energy/e_gun/mini,
-/obj/item/clothing/suit/frontier_colonist_flak,
-/obj/item/clothing/suit/frontier_colonist_flak,
-/obj/item/clothing/head/frontier_colonist_helmet,
-/obj/item/clothing/head/frontier_colonist_helmet,
+/obj/machinery/suit_storage_unit/standard_unit,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
 "afc" = (
@@ -5617,12 +5604,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "awW" = (
-/obj/structure/cable,
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/tcommsat/computer)
+/turf/closed/wall/r_wall,
+/area/station/medical/paramedic)
 "awY" = (
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -8837,7 +8820,8 @@
 /area/station/ai_monitored/command/storage/eva)
 "aLb" = (
 /obj/machinery/door/airlock/command/glass{
-	name = "EVA Storage"
+	name = "EVA Storage";
+	red_alert_access = 1
 	},
 /obj/effect/landmark/navigate_destination/eva,
 /obj/machinery/door/firedoor,
@@ -9495,11 +9479,22 @@
 /turf/open/floor/plating,
 /area/station/maintenance/central)
 "aOD" = (
-/obj/machinery/suit_storage_unit/standard_unit,
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/closet/secure_closet{
+	name = "Civilian-Issue Gear";
+	access_locked = 1;
+	req_access = list("brig_entrance");
+	anchored = 1
+	},
+/obj/item/clothing/head/frontier_colonist_helmet,
+/obj/item/clothing/head/frontier_colonist_helmet,
+/obj/item/clothing/suit/frontier_colonist_flak,
+/obj/item/clothing/suit/frontier_colonist_flak,
+/obj/item/gun/energy/e_gun/mini,
+/obj/item/gun/energy/e_gun/mini,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
 "aOE" = (
@@ -9760,7 +9755,6 @@
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
 "aPL" = (
-/obj/machinery/suit_storage_unit/standard_unit,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -9768,6 +9762,18 @@
 	department = "E.V.A. Storage";
 	name = "E.V.A. RC"
 	},
+/obj/structure/closet/secure_closet{
+	name = "Civilian-Issue Gear";
+	access_locked = 1;
+	req_access = list("brig_entrance");
+	anchored = 1
+	},
+/obj/item/clothing/head/frontier_colonist_helmet,
+/obj/item/clothing/head/frontier_colonist_helmet,
+/obj/item/clothing/suit/frontier_colonist_flak,
+/obj/item/clothing/suit/frontier_colonist_flak,
+/obj/item/gun/energy/e_gun/mini,
+/obj/item/gun/energy/e_gun/mini,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
 "aPM" = (
@@ -10066,24 +10072,7 @@
 /area/station/service/bar)
 "aQY" = (
 /obj/structure/cable,
-/obj/structure/closet/secure_closet{
-	name = "Civilian-Issue Gear";
-	access_locked = 1;
-	req_access = list("brig_entrance");
-	anchored = 1
-	},
-/obj/structure/closet/secure_closet{
-	name = "Civilian-Issue Gear";
-	access_locked = 1;
-	req_access = list("brig_entrance");
-	anchored = 1
-	},
-/obj/item/gun/energy/e_gun/mini,
-/obj/item/gun/energy/e_gun/mini,
-/obj/item/clothing/suit/frontier_colonist_flak,
-/obj/item/clothing/suit/frontier_colonist_flak,
-/obj/item/clothing/head/frontier_colonist_helmet,
-/obj/item/clothing/head/frontier_colonist_helmet,
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
 "aQZ" = (
@@ -10102,18 +10091,6 @@
 /area/station/ai_monitored/command/storage/eva)
 "aRb" = (
 /obj/machinery/airalarm/directional/south,
-/obj/structure/closet/secure_closet{
-	name = "Civilian-Issue Gear";
-	access_locked = 1;
-	req_access = list("brig_entrance");
-	anchored = 1
-	},
-/obj/item/gun/energy/e_gun/mini,
-/obj/item/gun/energy/e_gun/mini,
-/obj/item/clothing/suit/frontier_colonist_flak,
-/obj/item/clothing/suit/frontier_colonist_flak,
-/obj/item/clothing/head/frontier_colonist_helmet,
-/obj/item/clothing/head/frontier_colonist_helmet,
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
 "aRc" = (
@@ -10127,11 +10104,11 @@
 	anchored = 1
 	},
 /obj/item/gun/energy/e_gun/mini,
+/obj/item/clothing/suit/frontier_colonist_flak,
+/obj/item/clothing/head/frontier_colonist_helmet,
+/obj/item/clothing/head/frontier_colonist_helmet,
+/obj/item/clothing/suit/frontier_colonist_flak,
 /obj/item/gun/energy/e_gun/mini,
-/obj/item/clothing/suit/frontier_colonist_flak,
-/obj/item/clothing/suit/frontier_colonist_flak,
-/obj/item/clothing/head/frontier_colonist_helmet,
-/obj/item/clothing/head/frontier_colonist_helmet,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
 "aRd" = (
@@ -10296,9 +10273,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/central)
 "aRX" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "EVA Maintenance"
-	},
+/obj/machinery/door/airlock/highsecurity,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -12006,19 +11981,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/service)
-"aZc" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/door/airlock/external{
-	name = "Telecommunications External Access"
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/tcommsat/computer)
 "aZd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -13658,9 +13620,12 @@
 /turf/open/floor/plating,
 /area/station/service/kitchen)
 "bgl" = (
-/obj/machinery/light/small/directional/east,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/colony_fabricator/preopen{
+	id_tag = "exam"
+	},
 /turf/open/floor/plating,
-/area/station/tcommsat/computer)
+/area/station/medical/treatment_center)
 "bgn" = (
 /obj/structure/chair{
 	dir = 4
@@ -14395,8 +14360,7 @@
 	},
 /area/station/medical/treatment_center)
 "bjU" = (
-/obj/effect/turf_decal/tile/yellow/full,
-/obj/effect/spawner/random/trash/bucket,
+/obj/effect/turf_decal/tile/yellow/half,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/maintenance/department/medical)
 "bjV" = (
@@ -14409,17 +14373,22 @@
 	},
 /area/station/medical/treatment_center)
 "bjW" = (
-/obj/machinery/iv_drip,
-/obj/machinery/light/directional/north,
+/obj/structure/closet/crate/freezer/blood,
+/obj/structure/window/spawner/directional/west,
+/obj/machinery/camera/autoname/motion/directional/north,
+/obj/machinery/button/door/directional/north{
+	id_tag = "exam";
+	name = "Entrance Lockdown"
+	},
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/treatment_center)
 "bjY" = (
-/obj/machinery/light/small/directional/west,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/tcommsat/computer)
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 1
+	},
+/obj/effect/spawner/random/trash/ghetto_containers,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/maintenance/department/medical)
 "bjZ" = (
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 1
@@ -14689,35 +14658,22 @@
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/treatment_center)
 "blf" = (
-/obj/effect/turf_decal/tile/pine_green/fourcorners,
-/obj/machinery/door/airlock/multi_tile/public/glass{
-	name = "Medbay Lobby";
-	red_alert_access = 1
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/machinery/door/poddoor/shutters/colony_fabricator/preopen{
-	id_tag = "exam"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/station/medical/treatment_center)
-"bli" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+/obj/effect/turf_decal/tile/pine_green{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
-/obj/machinery/door/airlock/security/glass{
-	name = "Medbay Security Post"
-	},
-/obj/effect/turf_decal/tile/dark_blue/fourcorners,
-/turf/open/floor/iron,
-/area/station/security/checkpoint/medical)
-"bll" = (
-/turf/open/space/basic,
+/turf/open/floor/iron/white/smooth_edge,
+/area/station/medical/medbay)
+"bli" = (
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plating,
 /area/station/tcommsat/computer)
+"bll" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/floor/grass,
+/area/station/medical/paramedic)
 "blo" = (
 /obj/effect/turf_decal/trimline/pine_green/line{
 	dir = 8
@@ -14945,6 +14901,13 @@
 /obj/structure/bed/medical,
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/treatment_center)
+"bmp" = (
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 1
+	},
+/obj/effect/spawner/random/structure/chair_maintenance,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/maintenance/department/medical)
 "bmv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -15264,12 +15227,9 @@
 /turf/open/floor/grass,
 /area/station/medical/treatment_center)
 "boF" = (
-/obj/effect/turf_decal/tile/electric_yellow{
-	dir = 8
-	},
-/obj/machinery/camera/autoname/directional/west,
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/obj/effect/spawner/random/glass_debris,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "boH" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
@@ -17876,15 +17836,12 @@
 /turf/open/floor/iron/terracotta,
 /area/station/medical/medbay)
 "bzX" = (
-/obj/effect/turf_decal/tile/pine_green/fourcorners,
-/obj/machinery/door/poddoor/shutters/colony_fabricator/preopen{
-	id_tag = "exam"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/treatment_center)
+/obj/structure/cable,
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/tcommsat/computer)
 "bzZ" = (
 /obj/machinery/airalarm/directional/west,
 /obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted{
@@ -18422,13 +18379,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "bCp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/yellow/full,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/maintenance/department/medical)
+/obj/item/wrench,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/tcommsat/computer)
 "bCr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -19104,16 +19058,9 @@
 /turf/open/floor/iron/white/small,
 /area/station/medical/virology)
 "bFS" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/external{
-	name = "Telecommunications External Access"
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/spawner/random/engineering/tank,
 /turf/open/floor/plating,
-/area/station/tcommsat/computer)
+/area/station/maintenance/department/medical)
 "bGb" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Research Security Post"
@@ -19673,8 +19620,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "bJc" = (
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/chem_storage)
+/obj/effect/spawner/random/structure/crate_abandoned,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "bJd" = (
 /obj/structure/chair/comfy/black,
 /obj/item/stack/spacecash/c100,
@@ -20046,9 +19994,10 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/dock)
 "bLs" = (
-/obj/effect/spawner/random/glass_debris,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/medical/treatment_center)
 "bLt" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor6"
@@ -20383,9 +20332,10 @@
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical)
 "bMM" = (
-/obj/effect/spawner/random/structure/girder,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/obj/structure/closet/secure_closet/medical2,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/white/textured_large,
+/area/station/medical/treatment_center)
 "bMN" = (
 /obj/effect/turf_decal/tile/electric_yellow/anticorner/contrasted{
 	dir = 8
@@ -24158,6 +24108,19 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/main)
+"cdk" = (
+/obj/structure/table,
+/obj/item/ph_booklet{
+	pixel_x = 0;
+	pixel_y = -3
+	},
+/obj/item/storage/test_tube_rack/full{
+	pixel_x = 1;
+	pixel_y = 12
+	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/chem_storage)
 "cdm" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
@@ -25409,21 +25372,24 @@
 /turf/closed/wall/r_wall,
 /area/station/tcommsat/computer)
 "clA" = (
-/obj/structure/closet/secure_closet/medical2,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/white/textured_large,
-/area/station/medical/treatment_center)
+/obj/structure/table,
+/obj/item/hand_labeler,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/chem_storage)
 "clC" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/transit_tube,
 /turf/open/floor/plating,
 /area/station/tcommsat/computer)
 "clD" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted,
-/obj/effect/spawner/random/trash/crushed_can,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/yellow/full,
+/obj/effect/spawner/random/medical/patient_stretcher,
+/turf/open/floor/iron/white/smooth_large,
 /area/station/maintenance/department/medical)
 "clG" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -25437,7 +25403,8 @@
 /turf/open/floor/plating,
 /area/station/tcommsat/computer)
 "clJ" = (
-/obj/effect/spawner/random/trash/food_packaging,
+/obj/effect/turf_decal/tile/yellow/full,
+/obj/effect/spawner/random/trash/bucket,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/maintenance/department/medical)
 "clL" = (
@@ -25449,13 +25416,18 @@
 /turf/open/floor/plating,
 /area/station/tcommsat/computer)
 "clM" = (
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/area/station/medical/treatment_center)
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/medical/chemistry,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "clN" = (
 /obj/effect/spawner/random/trash/grime,
-/turf/open/floor/iron/white/smooth_large,
+/turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "clO" = (
 /obj/effect/landmark/start/hangover,
@@ -25476,22 +25448,13 @@
 /turf/open/floor/iron,
 /area/station/tcommsat/computer)
 "clU" = (
-/obj/machinery/power/port_gen/pacman,
+/obj/effect/landmark/start/medical_doctor,
+/obj/machinery/holopad,
+/turf/open/floor/iron/white/textured_large,
+/area/station/medical/treatment_center)
+"clV" = (
 /turf/open/floor/plating,
 /area/station/tcommsat/computer)
-"clV" = (
-/obj/structure/table,
-/obj/item/ph_booklet{
-	pixel_x = 0;
-	pixel_y = -3
-	},
-/obj/item/storage/test_tube_rack/full{
-	pixel_x = 1;
-	pixel_y = 12
-	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/chem_storage)
 "clY" = (
 /obj/item/beacon,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -25503,13 +25466,13 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/heads_quarters/ce)
 "cmb" = (
-/obj/item/wrench,
+/obj/item/stack/cable_coil,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/tcommsat/computer)
 "cmc" = (
-/obj/effect/spawner/random/structure/table_or_rack,
-/turf/open/floor/plating,
+/obj/effect/spawner/random/trash/mess,
+/turf/open/floor/iron/white/smooth_large,
 /area/station/maintenance/department/medical)
 "cmf" = (
 /obj/structure/rack,
@@ -28087,11 +28050,9 @@
 /turf/open/floor/iron/white/smooth_corner,
 /area/station/science/lab)
 "cLB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/treatment_center)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/tcommsat/computer)
 "cMa" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
@@ -28122,16 +28083,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
 /area/station/service/library/lounge)
-"cOB" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/any/medical/chemistry,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
 "cOG" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -28312,13 +28263,6 @@
 "cWk" = (
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
-"cWA" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Paramedic Dispatch Room"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/turf/open/floor/plating,
-/area/station/medical/paramedic)
 "cXd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -28400,11 +28344,19 @@
 /turf/open/floor/iron,
 /area/station/security/office)
 "dcN" = (
-/obj/effect/turf_decal/tile/pine_green{
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron/white/smooth_edge,
-/area/station/medical/medbay)
+/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
+/obj/machinery/door/airlock/security/glass{
+	name = "Medbay Security Post"
+	},
+/obj/effect/turf_decal/tile/dark_blue/fourcorners,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/medical)
 "dcQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
@@ -28664,9 +28616,9 @@
 /turf/open/floor/plating,
 /area/station/science/ordnance/burnchamber)
 "dpV" = (
-/obj/effect/turf_decal/tile/yellow/half,
-/obj/effect/spawner/random/medical/patient_stretcher,
-/obj/effect/spawner/random/medical/organs,
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 1
+	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/maintenance/department/medical)
 "dqa" = (
@@ -29352,9 +29304,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal)
-"dSC" = (
-/turf/open/floor/iron,
-/area/station/tcommsat/computer)
 "dSI" = (
 /obj/structure/sign/poster/contraband/random/directional/west,
 /obj/effect/decal/cleanable/dirt,
@@ -29650,6 +29599,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "eeW" = (
+/obj/effect/spawner/random/trash/food_packaging,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/maintenance/department/medical)
 "efu" = (
@@ -29811,6 +29761,10 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"elU" = (
+/obj/effect/turf_decal/tile/yellow/full,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/maintenance/department/medical)
 "ema" = (
 /obj/structure/plasticflaps/opaque,
 /turf/open/floor/plating,
@@ -30597,6 +30551,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/server)
+"eVp" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/chem_storage)
 "eVv" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -30651,8 +30609,7 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "eXa" = (
-/obj/effect/spawner/random/epic_loot/random_supply_crate,
-/turf/open/floor/plating,
+/turf/open/floor/iron/white/smooth_large,
 /area/station/maintenance/department/medical)
 "eXo" = (
 /obj/structure/disposalpipe/segment,
@@ -31019,10 +30976,18 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "fhH" = (
-/obj/effect/landmark/start/medical_doctor,
-/obj/machinery/holopad,
-/turf/open/floor/iron/white/textured_large,
-/area/station/medical/treatment_center)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 4
+	},
+/area/station/maintenance/department/medical)
 "fhM" = (
 /obj/structure/secure_safe{
 	pixel_x = -22
@@ -31300,14 +31265,14 @@
 /turf/open/floor/iron/terracotta/small,
 /area/station/service/kitchen)
 "ftW" = (
-/obj/structure/closet/crate/freezer/blood,
-/obj/structure/window/spawner/directional/west,
-/obj/machinery/camera/autoname/motion/directional/north,
-/obj/machinery/button/door/directional/north{
-	id_tag = "exam";
-	name = "Entrance Lockdown"
+/obj/effect/turf_decal/tile/pine_green/fourcorners,
+/obj/machinery/door/poddoor/shutters/colony_fabricator/preopen{
+	id_tag = "exam"
 	},
-/turf/open/floor/iron/white/textured_large,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
 /area/station/medical/treatment_center)
 "ftY" = (
 /obj/machinery/conveyor{
@@ -31710,11 +31675,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
-"fKv" = (
-/obj/item/stack/cable_coil,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/tcommsat/computer)
 "fLd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -31870,6 +31830,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"fTD" = (
+/obj/effect/turf_decal/tile/yellow/half,
+/obj/effect/spawner/random/medical/patient_stretcher,
+/obj/effect/spawner/random/medical/organs,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/maintenance/department/medical)
 "fTY" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -32527,12 +32493,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
-"gwJ" = (
-/obj/structure/table,
-/obj/item/hand_labeler,
-/obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/chem_storage)
 "gwZ" = (
 /turf/closed/wall,
 /area/station/security/range)
@@ -32988,6 +32948,12 @@
 /mob/living/carbon/human/species/monkey,
 /turf/open/floor/grass,
 /area/station/science/genetics)
+"gPn" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/turf/open/floor/grass,
+/area/station/medical/paramedic)
 "gQa" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -34002,6 +33968,9 @@
 	},
 /turf/open/floor/iron/white/small,
 /area/station/medical/virology)
+"hIG" = (
+/turf/open/floor/iron,
+/area/station/tcommsat/computer)
 "hIQ" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/airalarm/directional/south,
@@ -34370,11 +34339,8 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "hXk" = (
-/obj/effect/turf_decal/tile/yellow/half{
-	dir = 1
-	},
-/obj/effect/spawner/random/trash/ghetto_containers,
-/turf/open/floor/iron/white/smooth_large,
+/obj/effect/spawner/random/epic_loot/random_supply_crate,
+/turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "hXt" = (
 /obj/structure/girder,
@@ -34493,6 +34459,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/captain)
+"ieL" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/departmental,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "ieU" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -34957,6 +34928,13 @@
 	},
 /turf/closed/wall,
 /area/station/hallway/secondary/entry)
+"iAH" = (
+/obj/effect/turf_decal/tile/electric_yellow{
+	dir = 8
+	},
+/obj/machinery/camera/autoname/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "iBi" = (
 /obj/machinery/light/directional/north,
 /obj/structure/table,
@@ -35034,11 +35012,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "iDT" = (
-/obj/effect/turf_decal/tile/yellow/half,
-/obj/effect/spawner/random/medical/patient_stretcher,
-/obj/effect/spawner/random/medical/surgery_tool,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/maintenance/department/medical)
+/obj/machinery/iv_drip,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/white/textured_large,
+/area/station/medical/treatment_center)
 "iDV" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Cargo Bay"
@@ -35348,6 +35325,19 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
+"iPy" = (
+/obj/effect/turf_decal/tile/pine_green/fourcorners,
+/obj/machinery/door/airlock/multi_tile/public/glass{
+	name = "Medbay Lobby";
+	red_alert_access = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/machinery/door/poddoor/shutters/colony_fabricator/preopen{
+	id_tag = "exam"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/station/medical/treatment_center)
 "iQR" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
@@ -35414,10 +35404,11 @@
 /turf/open/floor/wood/large,
 /area/station/command/bridge)
 "iWQ" = (
-/obj/effect/spawner/random/structure/table_or_rack,
-/obj/machinery/light/cold/dim/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/floor/grass,
+/area/station/medical/paramedic)
 "iWV" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -35488,11 +35479,6 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/exit)
-"jal" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/any/medical/chemistry,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
 "jat" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -35624,12 +35610,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "jfg" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/machinery/computer/security/telescreen/entertainment/directional/east,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/obj/effect/spawner/random/structure/girder,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "jgr" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Library"
@@ -35782,14 +35765,12 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/storage_shared)
 "jlc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
+/obj/structure/closet/secure_closet/chemical,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/yellow/full,
-/obj/effect/spawner/random/medical/patient_stretcher,
 /turf/open/floor/iron/white/smooth_large,
-/area/station/maintenance/department/medical)
+/area/station/medical/chem_storage)
 "jmr" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -37422,11 +37403,6 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/carpet/black,
 /area/station/service/chapel/office)
-"kDw" = (
-/obj/effect/turf_decal/tile/pine_green,
-/obj/effect/turf_decal/caution/stand_clear/red,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
 "kDJ" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/conveyor_switch/oneway{
@@ -37559,7 +37535,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/yellow/full,
-/obj/effect/spawner/random/trash/grime,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/maintenance/department/medical)
 "kHO" = (
@@ -37811,13 +37786,6 @@
 /obj/effect/spawner/random/structure/tank_holder,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
-"kUL" = (
-/obj/effect/turf_decal/tile/yellow/half{
-	dir = 1
-	},
-/obj/effect/spawner/random/structure/chair_maintenance,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/maintenance/department/medical)
 "kVc" = (
 /obj/machinery/light/directional/north,
 /obj/structure/cable,
@@ -38062,6 +38030,12 @@
 /obj/effect/mapping_helpers/airalarm/unlocked,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"leL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/medical/treatment_center)
 "lfc" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -38277,9 +38251,11 @@
 	},
 /area/station/medical/pharmacy)
 "lnn" = (
-/obj/effect/spawner/random/trash/crushed_can,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/maintenance/department/medical)
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/medical/treatment_center)
 "lnw" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/machinery/requests_console/directional/north{
@@ -38318,11 +38294,12 @@
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
 "lou" = (
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/flora/bush/flowers_br/style_random,
-/turf/open/floor/grass,
-/area/station/medical/paramedic)
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/east,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "lpW" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -38676,8 +38653,8 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/medical)
 "lFb" = (
-/turf/closed/wall/r_wall,
-/area/station/medical/pharmacy)
+/turf/open/space/basic,
+/area/station/tcommsat/computer)
 "lFh" = (
 /obj/machinery/holopad,
 /obj/structure/cable,
@@ -38987,12 +38964,6 @@
 /obj/effect/turf_decal/tile/dark/diagonal_edge,
 /turf/open/floor/iron/white/diagonal,
 /area/station/ai_monitored/turret_protected/ai_upload)
-"lUc" = (
-/obj/effect/turf_decal/tile/yellow/half{
-	dir = 1
-	},
-/turf/open/floor/iron/white/smooth_large,
-/area/station/maintenance/department/medical)
 "lUC" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -39404,10 +39375,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/supply)
-"mmq" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/tcommsat/computer)
 "mmu" = (
 /obj/structure/table,
 /obj/structure/maintenance_loot_structure/computer_tower/random,
@@ -39749,6 +39716,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/command/bridge)
+"myz" = (
+/obj/machinery/light/small/directional/west,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/tcommsat/computer)
 "mzp" = (
 /obj/effect/turf_decal/siding/dark_blue{
 	dir = 5
@@ -40048,12 +40022,6 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/command/bridge)
-"mOh" = (
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/treatment_center)
 "mOt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -41271,10 +41239,6 @@
 /obj/structure/sign/poster/official/there_is_no_gas_giant/directional/north,
 /turf/open/floor/engine,
 /area/station/science/ordnance/storage)
-"nRE" = (
-/obj/effect/spawner/random/trash/mess,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/maintenance/department/medical)
 "nSe" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/paramedic,
@@ -42843,8 +42807,8 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/medbay)
 "oXV" = (
-/obj/effect/spawner/random/structure/crate_abandoned,
-/turf/open/floor/plating,
+/obj/effect/spawner/random/trash/crushed_can,
+/turf/open/floor/iron/white/smooth_large,
 /area/station/maintenance/department/medical)
 "oYc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -43568,10 +43532,10 @@
 /turf/open/floor/plating,
 /area/station/engineering/storage_shared)
 "pAo" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/departmental,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/obj/effect/turf_decal/tile/pine_green,
+/obj/effect/turf_decal/caution/stand_clear/red,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "pAM" = (
 /obj/structure/chair/stool/bar/directional/west,
 /turf/open/floor/plating,
@@ -44444,11 +44408,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"qho" = (
-/obj/effect/turf_decal/tile/pine_green,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
 "qhH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -44915,9 +44874,12 @@
 	},
 /area/station/cargo/storage)
 "qwJ" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/chem_storage)
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/turf/open/floor/grass,
+/area/station/medical/paramedic)
 "qwS" = (
 /obj/effect/turf_decal/siding{
 	dir = 4
@@ -44947,13 +44909,9 @@
 /turf/open/floor/carpet/black,
 /area/station/service/chapel/office)
 "qxq" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/right/directional/south{
-	name = "Security Checkpoint";
-	req_access = list("brig_entrance")
-	},
+/obj/effect/spawner/random/structure/table_or_rack,
 /turf/open/floor/plating,
-/area/station/security/checkpoint/medical)
+/area/station/maintenance/department/medical)
 "qxE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -44989,6 +44947,10 @@
 	},
 /turf/open/floor/iron/terracotta/small,
 /area/station/service/kitchen)
+"qyV" = (
+/obj/machinery/power/port_gen/pacman,
+/turf/open/floor/plating,
+/area/station/tcommsat/computer)
 "qzm" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -45285,10 +45247,6 @@
 	},
 /turf/open/floor/iron/white/small,
 /area/station/medical/virology)
-"qNi" = (
-/obj/effect/turf_decal/tile/yellow/full,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/maintenance/department/medical)
 "qNy" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/left/directional/south{
@@ -45634,8 +45592,10 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "rcF" = (
-/turf/closed/wall/r_wall,
-/area/station/medical/paramedic)
+/obj/effect/turf_decal/tile/pine_green,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "rdU" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
@@ -47059,6 +47019,15 @@
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
+"sdY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/yellow/full,
+/obj/effect/spawner/random/trash/grime,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/maintenance/department/medical)
 "sea" = (
 /obj/structure/flora/bush/lavendergrass/style_random,
 /obj/structure/flora/bush/sparsegrass/style_random,
@@ -47690,6 +47659,8 @@
 /area/station/cargo/storage)
 "sAE" = (
 /obj/effect/turf_decal/tile/yellow/half,
+/obj/effect/spawner/random/medical/patient_stretcher,
+/obj/effect/spawner/random/medical/surgery_tool,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/maintenance/department/medical)
 "sAK" = (
@@ -48737,6 +48708,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"tnI" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/right/directional/south{
+	name = "Security Checkpoint";
+	req_access = list("brig_entrance")
+	},
+/turf/open/floor/plating,
+/area/station/security/checkpoint/medical)
 "tnY" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -48800,6 +48779,11 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark,
 /area/station/service/library)
+"tqK" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/medical/chemistry,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "tqO" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/line{
@@ -49042,17 +49026,8 @@
 /turf/open/floor/iron/dark,
 /area/station/service/library/lounge)
 "txK" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 4
-	},
+/obj/effect/spawner/random/trash/grime,
+/turf/open/floor/iron/white/smooth_large,
 /area/station/maintenance/department/medical)
 "txZ" = (
 /obj/structure/cable,
@@ -50000,6 +49975,14 @@
 /turf/open/floor/wood,
 /area/station/science/lab)
 "uik" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/external{
+	name = "Telecommunications External Access"
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/tcommsat/computer)
 "uiP" = (
@@ -50635,13 +50618,6 @@
 /obj/item/beacon,
 /turf/open/floor/iron,
 /area/station/security/eva)
-"uEh" = (
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/flora/bush/flowers_br/style_random,
-/turf/open/floor/grass,
-/area/station/medical/paramedic)
 "uEr" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -50800,6 +50776,19 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/storage_shared)
+"uMq" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/airlock/external{
+	name = "Telecommunications External Access"
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/tcommsat/computer)
 "uMr" = (
 /obj/machinery/power/supermatter_crystal/engine,
 /obj/effect/turf_decal/bot,
@@ -51275,7 +51264,8 @@
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
 "veb" = (
-/obj/effect/spawner/random/trash/grime,
+/obj/effect/spawner/random/structure/table_or_rack,
+/obj/machinery/light/cold/dim/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "vek" = (
@@ -51694,6 +51684,13 @@
 /obj/structure/rack,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
+"vvd" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Paramedic Dispatch Room"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/turf/open/floor/plating,
+/area/station/medical/paramedic)
 "vvn" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -52103,13 +52100,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/library)
-"vOk" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/colony_fabricator/preopen{
-	id_tag = "exam"
-	},
-/turf/open/floor/plating,
-/area/station/medical/treatment_center)
 "vOB" = (
 /obj/effect/landmark/start/paramedic,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -52310,10 +52300,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "vTg" = (
-/obj/structure/closet/secure_closet/chemical,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 1
-	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/chem_storage)
 "vTL" = (
@@ -53443,6 +53429,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/library/artgallery)
+"wJO" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/obj/effect/spawner/random/trash/crushed_can,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/maintenance/department/medical)
 "wJT" = (
 /obj/structure/chair/wood,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -53896,6 +53889,10 @@
 /obj/effect/landmark/atmospheric_sanity/ignore_area,
 /turf/open/floor/carpet,
 /area/station/service/chapel)
+"xaw" = (
+/obj/effect/spawner/random/trash/caution_sign,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/maintenance/department/medical)
 "xay" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -54429,9 +54426,8 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "xnm" = (
-/obj/effect/spawner/random/engineering/tank,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/turf/closed/wall/r_wall,
+/area/station/medical/pharmacy)
 "xnp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -54459,10 +54455,6 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
-"xpq" = (
-/obj/effect/spawner/random/trash/caution_sign,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/maintenance/department/medical)
 "xpw" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -55300,13 +55292,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
-"xUQ" = (
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/flora/bush/flowers_yw/style_random,
-/turf/open/floor/grass,
-/area/station/medical/paramedic)
 "xUU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -55421,12 +55406,6 @@
 	},
 /turf/open/floor/iron/white/textured_edge,
 /area/station/medical/pharmacy)
-"yam" = (
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/flora/bush/flowers_pp/style_random,
-/turf/open/floor/grass,
-/area/station/medical/paramedic)
 "yat" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -81811,9 +81790,9 @@ bfk
 bdm
 dyg
 sMg
-qho
+rcF
 dYh
-bjW
+iDT
 blc
 tgT
 mDN
@@ -82326,7 +82305,7 @@ bdm
 dyg
 sMg
 bik
-vOk
+bgl
 bjS
 tgd
 nUo
@@ -82582,8 +82561,8 @@ bfm
 xPQ
 dyg
 sMg
-kDw
-blf
+pAo
+iPy
 bjT
 hfw
 gnS
@@ -82839,13 +82818,13 @@ bfn
 bdm
 dyg
 sMg
-kDw
-bzX
+pAo
+ftW
 bjT
-clM
-cLB
-clM
-mOh
+bLs
+leL
+bLs
+lnn
 xsa
 xUU
 uFc
@@ -83097,13 +83076,13 @@ aRL
 dyg
 sMg
 bik
-vOk
+bgl
 bjV
 qwS
 jJm
 aFM
 uQu
-dcN
+blf
 ktU
 uFc
 buc
@@ -83355,8 +83334,8 @@ eZv
 sMg
 bik
 dYh
-ftW
-fhH
+bjW
+clU
 idj
 tCi
 xQO
@@ -83612,7 +83591,7 @@ aDm
 sMg
 rkq
 dYh
-bjW
+iDT
 tgT
 cRi
 bny
@@ -83869,7 +83848,7 @@ tWc
 sMg
 bin
 dYh
-clA
+bMM
 tgT
 pku
 qib
@@ -83886,12 +83865,12 @@ fbc
 bCn
 bDs
 mOx
-txK
-txK
-txK
-txK
-txK
-txK
+fhH
+fhH
+fhH
+fhH
+fhH
+fhH
 bMK
 oJj
 eMp
@@ -84142,12 +84121,12 @@ gKB
 tli
 peY
 bjc
-bMM
+jfg
 nKE
 egX
 tcX
 egX
-eeW
+eXa
 mwc
 ygx
 cBL
@@ -84226,10 +84205,10 @@ aaa
 aaa
 aaa
 teJ
-bFS
-bjY
-aZc
-awW
+uik
+myz
+uMq
+bzX
 clY
 gmH
 cmh
@@ -84387,7 +84366,7 @@ bjZ
 vaR
 eus
 bnD
-bli
+dcN
 brg
 sgD
 cqd
@@ -84399,14 +84378,14 @@ cqd
 bIi
 wLW
 bjc
-bMM
+jfg
 drQ
 sMx
 tcX
 sMx
 dLb
 bwV
-bMM
+jfg
 oJj
 eMp
 lRN
@@ -84487,7 +84466,7 @@ clw
 hQz
 nTk
 jCr
-dSC
+hIG
 kCI
 nTk
 nMG
@@ -84639,7 +84618,7 @@ bgk
 dyg
 sMg
 fih
-qxq
+tnI
 bka
 tLk
 bmv
@@ -84655,13 +84634,13 @@ jze
 jze
 qnJ
 jze
-rcF
+awW
 oPH
 hEF
 tKY
-bjU
-bCp
-lUc
+clJ
+kHD
+dpV
 eeb
 oJj
 oJj
@@ -84739,7 +84718,7 @@ aaa
 aaa
 aaa
 aaa
-bll
+lFb
 clw
 nTk
 nTk
@@ -84908,17 +84887,17 @@ hZH
 hZH
 bvl
 bwO
-lou
+iWQ
 bzZ
 bsJ
 bCr
-rcF
+awW
 tta
-dpV
-qNi
-eeW
-bCp
-hXk
+fTD
+elU
+eXa
+kHD
+bjY
 bAg
 oJj
 bNV
@@ -84996,12 +84975,12 @@ aaa
 aaa
 aaa
 aaa
-bll
+lFb
 clw
-clU
-uik
-cmb
-uik
+qyV
+clV
+bCp
+clV
 mxy
 nTk
 qPu
@@ -85165,17 +85144,17 @@ jWH
 nYu
 oSa
 gfH
-xUQ
+qwJ
 fgs
 xmg
 buk
-rcF
-veb
-iDT
-clJ
+awW
+clN
+sAE
 eeW
-kHD
-kUL
+eXa
+sdY
+bmp
 bLL
 oJj
 bNW
@@ -85255,10 +85234,10 @@ aaa
 aaa
 abI
 clw
-uik
-bgl
-mmq
-fKv
+clV
+bli
+cLB
+cmb
 mDW
 nTk
 cml
@@ -85422,17 +85401,17 @@ frX
 dRU
 gzG
 brh
-cWA
+vvd
 brl
 bsL
 bFl
-rcF
-oXV
-sAE
-clN
-clN
-kHD
-xnm
+awW
+bJc
+bjU
+txK
+txK
+sdY
+bFS
 anH
 oJj
 oxA
@@ -85679,17 +85658,17 @@ bsH
 blo
 crd
 gfH
-uEh
+bll
 hjy
 nSe
 xsT
-rcF
-iWQ
-sAE
-clN
-clN
-bCp
-eXa
+awW
+veb
+bjU
+txK
+txK
+kHD
+hXk
 prD
 oJj
 oJj
@@ -85936,16 +85915,16 @@ mZi
 wEl
 bvp
 xTf
-yam
+gPn
 brm
 bsN
 bCv
-rcF
-cmc
-sAE
-bLs
-bLs
-jlc
+awW
+qxq
+bjU
+boF
+boF
+clD
 mFY
 bLM
 bMN
@@ -86189,15 +86168,15 @@ ufo
 boL
 bpY
 fms
-lFb
-lFb
+xnm
+xnm
 qgA
-lFb
-rcF
+xnm
+awW
 jze
 jze
 jze
-rcF
+awW
 lRN
 eGL
 iZl
@@ -86456,9 +86435,9 @@ uqf
 bCx
 byw
 lRN
-nRE
+cmc
+hXk
 eXa
-eeW
 oPH
 ipz
 udS
@@ -86709,15 +86688,15 @@ xHJ
 bwT
 eBd
 bsK
-bJc
-bJc
-qwJ
-jal
-xpq
-clN
-nRE
-lnn
-clD
+vTg
+vTg
+eVp
+tqK
+xaw
+txK
+cmc
+oXV
+wJO
 byz
 ooh
 oJj
@@ -87222,16 +87201,16 @@ qHa
 pxw
 dRj
 hEC
+jlc
 vTg
-bJc
-clV
+cdk
 lRN
 lRN
 oJj
 oJj
 oJj
 oJj
-pAo
+ieL
 oJj
 oJj
 oJj
@@ -87482,7 +87461,7 @@ hEC
 ipu
 phx
 azR
-cOB
+clM
 eMp
 eMp
 eMp
@@ -87738,7 +87717,7 @@ lRN
 hEC
 cIe
 fby
-gwJ
+clA
 lRN
 eMp
 oJj
@@ -88001,7 +87980,7 @@ hop
 oJj
 jCv
 bOK
-boF
+iAH
 ery
 sAC
 bIT
@@ -91560,7 +91539,7 @@ swT
 swT
 swT
 aXr
-jfg
+lou
 mvJ
 swT
 swT

--- a/_maps/map_files/Pubbystation/pubbystation.dmm
+++ b/_maps/map_files/Pubbystation/pubbystation.dmm
@@ -2325,7 +2325,7 @@
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 1
 	},
-/obj/structure/sign/poster/official/space_cops/directional/west,
+/obj/machinery/computer/security/telescreen/entertainment/directional/west,
 /turf/open/floor/iron,
 /area/station/security/office)
 "akR" = (
@@ -3083,7 +3083,7 @@
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1
 	},
-/area/station/medical/chemistry)
+/area/station/maintenance/department/medical)
 "anI" = (
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/warden)
@@ -4268,9 +4268,7 @@
 /area/station/commons/dorms/laundry)
 "asg" = (
 /obj/structure/bedsheetbin,
-/obj/item/wallframe/telescreen/entertainment{
-	pixel_x = 32
-	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/east,
 /turf/open/floor/iron/cafeteria,
 /area/station/commons/dorms/laundry)
 "ash" = (
@@ -4845,6 +4843,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/west,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "auz" = (
@@ -5109,9 +5108,7 @@
 	c_tag = "Dormitories Fore"
 	},
 /obj/machinery/light/directional/north,
-/obj/item/wallframe/telescreen/entertainment{
-	pixel_y = 32
-	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "avm" = (
@@ -5612,22 +5609,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "awW" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Medbay Paramedic Dispatch";
-	network = list("ss13","medbay")
+/obj/structure/closet/crate/freezer/blood,
+/obj/structure/window/spawner/directional/west,
+/obj/machinery/camera/autoname/motion/directional/north,
+/obj/machinery/button/door/directional/north{
+	id_tag = "exam";
+	name = "Entrance Lockdown"
 	},
-/obj/machinery/firealarm/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark/smooth_edge{
-	dir = 4
-	},
-/area/station/medical/paramedic)
+/turf/open/floor/iron/white/textured_large,
+/area/station/medical/treatment_center)
 "awY" = (
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -6254,19 +6244,12 @@
 /area/station/engineering/atmos/hfr_room)
 "azR" = (
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/any/medical/cmo,
-/obj/machinery/door/airlock/grunge{
-	name = "Personal Examination Room"
-	},
-/turf/open/floor/iron/dark,
-/area/station/medical/abandoned)
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/chem_storage)
 "azS" = (
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
@@ -6664,9 +6647,7 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/wallframe/telescreen/entertainment{
-	pixel_y = 32
-	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/hop)
 "aBB" = (
@@ -6859,9 +6840,7 @@
 	c_tag = "Primary Tool Storage"
 	},
 /obj/item/assembly/voice,
-/obj/structure/noticeboard{
-	pixel_y = 32
-	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/commons/storage/primary)
 "aCw" = (
@@ -9258,7 +9237,7 @@
 /area/station/commons/cryopods)
 "aNb" = (
 /obj/effect/turf_decal/tile/pine_green,
-/obj/structure/sign/poster/official/moth_epi/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "aNc" = (
@@ -9397,7 +9376,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/structure/sign/poster/official/obey/directional/west,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "aNE" = (
@@ -12226,17 +12204,12 @@
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 8
 	},
-/obj/item/wallframe/telescreen/entertainment{
-	pixel_x = 32
-	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/commons/lounge)
 "bap" = (
 /obj/machinery/computer/slot_machine,
 /obj/structure/sign/poster/official/soft_cap_pop_art/directional/north,
-/obj/item/wallframe/telescreen/entertainment{
-	pixel_x = -32
-	},
 /turf/open/floor/carpet/purple,
 /area/station/commons/lounge)
 "baq" = (
@@ -12740,9 +12713,7 @@
 "bck" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal/bin,
-/obj/item/wallframe/telescreen/entertainment{
-	pixel_x = 32
-	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/east,
 /turf/open/floor/iron/dark/side{
 	dir = 6
 	},
@@ -13228,9 +13199,7 @@
 	c_tag = "Bar Port"
 	},
 /obj/machinery/light/directional/south,
-/obj/item/wallframe/telescreen/entertainment{
-	pixel_y = -32
-	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/commons/lounge)
 "bey" = (
@@ -13652,11 +13621,12 @@
 /turf/open/floor/plating,
 /area/station/service/kitchen)
 "bgl" = (
-/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating/airless,
-/area/station/tcommsat/computer)
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/turf/open/floor/grass,
+/area/station/medical/paramedic)
 "bgn" = (
 /obj/structure/chair{
 	dir = 4
@@ -14154,7 +14124,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "bin" = (
-/obj/machinery/light/directional/south,
 /obj/machinery/camera/directional/south{
 	c_tag = "Central Primary Hallway Hydroponics"
 	},
@@ -14374,120 +14343,85 @@
 /turf/open/floor/grass,
 /area/station/medical/treatment_center)
 "bjS" = (
-/obj/machinery/requests_console/directional/north{
-	department = "Medbay";
-	name = "Medbay Requests Console"
-	},
-/obj/item/storage/pill_bottle/painkiller{
-	pixel_x = 1;
-	pixel_y = 11
-	},
-/obj/item/storage/pill_bottle/painkiller{
-	pixel_x = 9;
-	pixel_y = 12
-	},
-/obj/structure/table,
 /obj/effect/turf_decal/siding/corner{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/pine_green/anticorner{
 	dir = 1
 	},
-/obj/item/storage/medkit/emergency,
 /turf/open/floor/iron/white/smooth_corner,
 /area/station/medical/treatment_center)
 "bjT" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Medbay Treatment";
-	network = list("ss13","medbay")
-	},
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/item/reagent_containers/hypospray/medipen/deforest/coagulants{
-	pixel_x = 0;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/hypospray/medipen/deforest/coagulants{
-	pixel_x = 0;
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/hypospray/medipen/deforest/coagulants{
-	pixel_x = 0;
-	pixel_y = 10
-	},
-/obj/structure/table,
 /obj/effect/turf_decal/tile/pine_green/half{
 	dir = 1
 	},
+/obj/effect/turf_decal/caution/stand_clear/red,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1
 	},
 /area/station/medical/treatment_center)
 "bjU" = (
-/obj/machinery/airalarm/directional/north,
-/obj/structure/table,
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
+/obj/machinery/door/airlock/security/glass{
+	name = "Medbay Security Post"
+	},
+/obj/effect/turf_decal/tile/dark_blue/fourcorners,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/medical)
+"bjV" = (
 /obj/effect/turf_decal/siding/corner,
 /obj/effect/turf_decal/tile/pine_green/anticorner{
 	dir = 4
 	},
-/obj/effect/spawner/random/medical/minor_healing,
-/obj/effect/spawner/random/medical/minor_healing,
 /turf/open/floor/iron/white/smooth_corner{
 	dir = 8
 	},
 /area/station/medical/treatment_center)
-"bjV" = (
-/obj/structure/closet/crate/freezer/blood,
-/obj/machinery/light/directional/north,
-/obj/structure/window/spawner/directional/west,
-/turf/open/floor/iron/white/textured_large,
-/area/station/medical/treatment_center)
 "bjW" = (
 /obj/machinery/iv_drip,
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/treatment_center)
 "bjY" = (
-/obj/structure/bed/medical/emergency,
-/obj/machinery/airalarm/directional/north,
-/obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/medical/paramedic)
+/obj/structure/cable,
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/tcommsat/computer)
 "bjZ" = (
-/obj/machinery/fax{
-	fax_name = "Medical";
-	name = "Medical Fax Machine"
-	},
-/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 1
 	},
-/obj/structure/table,
-/turf/open/floor/iron/dark/smooth_edge,
-/area/station/medical/paramedic)
-"bka" = (
-/obj/machinery/light/directional/north,
-/obj/machinery/requests_console/directional/north{
-	department = "Medbay";
-	name = "Medbay Front Desk Requests console"
-	},
-/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/effect/spawner/random/medical/medkit,
-/obj/effect/spawner/random/medical/medkit_rare,
-/turf/open/floor/iron/dark/smooth_edge,
-/area/station/medical/paramedic)
-"bkc" = (
-/obj/machinery/vending/wallmed/directional/north,
-/obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted{
+/obj/machinery/computer/security{
 	dir = 4
 	},
-/obj/item/storage/epic_loot_medical_case,
-/obj/structure/table,
-/turf/open/floor/iron/dark,
-/area/station/medical/paramedic)
+/turf/open/floor/iron,
+/area/station/security/checkpoint/medical)
+"bka" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/structure/chair/office/tactical{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/security/checkpoint/medical)
+"bkc" = (
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/requests_console/assistance,
+/obj/effect/mapping_helpers/requests_console/information,
+/obj/machinery/requests_console/auto_name/directional/north,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/medical)
 "bkd" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -14609,9 +14543,7 @@
 /turf/open/floor/engine,
 /area/station/science/lab)
 "bkz" = (
-/obj/item/wallframe/telescreen/entertainment{
-	pixel_y = 32
-	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /turf/open/floor/wood/large,
 /area/station/science/breakroom)
 "bkA" = (
@@ -14710,6 +14642,7 @@
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 1
 	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/freezer,
 /area/station/medical/coldroom)
 "blb" = (
@@ -14727,36 +14660,27 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/treatment_center)
 "blf" = (
-/obj/effect/landmark/start/medical_doctor,
-/turf/open/floor/iron/white/textured_large,
-/area/station/medical/treatment_center)
+/obj/machinery/door/airlock/command/glass{
+	name = "Paramedic Dispatch Room"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/turf/open/floor/plating,
+/area/station/medical/paramedic)
 "bli" = (
-/obj/structure/bed/medical/emergency,
-/obj/machinery/newscaster/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+/obj/effect/turf_decal/tile/pine_green{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/smooth_edge{
-	dir = 4
-	},
-/area/station/medical/paramedic)
+/turf/open/floor/iron/white/smooth_edge,
+/area/station/medical/medbay)
 "bll" = (
-/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
-	dir = 4
-	},
-/obj/structure/chair/office/light{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/smooth_edge{
-	dir = 8
-	},
-/area/station/medical/paramedic)
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/departmental,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "blo" = (
 /obj/effect/turf_decal/trimline/pine_green/line{
 	dir = 8
@@ -14986,21 +14910,18 @@
 /area/station/medical/treatment_center)
 "bmv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/dark_blue/line,
-/obj/effect/landmark/start/paramedic,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/medical/paramedic)
+/turf/open/floor/iron,
+/area/station/security/checkpoint/medical)
 "bmw" = (
-/obj/machinery/computer/crew{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+/obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
 	},
-/turf/open/floor/iron/dark/smooth_edge{
-	dir = 8
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_y = 4
 	},
-/area/station/medical/paramedic)
+/turf/open/floor/iron,
+/area/station/security/checkpoint/medical)
 "bmz" = (
 /obj/effect/turf_decal/tile/pine_green,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -15168,27 +15089,28 @@
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/treatment_center)
 "bnB" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/east,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
+"bnC" = (
+/obj/machinery/requests_console/auto_name/directional/north,
+/turf/open/floor/iron,
+/area/station/commons/dorms)
+"bnD" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted{
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
-/area/station/medical/paramedic)
-"bnC" = (
-/obj/machinery/requests_console/auto_name/directional/north,
 /turf/open/floor/iron,
-/area/station/commons/dorms)
-"bnD" = (
-/obj/effect/turf_decal/tile/dark_blue/half/contrasted,
-/turf/open/floor/iron/dark/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/paramedic)
+/area/station/security/checkpoint/medical)
 "bnG" = (
 /obj/effect/turf_decal/tile/pine_green/anticorner{
 	dir = 4
@@ -15305,28 +15227,24 @@
 /turf/open/floor/grass,
 /area/station/medical/treatment_center)
 "boF" = (
-/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/external{
+	name = "Telecommunications External Access"
+	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/access/any/medical/general,
-/obj/machinery/door/airlock/command/glass{
-	name = "Paramedic Dispatch Room"
-	},
-/obj/effect/turf_decal/tile/dark_blue/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/medical/paramedic)
+/turf/open/floor/plating,
+/area/station/tcommsat/computer)
 "boH" = (
-/obj/structure/extinguisher_cabinet/directional/north,
-/obj/item/storage/backpack/duffelbag/deforest_surgical/stocked,
-/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+/obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
 /obj/structure/table,
-/turf/open/floor/iron/dark/smooth_edge,
-/area/station/medical/paramedic)
+/obj/item/paper_bin,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/medical)
 "boL" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Medbay Entrance";
@@ -15544,7 +15462,7 @@
 "bpQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/station/medical/paramedic)
+/area/station/security/checkpoint/medical)
 "bpR" = (
 /obj/machinery/door/window/right/directional/north{
 	name = "Medbay Front Desk";
@@ -15554,7 +15472,7 @@
 /obj/effect/turf_decal/tile/dark_blue/opposingcorners,
 /obj/structure/table/reinforced,
 /turf/open/floor/iron/white,
-/area/station/medical/paramedic)
+/area/station/security/checkpoint/medical)
 "bpT" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/status_display/ai{
@@ -15942,8 +15860,6 @@
 /obj/effect/turf_decal/tile/pine_green/anticorner/contrasted{
 	dir = 4
 	},
-/obj/structure/sign/warning/no_smoking/circle/directional/north,
-/obj/structure/tank_holder/extinguisher,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "brh" = (
@@ -15965,23 +15881,20 @@
 /turf/open/floor/iron/white/textured,
 /area/station/medical/pharmacy)
 "brl" = (
-/obj/structure/table,
-/obj/machinery/recharger{
-	pixel_y = 4
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 1
 	},
-/turf/open/floor/iron,
-/area/station/security/checkpoint/medical)
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/paramedic)
 "brm" = (
-/obj/machinery/computer/records/security,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+/obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/security/checkpoint/medical)
+/obj/structure/table/reinforced/rglass,
+/obj/item/storage/medkit/combat_surgeon/stocked,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/paramedic)
 "bro" = (
 /obj/structure/plasticflaps/opaque,
 /obj/effect/turf_decal/delivery,
@@ -16255,22 +16168,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 8
 	},
-/turf/open/floor/iron,
-/area/station/security/checkpoint/medical)
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/paramedic)
 "bsK" = (
 /turf/open/floor/iron/white/smooth_edge,
-/area/station/medical/chemistry)
+/area/station/medical/chem_storage)
 "bsL" = (
-/obj/effect/landmark/start/depsec/medical,
-/obj/structure/chair/office/light{
-	dir = 1
-	},
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/security/checkpoint/medical)
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/paramedic)
 "bsN" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Security Post - Medbay";
@@ -16278,11 +16189,12 @@
 	},
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/security/checkpoint/medical)
+/obj/effect/landmark/start/paramedic,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/paramedic)
 "bsR" = (
 /obj/effect/turf_decal/siding/dark_blue,
 /obj/effect/turf_decal/siding/wood{
@@ -16577,18 +16489,15 @@
 	},
 /area/station/medical/pharmacy)
 "buk" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted,
 /obj/machinery/requests_console/directional/south{
 	department = "Security";
 	name = "Medical Post Requests Console"
 	},
 /obj/effect/mapping_helpers/requests_console/information,
 /obj/effect/mapping_helpers/requests_console/assistance,
-/turf/open/floor/iron,
-/area/station/security/checkpoint/medical)
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/paramedic)
 "bun" = (
 /obj/machinery/chem_heater/withbuffer,
 /obj/item/radio/intercom/directional/east,
@@ -17088,7 +16997,7 @@
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/siding,
 /turf/open/floor/iron/white/smooth_corner,
-/area/station/medical/chemistry)
+/area/station/maintenance/department/medical)
 "bxa" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/structure/table,
@@ -17554,22 +17463,14 @@
 	},
 /area/station/medical/medbay)
 "byw" = (
-/obj/item/stack/ducts/fifty{
-	pixel_y = 7
-	},
-/obj/item/stack/ducts/fifty{
-	pixel_y = 5
-	},
-/obj/item/construction/plumbing,
-/obj/item/construction/plumbing,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 8
 	},
-/obj/structure/table,
+/obj/machinery/vending/wardrobe/chem_wardrobe,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 4
 	},
-/area/station/medical/chemistry)
+/area/station/medical/chem_storage)
 "byz" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/machinery/door/window/right/directional/north{
@@ -17583,7 +17484,7 @@
 	name = "Labrette"
 	},
 /turf/open/floor/engine,
-/area/station/medical/chemistry)
+/area/station/maintenance/department/medical)
 "byA" = (
 /obj/structure/window/reinforced/spawner/directional/north{
 	pixel_y = 2
@@ -17592,7 +17493,7 @@
 	dir = 1
 	},
 /turf/open/floor/engine,
-/area/station/medical/chemistry)
+/area/station/maintenance/department/medical)
 "byD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -17941,22 +17842,19 @@
 /turf/open/floor/iron/terracotta,
 /area/station/medical/medbay)
 "bzX" = (
-/obj/effect/turf_decal/tile/pine_green/half/contrasted{
-	dir = 4
-	},
-/obj/structure/sign/departments/security/directional/east,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 8
-	},
-/area/station/medical/medbay)
+/obj/effect/turf_decal/tile/pine_green,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "bzZ" = (
-/obj/structure/table,
 /obj/machinery/airalarm/directional/west,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+/obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted{
 	dir = 1
 	},
-/turf/open/floor/iron,
-/area/station/security/checkpoint/medical)
+/obj/structure/table/reinforced/rglass,
+/obj/item/storage/backpack/duffelbag/deforest_medkit/stocked,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/paramedic)
 "bAe" = (
 /obj/item/stack/cable_coil,
 /obj/item/storage/box/beakers,
@@ -17964,8 +17862,9 @@
 	dir = 8
 	},
 /obj/structure/table,
+/obj/item/construction/plumbing,
 /turf/open/floor/iron/white,
-/area/station/medical/chemistry)
+/area/station/medical/chem_storage)
 "bAg" = (
 /obj/machinery/light/directional/south,
 /obj/item/book/manual/wiki/chemistry,
@@ -17978,16 +17877,16 @@
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1
 	},
-/area/station/medical/chemistry)
+/area/station/maintenance/department/medical)
 "bAh" = (
 /obj/machinery/chem_heater/withbuffer,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
 /turf/open/floor/iron/white,
-/area/station/medical/chemistry)
+/area/station/maintenance/department/medical)
 "bAi" = (
 /obj/machinery/smoke_machine,
 /turf/open/floor/engine,
-/area/station/medical/chemistry)
+/area/station/maintenance/department/medical)
 "bAl" = (
 /obj/structure/sign/directions/cryo/directional/west{
 	pixel_x = 0;
@@ -18488,40 +18387,36 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "bCp" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "plumbing_shutters";
-	name = "Plumbing Shutter"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/station/medical/chemistry)
+/obj/structure/closet/secure_closet/medical2,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/white/textured_large,
+/area/station/medical/treatment_center)
 "bCr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/structure/reagent_dispensers/wall/peppertank/directional/west,
 /obj/machinery/light/directional/south,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+/obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted{
 	dir = 8
 	},
-/turf/open/floor/iron,
-/area/station/security/checkpoint/medical)
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/paramedic)
 "bCv" = (
-/obj/structure/closet/secure_closet/security/med,
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/east,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted,
-/turf/open/floor/iron,
-/area/station/security/checkpoint/medical)
+/obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/paramedic)
 "bCx" = (
-/obj/structure/closet/secure_closet/chemical,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
 	},
+/obj/structure/table,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 4
 	},
-/area/station/medical/chemistry)
+/area/station/medical/chem_storage)
 "bCE" = (
 /obj/machinery/computer/robotics{
 	dir = 4
@@ -18686,17 +18581,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/any/medical/chemistry,
-/obj/machinery/door/airlock/public/glass{
-	name = "Chemistry"
-	},
 /obj/effect/turf_decal/tile/pine_green/half/contrasted{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
-/obj/effect/landmark/navigate_destination/chemfactory,
+/obj/machinery/door/airlock/maintenance{
+	name = "Medbay Maintenance"
+	},
 /turf/open/floor/iron/white,
-/area/station/medical/chemistry)
+/area/station/medical/medbay)
 "bDw" = (
 /obj/effect/turf_decal/tile/pine_green{
 	dir = 4
@@ -18716,17 +18609,12 @@
 /area/station/command/heads_quarters/cmo)
 "bDy" = (
 /obj/machinery/light/directional/east,
-/obj/item/clothing/head/utility/welding,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/stack/sheet/iron/fifty,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 4
-	},
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
 /obj/structure/table,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 8
 	},
-/area/station/medical/chemistry)
+/area/station/medical/chem_storage)
 "bDA" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/light/small/directional/east,
@@ -18950,16 +18838,10 @@
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "bEI" = (
-/obj/item/clothing/glasses/science,
-/obj/item/clothing/glasses/science,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 4
-	},
-/obj/structure/table,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 8
 	},
-/area/station/medical/chemistry)
+/area/station/medical/chem_storage)
 "bEN" = (
 /obj/structure/sign/directions/cryo/directional/north{
 	pixel_x = 0;
@@ -19068,11 +18950,11 @@
 /turf/open/floor/plating,
 /area/station/science/ordnance/freezerchamber)
 "bFl" = (
-/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted,
 /obj/structure/sign/warning/electric_shock/directional/south,
 /obj/structure/maintenance_loot_structure/file_cabinet/random,
-/turf/open/floor/iron,
-/area/station/security/checkpoint/medical)
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/paramedic)
 "bFq" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/disposalpipe/segment,
@@ -19080,6 +18962,11 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "bFr" = (
@@ -19170,7 +19057,7 @@
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 4
 	},
-/area/station/medical/chemistry)
+/area/station/maintenance/department/medical)
 "bGb" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Research Security Post"
@@ -19730,10 +19617,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "bJc" = (
-/obj/structure/cable,
-/obj/machinery/holopad,
-/turf/open/floor/iron,
-/area/station/tcommsat/computer)
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/floor/grass,
+/area/station/medical/paramedic)
 "bJd" = (
 /obj/structure/chair/comfy/black,
 /obj/item/stack/spacecash/c100,
@@ -20105,12 +19993,9 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/dock)
 "bLs" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 1
-	},
 /obj/structure/sign/poster/official/moth_meth/directional/north,
-/turf/open/floor/iron/white/smooth_edge,
-/area/station/medical/chemistry)
+/turf/open/space/basic,
+/area/station/maintenance/department/medical)
 "bLt" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor6"
@@ -20162,7 +20047,7 @@
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1
 	},
-/area/station/medical/chemistry)
+/area/station/maintenance/department/medical)
 "bLM" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -20170,7 +20055,7 @@
 /turf/open/floor/iron/white/smooth_corner{
 	dir = 8
 	},
-/area/station/medical/chemistry)
+/area/station/maintenance/department/medical)
 "bLR" = (
 /obj/machinery/vending/cigarette,
 /obj/structure/cable,
@@ -20183,6 +20068,7 @@
 /obj/effect/turf_decal/tile/electric_yellow{
 	dir = 4
 	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/west,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "bLS" = (
@@ -20448,20 +20334,20 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/chemistry)
+/area/station/maintenance/department/medical)
 "bMM" = (
 /obj/structure/fluff/shower_drain,
 /obj/machinery/shower/directional/north,
 /obj/effect/turf_decal/tile/yellow/full,
 /turf/open/floor/iron/white/smooth_large,
-/area/station/medical/chemistry)
+/area/station/maintenance/department/medical)
 "bMN" = (
 /obj/machinery/chem_master,
 /obj/effect/turf_decal/tile/electric_yellow/anticorner/contrasted{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/chemistry)
+/area/station/maintenance/department/medical)
 "bMT" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -24835,9 +24721,8 @@
 /obj/machinery/light/small/directional/west,
 /obj/structure/sign/warning/vacuum/external/directional/west,
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/airlock_pump/silent{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/engineering/transit_tube)
 "cgT" = (
@@ -24941,6 +24826,8 @@
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/engineering/transit_tube)
 "chw" = (
@@ -25477,24 +25364,28 @@
 /turf/closed/wall/r_wall,
 /area/station/tcommsat/computer)
 "clA" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/external{
-	name = "Telecommunications External Access"
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
-/turf/open/floor/plating,
-/area/station/tcommsat/computer)
+/obj/effect/landmark/start/medical_doctor,
+/obj/machinery/holopad,
+/turf/open/floor/iron/white/textured_large,
+/area/station/medical/treatment_center)
 "clC" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/transit_tube,
 /turf/open/floor/plating,
 /area/station/tcommsat/computer)
 "clD" = (
-/obj/machinery/light/small/directional/west,
-/obj/structure/cable,
+/obj/effect/turf_decal/tile/pine_green/fourcorners,
+/obj/machinery/door/airlock/multi_tile/public/glass{
+	name = "Medbay Lobby";
+	red_alert_access = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/machinery/door/poddoor/shutters/colony_fabricator/preopen{
+	id_tag = "exam"
+	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/station/tcommsat/computer)
+/area/station/medical/treatment_center)
 "clG" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -25507,16 +25398,9 @@
 /turf/open/floor/plating,
 /area/station/tcommsat/computer)
 "clJ" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/door/airlock/external{
-	name = "Telecommunications External Access"
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
-/turf/open/floor/plating,
-/area/station/tcommsat/computer)
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/chem_storage)
 "clL" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Telecommunications Maintenance"
@@ -25526,14 +25410,14 @@
 /turf/open/floor/plating,
 /area/station/tcommsat/computer)
 "clM" = (
-/obj/machinery/atmospherics/components/binary/pump/on/layer2{
-	dir = 1;
-	name = "Tcomms Sat Waste"
+/obj/effect/turf_decal/tile/electric_yellow{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/station/tcommsat/computer)
+/obj/machinery/camera/autoname/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "clN" = (
-/obj/machinery/atmospherics/components/tank/air,
+/obj/machinery/power/port_gen/pacman,
 /turf/open/floor/plating,
 /area/station/tcommsat/computer)
 "clO" = (
@@ -25555,13 +25439,17 @@
 /turf/open/floor/iron,
 /area/station/tcommsat/computer)
 "clU" = (
-/obj/item/wrench,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/medical/chemistry,
 /turf/open/floor/plating,
-/area/station/tcommsat/computer)
+/area/station/maintenance/department/medical)
 "clV" = (
-/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/item/stack/cable_coil,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/tcommsat/computer)
@@ -25576,16 +25464,14 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/heads_quarters/ce)
 "cmb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/station/tcommsat/computer)
 "cmc" = (
-/obj/item/stack/cable_coil,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/tcommsat/computer)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/medical/treatment_center)
 "cmf" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical,
@@ -27888,7 +27774,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/any/medical/chemistry,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/departmental,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "cBM" = (
@@ -28123,12 +28009,14 @@
 /turf/open/floor/plating,
 /area/station/service/chapel/funeral)
 "cIe" = (
-/obj/machinery/computer/records/medical/laptop,
-/obj/machinery/light/small/directional/north,
-/obj/machinery/airalarm/directional/north,
-/obj/structure/table,
-/turf/open/floor/iron/dark,
-/area/station/medical/abandoned)
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 4
+	},
+/obj/structure/closet/secure_closet/medical1{
+	pixel_x = -3
+	},
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/chem_storage)
 "cIt" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor6"
@@ -28163,6 +28051,11 @@
 /area/station/science/lab)
 "cLB" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "cMa" = (
@@ -28456,13 +28349,11 @@
 /turf/open/floor/iron,
 /area/station/security/office)
 "dcN" = (
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white/smooth_edge{
 	dir = 1
 	},
-/turf/open/floor/iron/white/smooth_corner{
-	dir = 1
-	},
-/area/station/medical/chemistry)
+/area/station/medical/treatment_center)
 "dcQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
@@ -28570,6 +28461,7 @@
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 1
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/white/smooth_edge,
 /area/station/medical/medbay)
 "dkg" = (
@@ -28721,10 +28613,15 @@
 /turf/open/floor/plating,
 /area/station/science/ordnance/burnchamber)
 "dpV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/tcommsat/computer)
+/obj/effect/turf_decal/tile/pine_green/fourcorners,
+/obj/machinery/door/poddoor/shutters/colony_fabricator/preopen{
+	id_tag = "exam"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/medical/treatment_center)
 "dqa" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -28773,7 +28670,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron/white/smooth_large,
-/area/station/medical/chemistry)
+/area/station/maintenance/department/medical)
 "drR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -29235,7 +29132,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white/smooth_large,
-/area/station/medical/chemistry)
+/area/station/maintenance/department/medical)
 "dLY" = (
 /obj/structure/table,
 /obj/item/assembly/igniter,
@@ -29363,19 +29260,8 @@
 "dRj" = (
 /obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
-/obj/effect/spawner/random/epic_loot/chemical{
-	pixel_x = 2;
-	pixel_y = -1
-	},
-/obj/effect/spawner/random/epic_loot/chemical{
-	pixel_x = 11;
-	pixel_y = 12
-	},
-/obj/effect/spawner/random/epic_loot/chemical{
-	pixel_x = -8;
-	pixel_y = 10
-	},
 /obj/structure/table,
+/obj/item/storage/bag/chemistry,
 /turf/open/floor/iron/white/textured_edge{
 	dir = 1
 	},
@@ -29698,7 +29584,7 @@
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1
 	},
-/area/station/medical/chemistry)
+/area/station/maintenance/department/medical)
 "eel" = (
 /obj/structure/table/reinforced/titaniumglass,
 /obj/item/radio/headset/headset_sci,
@@ -29716,7 +29602,7 @@
 "eeW" = (
 /obj/effect/turf_decal/tile/yellow/full,
 /turf/open/floor/iron/white/smooth_large,
-/area/station/medical/chemistry)
+/area/station/maintenance/department/medical)
 "efu" = (
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/iron/dark/small,
@@ -29748,7 +29634,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/smooth_large,
-/area/station/medical/chemistry)
+/area/station/maintenance/department/medical)
 "ehK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -30085,12 +29971,20 @@
 /turf/open/floor/iron/large,
 /area/station/engineering/lobby)
 "eus" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/dark_blue/line{
-	dir = 10
+/obj/machinery/camera/directional/west{
+	c_tag = "Medbay Paramedic Dispatch";
+	network = list("ss13","medbay")
 	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/medical/paramedic)
+/obj/machinery/firealarm/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/medical)
 "euv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/dark/visible{
 	dir = 8
@@ -30170,7 +30064,7 @@
 "ezC" = (
 /obj/structure/chair/office/light,
 /turf/open/floor/iron/white/smooth_large,
-/area/station/medical/chemistry)
+/area/station/maintenance/department/medical)
 "ezF" = (
 /obj/structure/table/wood,
 /obj/item/pen/red,
@@ -30206,7 +30100,7 @@
 	name = "Chemistry"
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/chemistry)
+/area/station/medical/chem_storage)
 "eBf" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 4
@@ -30317,7 +30211,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white/smooth_large,
-/area/station/medical/chemistry)
+/area/station/maintenance/department/medical)
 "eGT" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
@@ -30689,7 +30583,7 @@
 "eWa" = (
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
 /turf/open/floor/iron/white,
-/area/station/medical/chemistry)
+/area/station/maintenance/department/medical)
 "eWl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -30707,11 +30601,13 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "eXa" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/right/directional/south{
+	name = "Security Checkpoint";
+	req_access = list("brig_entrance")
+	},
 /turf/open/floor/plating,
-/area/station/tcommsat/computer)
+/area/station/security/checkpoint/medical)
 "eXo" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/engine,
@@ -30862,15 +30758,17 @@
 /area/station/science/ordnance/testlab)
 "fby" = (
 /obj/structure/sign/poster/official/no_erp/directional/east,
-/obj/structure/chair/office{
-	dir = 1
-	},
-/obj/machinery/light_switch/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
-/area/station/medical/abandoned)
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/glasses/science,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/chem_storage)
 "fcK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -31011,20 +30909,12 @@
 /turf/open/floor/plating,
 /area/station/construction/mining/aux_base)
 "fgs" = (
-/obj/structure/table,
-/obj/item/book/manual/wiki/security_space_law{
-	pixel_x = 3;
-	pixel_y = 4
-	},
-/obj/item/screwdriver{
-	pixel_y = 10
-	},
-/obj/item/radio/off,
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 1
 	},
-/turf/open/floor/iron,
-/area/station/security/checkpoint/medical)
+/obj/machinery/computer/crew,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/paramedic)
 "fgv" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
@@ -31100,7 +30990,7 @@
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 4
 	},
-/area/station/medical/chemistry)
+/area/station/maintenance/department/medical)
 "fhM" = (
 /obj/structure/secure_safe{
 	pixel_x = -22
@@ -31284,7 +31174,7 @@
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 8
 	},
-/area/station/medical/chemistry)
+/area/station/maintenance/department/medical)
 "frq" = (
 /obj/effect/turf_decal/tile/pine_green/full,
 /obj/machinery/light/directional/north,
@@ -31378,13 +31268,8 @@
 /turf/open/floor/iron/terracotta/small,
 /area/station/service/kitchen)
 "ftW" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/pine_green/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/white/smooth_edge,
-/area/station/medical/medbay)
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/chem_storage)
 "ftY" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -31576,6 +31461,7 @@
 	dir = 4
 	},
 /obj/machinery/photocopier,
+/obj/machinery/computer/security/telescreen/entertainment/directional/south,
 /turf/open/floor/wood/large,
 /area/station/command/bridge)
 "fCX" = (
@@ -31629,18 +31515,16 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
-/obj/effect/spawner/random/epic_loot/chemical,
-/obj/effect/spawner/random/epic_loot/chemical{
-	pixel_x = 10;
-	pixel_y = 13
-	},
-/obj/effect/spawner/random/epic_loot/chemical{
-	pixel_x = -7;
-	pixel_y = 11
-	},
 /obj/structure/table,
+/obj/item/storage/box/alchemist_chemistry_kit,
 /turf/open/floor/iron/white/textured,
 /area/station/medical/pharmacy)
+"fEV" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "fFF" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
@@ -32363,6 +32247,11 @@
 /obj/effect/turf_decal/tile/office_blue{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "gmH" = (
@@ -33014,14 +32903,8 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/dark_blue/line{
-	dir = 6
-	},
-/obj/structure/chair/office/light{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/medical/paramedic)
+/turf/open/floor/iron,
+/area/station/security/checkpoint/medical)
 "gNv" = (
 /obj/structure/sign/poster/contraband/random/directional/east,
 /turf/open/floor/iron/stairs/right,
@@ -33097,9 +32980,7 @@
 /area/station/maintenance/department/science/xenobiology)
 "gQU" = (
 /obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal/bin{
-	name = "Corpse Disposal"
-	},
+/obj/machinery/disposal/bin,
 /obj/effect/turf_decal/tile/pine_green/anticorner/contrasted{
 	dir = 1
 	},
@@ -33420,7 +33301,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white/smooth_large,
-/area/station/medical/chemistry)
+/area/station/maintenance/department/medical)
 "hiw" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -33476,12 +33357,13 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "hjy" = (
-/obj/machinery/computer/security,
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 1
 	},
-/turf/open/floor/iron,
-/area/station/security/checkpoint/medical)
+/obj/structure/table/reinforced/rglass,
+/obj/machinery/computer/records/medical/laptop,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/paramedic)
 "hjW" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/structure/railing{
@@ -33954,12 +33836,12 @@
 /area/station/maintenance/disposal)
 "hEC" = (
 /turf/closed/wall/r_wall,
-/area/station/medical/abandoned)
+/area/station/medical/chem_storage)
 "hEF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/tile/yellow/half,
 /turf/open/floor/iron/white/smooth_large,
-/area/station/medical/chemistry)
+/area/station/maintenance/department/medical)
 "hEJ" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
@@ -34383,9 +34265,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "hVJ" = (
-/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/pine_green,
 /obj/effect/landmark/start/hangover,
+/obj/machinery/button/door/directional/south{
+	id_tag = "exam";
+	name = "Entrance Lockdown"
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "hVS" = (
@@ -34445,7 +34330,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white/smooth_large,
-/area/station/medical/chemistry)
+/area/station/maintenance/department/medical)
 "hXt" = (
 /obj/structure/girder,
 /turf/open/floor/plating,
@@ -34771,18 +34656,14 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "ipu" = (
-/obj/machinery/vending/wallmed{
-	pixel_y = 28
-	},
-/obj/item/clothing/neck/stethoscope,
-/obj/item/folder/white,
-/obj/structure/table,
-/turf/open/floor/iron/dark,
-/area/station/medical/abandoned)
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/chem_storage)
 "ipz" = (
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron/white/smooth_corner,
-/area/station/medical/chemistry)
+/area/station/maintenance/department/medical)
 "ipE" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -35105,14 +34986,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "iDT" = (
-/obj/structure/closet/secure_closet/medical2,
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/iron/white/textured_large,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/colony_fabricator/preopen{
+	id_tag = "exam"
+	},
+/turf/open/floor/plating,
 /area/station/medical/treatment_center)
 "iDV" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Cargo Bay"
 	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/east,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "iDX" = (
@@ -35483,9 +35367,8 @@
 /turf/open/floor/wood/large,
 /area/station/command/bridge)
 "iWQ" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
-/turf/open/floor/plating,
-/area/station/medical/treatment_center)
+/turf/open/space/basic,
+/area/station/tcommsat/computer)
 "iWV" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -35527,7 +35410,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white/smooth_large,
-/area/station/medical/chemistry)
+/area/station/maintenance/department/medical)
 "iZo" = (
 /obj/machinery/airalarm/directional/south,
 /obj/effect/landmark/start/bitrunner,
@@ -35687,11 +35570,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "jfg" = (
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 1
-	},
-/turf/open/floor/iron/white/smooth_edge,
-/area/station/medical/chemistry)
+/turf/open/space/basic,
+/area/station/maintenance/department/medical)
 "jgr" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Library"
@@ -35716,9 +35596,7 @@
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/surgery/theatre)
 "jhd" = (
-/obj/item/wallframe/telescreen/entertainment{
-	pixel_x = 32
-	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/east,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/cryo)
 "jhk" = (
@@ -35846,9 +35724,12 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/storage_shared)
 "jlc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
-/turf/closed/wall/r_wall,
-/area/station/tcommsat/computer)
+/obj/structure/cable,
+/obj/structure/sign/departments/telecomms/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "jmr" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -36098,16 +35979,11 @@
 /turf/open/floor/iron/white/smooth_half,
 /area/station/science/xenobiology)
 "jyJ" = (
-/obj/structure/closet/secure_closet/medical1{
-	pixel_x = -3
-	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 4
-	},
+/obj/structure/table,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 8
 	},
-/area/station/medical/chemistry)
+/area/station/medical/chem_storage)
 "jze" = (
 /turf/closed/wall,
 /area/station/medical/paramedic)
@@ -36207,7 +36083,7 @@
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1
 	},
-/area/station/medical/chemistry)
+/area/station/maintenance/department/medical)
 "jCH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -37618,10 +37494,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/yellow/full,
 /turf/open/floor/iron/white/smooth_large,
-/area/station/medical/chemistry)
+/area/station/maintenance/department/medical)
 "kHO" = (
 /obj/structure/bed/dogbed/renault,
 /mob/living/basic/pet/fox/renault,
+/obj/machinery/computer/security/telescreen/entertainment/directional/east,
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/captain)
 "kHP" = (
@@ -38343,7 +38220,7 @@
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 4
 	},
-/area/station/medical/chemistry)
+/area/station/maintenance/department/medical)
 "lnw" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/machinery/requests_console/directional/north{
@@ -38389,7 +38266,7 @@
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 8
 	},
-/area/station/medical/chemistry)
+/area/station/maintenance/department/medical)
 "lpW" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -38596,7 +38473,7 @@
 /obj/effect/turf_decal/tile/dark_blue/opposingcorners,
 /obj/structure/table/reinforced,
 /turf/open/floor/iron/white,
-/area/station/medical/paramedic)
+/area/station/security/checkpoint/medical)
 "lyd" = (
 /obj/effect/landmark/start/security_officer,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
@@ -38739,11 +38616,9 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "lEs" = (
-/obj/effect/turf_decal/trimline/dark_blue/line{
-	dir = 5
-	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/medical/paramedic)
+/obj/effect/landmark/start/depsec/medical,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/medical)
 "lFb" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -38758,7 +38633,7 @@
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 4
 	},
-/area/station/medical/chemistry)
+/area/station/maintenance/department/medical)
 "lFh" = (
 /obj/machinery/holopad,
 /obj/structure/cable,
@@ -39394,7 +39269,7 @@
 "mhF" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
-/area/station/medical/chemistry)
+/area/station/medical/chem_storage)
 "mhL" = (
 /obj/structure/cable,
 /obj/structure/extinguisher_cabinet/directional/north,
@@ -39593,7 +39468,7 @@
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 8
 	},
-/area/station/medical/chemistry)
+/area/station/maintenance/department/medical)
 "mql" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
 	dir = 9
@@ -39756,7 +39631,7 @@
 "mwc" = (
 /obj/effect/turf_decal/siding/corner,
 /turf/open/floor/iron/white/smooth_large,
-/area/station/medical/chemistry)
+/area/station/maintenance/department/medical)
 "mwg" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -39968,7 +39843,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white/smooth_large,
-/area/station/medical/chemistry)
+/area/station/maintenance/department/medical)
 "mGK" = (
 /obj/structure/table,
 /obj/structure/disposalpipe/segment{
@@ -40143,7 +40018,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/chemistry)
+/area/station/maintenance/department/medical)
 "mOH" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
@@ -40969,12 +40844,11 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "nAh" = (
-/obj/effect/turf_decal/tile/dark_blue/half/contrasted,
+/obj/effect/turf_decal/tile/red/half/contrasted,
 /obj/machinery/light/small/directional/south,
-/turf/open/floor/iron/dark/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/paramedic)
+/obj/structure/maintenance_loot_structure/file_cabinet/random,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/medical)
 "nAF" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/dark,
@@ -41191,7 +41065,12 @@
 /area/station/science/xenobiology)
 "nKE" = (
 /turf/open/floor/iron/white/smooth_large,
-/area/station/medical/chemistry)
+/area/station/maintenance/department/medical)
+"nKM" = (
+/obj/structure/table,
+/obj/item/hand_labeler,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/chem_storage)
 "nKU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -41340,8 +41219,13 @@
 /area/station/science/ordnance/storage)
 "nSe" = (
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/security/checkpoint/medical)
+/obj/effect/landmark/start/paramedic,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/paramedic)
 "nSz" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -41960,7 +41844,7 @@
 	},
 /obj/item/wrench/medical,
 /turf/open/floor/engine,
-/area/station/medical/chemistry)
+/area/station/maintenance/department/medical)
 "oon" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -42869,11 +42753,9 @@
 /turf/open/floor/iron/dark,
 /area/station/service/abandoned_gambling_den/gaming)
 "oWN" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/obj/structure/table,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/chem_storage)
 "oXp" = (
 /obj/machinery/requests_console/directional/east{
 	department = "Medical";
@@ -42887,9 +42769,7 @@
 /area/station/medical/morgue)
 "oXR" = (
 /obj/effect/landmark/start/hangover,
-/obj/item/wallframe/telescreen/entertainment{
-	pixel_y = -32
-	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/south,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "oXU" = (
@@ -42900,11 +42780,8 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/medbay)
 "oXV" = (
-/obj/structure/chair{
-	dir = 8
-	},
 /turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/area/station/tcommsat/computer)
 "oYc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -43155,15 +43032,13 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "phx" = (
-/obj/effect/landmark/blobstart,
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
-/area/station/medical/abandoned)
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/chem_storage)
 "phY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -43208,9 +43083,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/psychology)
 "pjB" = (
-/obj/machinery/disposal/bin{
-	name = "Corpse Disposal"
-	},
+/obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
@@ -43426,7 +43299,7 @@
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1
 	},
-/area/station/medical/chemistry)
+/area/station/maintenance/department/medical)
 "prI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 4;
@@ -43631,13 +43504,9 @@
 /turf/open/floor/plating,
 /area/station/engineering/storage_shared)
 "pAo" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "pAM" = (
 /obj/structure/chair/stool/bar/directional/west,
@@ -43742,10 +43611,10 @@
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/medical/morgue)
 "pEK" = (
-/obj/structure/cable,
-/obj/structure/sign/departments/telecomms/directional/south,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/obj/effect/turf_decal/tile/pine_green,
+/obj/effect/turf_decal/caution/stand_clear/red,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "pFy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -44714,8 +44583,8 @@
 /turf/open/floor/plating,
 /area/station/service/chapel/dock)
 "qnJ" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Medbay Security Post"
+/obj/machinery/door/airlock/command/glass{
+	name = "Paramedic Dispatch Room"
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -44723,11 +44592,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /turf/open/floor/iron/white/side{
 	dir = 8
 	},
-/area/station/security/checkpoint/medical)
+/area/station/medical/paramedic)
 "qnQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -44996,7 +44865,7 @@
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 8
 	},
-/area/station/medical/chemistry)
+/area/station/maintenance/department/medical)
 "qwS" = (
 /obj/effect/turf_decal/siding{
 	dir = 4
@@ -45026,10 +44895,16 @@
 /turf/open/floor/carpet/black,
 /area/station/service/chapel/office)
 "qxq" = (
-/obj/machinery/light/small/directional/east,
-/obj/machinery/atmospherics/components/binary/pump/on{
-	name = "Air Out"
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
 	},
+/obj/machinery/door/airlock/external{
+	name = "Telecommunications External Access"
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/tcommsat/computer)
 "qxE" = (
@@ -45708,8 +45583,11 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "rcF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
-/turf/open/floor/plating/airless,
+/obj/machinery/light/small/directional/west,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
 /area/station/tcommsat/computer)
 "rdU" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
@@ -45857,6 +45735,7 @@
 "rkq" = (
 /obj/effect/turf_decal/tile/pine_green,
 /obj/machinery/firealarm/directional/south,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "rkZ" = (
@@ -46199,8 +46078,8 @@
 /area/station/service/library)
 "rvH" = (
 /obj/structure/closet/crate/freezer/surplus_limbs,
-/obj/machinery/light/directional/north,
 /obj/structure/window/spawner/directional/east,
+/obj/machinery/camera/autoname/motion/directional/north,
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/treatment_center)
 "rvO" = (
@@ -46533,13 +46412,8 @@
 /area/station/cargo/bitrunning/den)
 "rIm" = (
 /obj/machinery/newscaster/directional/east,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 8
-	},
-/area/station/medical/chemistry)
+/turf/closed/wall,
+/area/station/maintenance/department/medical)
 "rIZ" = (
 /obj/machinery/airalarm/directional/north,
 /obj/structure/rack,
@@ -47461,7 +47335,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white/smooth_large,
-/area/station/medical/chemistry)
+/area/station/maintenance/department/medical)
 "ssk" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -47759,7 +47633,7 @@
 "sAE" = (
 /obj/effect/turf_decal/tile/yellow/half,
 /turf/open/floor/iron/white/smooth_large,
-/area/station/medical/chemistry)
+/area/station/maintenance/department/medical)
 "sAK" = (
 /obj/item/clothing/mask/gas/plaguedoctor,
 /turf/open/floor/plating,
@@ -47983,7 +47857,7 @@
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/bureaucracy/pen,
 /turf/open/floor/iron/white,
-/area/station/medical/paramedic)
+/area/station/security/checkpoint/medical)
 "sLD" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -48014,7 +47888,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white/smooth_large,
-/area/station/medical/chemistry)
+/area/station/maintenance/department/medical)
 "sNk" = (
 /obj/effect/turf_decal/tile/dark_green/half/contrasted{
 	dir = 1
@@ -48043,6 +47917,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"sOb" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/medical/chemistry,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "sOB" = (
 /turf/closed/wall,
 /area/station/medical/psychology)
@@ -48449,17 +48328,17 @@
 /turf/open/floor/engine,
 /area/station/science/ordnance/storage)
 "tcV" = (
-/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+/obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
-/area/station/medical/paramedic)
+/turf/open/floor/iron,
+/area/station/security/checkpoint/medical)
 "tcX" = (
 /obj/effect/turf_decal/tile/yellow/half{
 	dir = 4
 	},
 /turf/open/floor/iron/white/smooth_large,
-/area/station/medical/chemistry)
+/area/station/maintenance/department/medical)
 "tcY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -48538,6 +48417,8 @@
 /area/station/commons/dorms)
 "teJ" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "teN" = (
@@ -48640,6 +48521,7 @@
 /obj/effect/turf_decal/tile/pine_green/half{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 8
 	},
@@ -48950,12 +48832,9 @@
 /turf/open/floor/iron,
 /area/station/security/eva)
 "tta" = (
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/white/smooth_edge,
-/area/station/medical/chemistry)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/tcommsat/computer)
 "ttA" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/incinerator_input{
 	dir = 8
@@ -49129,7 +49008,7 @@
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 4
 	},
-/area/station/medical/chemistry)
+/area/station/maintenance/department/medical)
 "txZ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -49154,10 +49033,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/noticeboard{
-	pixel_y = 32
-	},
 /obj/machinery/photocopier,
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /turf/open/floor/iron/kitchen/small,
 /area/station/medical/medbay/central)
 "tyz" = (
@@ -49414,13 +49291,18 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "tIx" = (
-/obj/item/hand_labeler,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 4
-	},
 /obj/structure/table,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/clothing/head/utility/welding,
 /turf/open/floor/iron/white,
-/area/station/medical/chemistry)
+/area/station/medical/chem_storage)
+"tIK" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/turf/open/floor/grass,
+/area/station/medical/paramedic)
 "tIQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -49462,14 +49344,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/yellow/full,
 /turf/open/floor/iron/white/smooth_large,
-/area/station/medical/chemistry)
+/area/station/maintenance/department/medical)
 "tLk" = (
-/obj/effect/turf_decal/trimline/dark_blue/line{
-	dir = 1
-	},
-/obj/effect/landmark/start/paramedic,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/medical/paramedic)
+/turf/open/floor/iron,
+/area/station/security/checkpoint/medical)
 "tLA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -49660,6 +49538,11 @@
 	},
 /turf/open/floor/iron/white/textured,
 /area/station/engineering/atmos/hfr_room)
+"tTd" = (
+/obj/item/wrench,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/tcommsat/computer)
 "tTB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -49912,7 +49795,7 @@
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 8
 	},
-/area/station/medical/chemistry)
+/area/station/maintenance/department/medical)
 "uea" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Research Division"
@@ -50097,7 +49980,7 @@
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 4
 	},
-/area/station/medical/chemistry)
+/area/station/maintenance/department/medical)
 "uiP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -50187,7 +50070,7 @@
 /obj/effect/turf_decal/tile/dark_blue/opposingcorners,
 /obj/structure/table/reinforced,
 /turf/open/floor/iron/white,
-/area/station/medical/paramedic)
+/area/station/security/checkpoint/medical)
 "ulu" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -50294,14 +50177,26 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "uqf" = (
-/obj/machinery/vending/wardrobe/chem_wardrobe,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
+	},
+/obj/structure/table,
+/obj/item/reagent_containers/cup/bottle/random_buffer{
+	pixel_x = 10;
+	pixel_y = 12
+	},
+/obj/item/reagent_containers/cup/bottle/random_buffer{
+	pixel_x = 1;
+	pixel_y = 12
+	},
+/obj/item/reagent_containers/cup/bottle/random_buffer{
+	pixel_x = -9;
+	pixel_y = 12
 	},
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 4
 	},
-/area/station/medical/chemistry)
+/area/station/medical/chem_storage)
 "uqs" = (
 /obj/structure/flora/bush/large/style_random,
 /turf/open/floor/grass,
@@ -50547,10 +50442,10 @@
 /turf/open/floor/iron,
 /area/station/tcommsat/computer)
 "uzr" = (
-/obj/machinery/photocopier,
-/obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted,
-/turf/open/floor/iron/dark,
-/area/station/medical/paramedic)
+/obj/effect/turf_decal/tile/red/anticorner/contrasted,
+/obj/structure/closet/secure_closet/security/med,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/medical)
 "uzx" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Genetics Maintenance"
@@ -51084,6 +50979,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
+/obj/machinery/holopad,
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/treatment_center)
 "uVN" = (
@@ -51269,14 +51166,18 @@
 /turf/open/floor/iron,
 /area/station/security/eva)
 "vaR" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/dark_blue/line{
-	dir = 9
+/obj/machinery/computer/records/security{
+	dir = 4
 	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/medical/paramedic)
+/obj/machinery/computer/security/telescreen/entertainment/directional/west,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/medical)
 "vaS" = (
 /obj/structure/chair/wood,
 /turf/open/floor/iron/chapel,
@@ -51334,11 +51235,12 @@
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
 "veb" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/white/smooth_edge,
-/area/station/medical/chemistry)
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/floor/grass,
+/area/station/medical/paramedic)
 "vek" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -51386,9 +51288,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/machinery/disposal/bin{
-	name = "Corpse Disposal"
-	},
+/obj/machinery/disposal/bin,
 /obj/effect/turf_decal/tile/pine_green/anticorner/contrasted{
 	dir = 8
 	},
@@ -51552,9 +51452,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/machinery/disposal/bin{
-	name = "Corpse Disposal"
-	},
+/obj/machinery/disposal/bin,
 /obj/effect/turf_decal/tile/pine_green/half/contrasted{
 	dir = 8
 	},
@@ -52197,14 +52095,11 @@
 	normaldoorcontrol = 1;
 	req_access = list("medical")
 	},
-/obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted{
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 8
 	},
-/obj/machinery/computer/records/medical{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/medical/paramedic)
+/turf/open/floor/iron,
+/area/station/security/checkpoint/medical)
 "vQo" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Cargo Office Maintenance"
@@ -52371,8 +52266,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "vTg" = (
-/turf/closed/wall,
-/area/station/medical/abandoned)
+/obj/structure/closet/secure_closet/chemical,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/chem_storage)
 "vTL" = (
 /obj/machinery/vending/tool,
 /turf/open/floor/iron/dark,
@@ -52503,6 +52399,7 @@
 /area/station/science/xenobiology)
 "vZw" = (
 /obj/machinery/firealarm/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/treatment_center)
 "vZJ" = (
@@ -53794,7 +53691,8 @@
 /area/space/nearstation)
 "wUf" = (
 /obj/structure/closet/secure_closet/medical2,
-/obj/item/radio/intercom/directional/west,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/treatment_center)
 "wUz" = (
@@ -54458,8 +54356,11 @@
 "xmg" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/security/checkpoint/medical)
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/paramedic)
 "xmE" = (
 /obj/structure/chair{
 	dir = 8
@@ -54481,8 +54382,7 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "xnm" = (
-/obj/machinery/power/port_gen/pacman,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
 /area/station/tcommsat/computer)
 "xnp" = (
@@ -54584,9 +54484,6 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "xsa" = (
-/obj/effect/turf_decal/tile/pine_green{
-	dir = 4
-	},
 /turf/open/floor/iron/white/smooth_corner{
 	dir = 4
 	},
@@ -54619,10 +54516,12 @@
 	},
 /area/station/maintenance/department/science/xenobiology)
 "xsT" = (
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/machinery/holopad,
-/turf/open/floor/iron,
-/area/station/security/checkpoint/medical)
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/paramedic)
 "xsZ" = (
 /obj/structure/maintenance_loot_structure/large_crate/medical,
 /turf/open/floor/plating,
@@ -55026,14 +54925,11 @@
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "xIP" = (
-/obj/effect/turf_decal/tile/dark_blue{
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/structure/chair/office/light,
-/turf/open/floor/iron/dark/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/paramedic)
+/turf/open/floor/iron,
+/area/station/security/checkpoint/medical)
 "xIZ" = (
 /turf/closed/wall,
 /area/station/medical/surgery/theatre)
@@ -55641,7 +55537,7 @@
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1
 	},
-/area/station/medical/chemistry)
+/area/station/maintenance/department/medical)
 "ygW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -81850,8 +81746,8 @@ bfk
 bdm
 dyg
 sMg
-bik
-iWQ
+bzX
+dYh
 bjW
 blc
 tgT
@@ -82365,7 +82261,7 @@ bdm
 dyg
 sMg
 bik
-dYh
+iDT
 bjS
 tgd
 nUo
@@ -82621,12 +82517,12 @@ bfm
 xPQ
 dyg
 sMg
-bik
-dYh
+pEK
+clD
 bjT
 hfw
 gnS
-pAo
+gnS
 lpW
 yhR
 kAD
@@ -82703,6 +82599,30 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 abI
 aaa
 aaa
@@ -82719,30 +82639,6 @@ aaa
 aaa
 aaa
 abI
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -82878,13 +82774,13 @@ bfn
 bdm
 dyg
 sMg
-bik
-dYh
-bjU
-qwS
-jJm
-aFM
-uQu
+pEK
+dpV
+bjT
+pAo
+cmc
+pAo
+dcN
 xsa
 xUU
 uFc
@@ -82958,6 +82854,30 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 adR
 adR
 adR
@@ -82980,30 +82900,6 @@ adR
 adR
 aaa
 adR
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -83136,13 +83032,13 @@ aRL
 dyg
 sMg
 bik
-dYh
+iDT
 bjV
-blf
-idj
-tCi
-xQO
-bpF
+qwS
+jJm
+aFM
+uQu
+bli
 ktU
 uFc
 buc
@@ -83217,6 +83113,30 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 abI
 aaa
 aaa
@@ -83237,30 +83157,6 @@ aaa
 aaa
 aaa
 adR
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -83393,12 +83289,12 @@ kEM
 eZv
 sMg
 bik
-iWQ
-bjW
-tgT
-cRi
-bny
-gHm
+dYh
+awW
+clA
+idj
+tCi
+xQO
 bpF
 tZX
 uFc
@@ -83469,6 +83365,30 @@ abI
 abI
 abI
 abI
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
 abI
 abI
 abI
@@ -83495,30 +83415,6 @@ cmB
 cny
 adR
 abI
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -83651,11 +83547,11 @@ aDm
 sMg
 rkq
 dYh
-iDT
+bjW
 tgT
-pku
-qib
-iGi
+cRi
+bny
+gHm
 anB
 anD
 hMt
@@ -83729,6 +83625,30 @@ cig
 cgP
 cgP
 cgP
+cgP
+cig
+cgP
+cgP
+cgP
+cgP
+cig
+cgP
+cgP
+cgP
+cgP
+cig
+cgP
+cgP
+cgP
+cgP
+cig
+cgP
+cgP
+cgP
+cig
+cgP
+cgP
+cgP
 clC
 clH
 clP
@@ -83751,30 +83671,6 @@ cnr
 cmB
 aaa
 adR
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -83907,13 +83803,13 @@ dyg
 tWc
 sMg
 bin
-jze
-jze
-jze
-jze
-jze
-jze
-ftW
+dYh
+bCp
+tgT
+pku
+qib
+iGi
+bpF
 xUU
 bsF
 fhc
@@ -83983,7 +83879,31 @@ teJ
 teJ
 teJ
 teJ
-pEK
+teJ
+teJ
+teJ
+teJ
+teJ
+teJ
+teJ
+teJ
+teJ
+teJ
+teJ
+teJ
+teJ
+teJ
+teJ
+teJ
+teJ
+teJ
+teJ
+teJ
+teJ
+teJ
+teJ
+teJ
+jlc
 clw
 clw
 clw
@@ -84008,30 +83928,6 @@ cns
 cmB
 aaa
 adR
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -84164,12 +84060,12 @@ aRN
 dyg
 sMg
 bik
-jze
-bjY
-bli
-awW
-bnB
-boF
+bja
+bja
+bja
+bja
+bja
+bja
 djh
 xte
 bIy
@@ -84180,7 +84076,7 @@ oXU
 gKB
 tli
 peY
-bCp
+bjc
 jfg
 nKE
 egX
@@ -84217,7 +84113,7 @@ rCm
 cgs
 cgQ
 chv
-teJ
+fEV
 aht
 aaa
 aht
@@ -84240,11 +84136,35 @@ aaa
 aaa
 aaa
 aaa
-teJ
-clA
-clD
-clJ
-bJc
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+fEV
+boF
+rcF
+qxq
+bjY
 clY
 gmH
 cmh
@@ -84265,30 +84185,6 @@ cnt
 cmB
 aaa
 adR
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -84421,12 +84317,12 @@ bgk
 dyg
 sMg
 aNb
-jze
+yat
 bjZ
 vaR
 eus
 bnD
-jze
+bjU
 brg
 sgD
 cqd
@@ -84434,11 +84330,11 @@ cqd
 bvn
 cqd
 byt
-bzX
+cqd
 bIi
 wLW
-bCp
-veb
+bjc
+jfg
 drQ
 sMx
 tcX
@@ -84497,12 +84393,36 @@ aaa
 aaa
 aaa
 bBW
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 iBJ
 clw
 hQz
 nTk
 jCr
-dpV
+cmb
 kCI
 nTk
 nMG
@@ -84523,30 +84443,6 @@ cmB
 bfr
 adR
 abI
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -84678,23 +84574,23 @@ bgk
 dyg
 sMg
 fih
-jze
+eXa
 bka
 tLk
 bmv
 nAh
-jze
+bja
 bpQ
 qqQ
 qEf
 bug
 bvo
 xQr
-bja
-bja
+jze
+jze
 qnJ
-bja
-bja
+jze
+jze
 bLs
 hEF
 tKY
@@ -84754,12 +84650,36 @@ aaa
 aaa
 aaa
 aaa
-bgl
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+iWQ
 clw
 nTk
 nTk
 clL
-eXa
+clG
 ugv
 nTk
 cmj
@@ -84779,30 +84699,6 @@ eel
 cmB
 aaa
 adR
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -84934,8 +84830,8 @@ cpz
 bgk
 dyg
 sMg
-bik
-jze
+aNb
+yat
 boH
 lEs
 gMY
@@ -84947,12 +84843,12 @@ hZH
 hZH
 bvl
 bwO
-yat
+bJc
 bzZ
 bsJ
 bCr
-bja
-tta
+jze
+jfg
 sAE
 eeW
 eeW
@@ -85011,12 +84907,36 @@ aaa
 aaa
 aaa
 aaa
-rcF
-jlc
-xnm
-clM
-clU
-cmb
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+iWQ
+clw
+clN
+oXV
+tTd
+oXV
 mxy
 nTk
 qPu
@@ -85036,30 +84956,6 @@ cnw
 cmB
 aaa
 adR
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -85192,9 +85088,9 @@ bgk
 eZv
 sMg
 bik
-jze
+bja
 bkc
-bll
+tcV
 bmw
 tcV
 uzr
@@ -85204,12 +85100,12 @@ jWH
 nYu
 oSa
 gfH
-yat
+bgl
 fgs
 xmg
 buk
-bja
-veb
+jze
+jfg
 sAE
 eeW
 eeW
@@ -85268,12 +85164,36 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 abI
 clw
-clN
-qxq
+oXV
+xnm
+tta
 clV
-cmc
 mDW
 nTk
 cml
@@ -85293,30 +85213,6 @@ cnx
 cmB
 aaa
 adR
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -85449,24 +85345,24 @@ bgk
 dyg
 sMg
 bik
-jze
-jze
+bja
+bja
 lxx
 sLv
 ulq
-jze
-jze
+bja
+bja
 vII
 frX
 dRU
 gzG
 brh
-yat
+blf
 brl
 bsL
 bFl
-bja
-veb
+jze
+jfg
 sAE
 eeW
 eeW
@@ -85525,6 +85421,30 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 abI
 clw
 clw
@@ -85551,30 +85471,6 @@ cmB
 cnz
 adR
 abI
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -85718,12 +85614,12 @@ bsH
 blo
 crd
 gfH
-yat
+veb
 hjy
 nSe
 xsT
-yat
-veb
+jze
+jfg
 sAE
 eeW
 eeW
@@ -85787,6 +85683,30 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 abI
 aaa
 aaa
@@ -85807,30 +85727,6 @@ aaa
 aaa
 aaa
 adR
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -85975,12 +85871,12 @@ mZi
 wEl
 bvp
 xTf
-yat
+tIK
 brm
 bsN
 bCv
-yat
-veb
+jze
+jfg
 sAE
 eeW
 eeW
@@ -86042,6 +85938,30 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 adR
 adR
 adR
@@ -86064,30 +85984,6 @@ adR
 adR
 aaa
 adR
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -86232,12 +86128,12 @@ bpY
 bpY
 qgA
 bpY
-bja
-bja
-bja
-bja
-bja
-tta
+jze
+jze
+jze
+jze
+jze
+jfg
 eGL
 iZl
 iZl
@@ -86301,6 +86197,30 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 abI
 aaa
 aaa
@@ -86317,30 +86237,6 @@ aaa
 aaa
 aaa
 abI
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -86494,7 +86390,7 @@ bAe
 uqf
 bCx
 byw
-dcN
+oJj
 nKE
 nKE
 nKE
@@ -86748,10 +86644,10 @@ xHJ
 bwT
 eBd
 bsK
-nKE
-nKE
-nKE
-nKE
+ftW
+ftW
+clJ
+sOb
 nKE
 nKE
 nKE
@@ -87262,15 +87158,15 @@ pxw
 dRj
 hEC
 vTg
-vTg
+ftW
+oWN
 oJj
 oJj
 oJj
 oJj
 oJj
 oJj
-oJj
-oJj
+bll
 oJj
 oJj
 oJj
@@ -87521,7 +87417,7 @@ hEC
 ipu
 phx
 azR
-eMp
+clU
 eMp
 eMp
 eMp
@@ -87777,9 +87673,9 @@ lRN
 hEC
 cIe
 fby
+nKM
 oJj
 eMp
-oXV
 oJj
 oJj
 oJj
@@ -88035,12 +87931,12 @@ oJj
 oJj
 oJj
 wqF
-hop
 oJj
+hop
 oJj
 jCv
 bOK
-sAC
+clM
 ery
 sAC
 bIT
@@ -88292,7 +88188,7 @@ gVk
 gVk
 gVk
 uQB
-oWN
+cLB
 cLB
 bFq
 gmv
@@ -91599,7 +91495,7 @@ swT
 swT
 swT
 aXr
-swT
+bnB
 mvJ
 swT
 swT

--- a/_maps/map_files/Pubbystation/pubbystation.dmm
+++ b/_maps/map_files/Pubbystation/pubbystation.dmm
@@ -13789,7 +13789,6 @@
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 1
 	},
-/obj/effect/spawner/random/trash/grime,
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
 "bgW" = (
@@ -13808,7 +13807,6 @@
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 1
 	},
-/obj/effect/spawner/random/trash/grime,
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
 "bgX" = (
@@ -14090,7 +14088,6 @@
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
 "bic" = (
-/obj/effect/spawner/random/trash/grime,
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
 "bie" = (
@@ -14244,7 +14241,6 @@
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/brown/half/contrasted,
-/obj/effect/spawner/random/trash/grime,
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
 "biO" = (
@@ -30385,7 +30381,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/effect/spawner/random/trash/grime,
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "eNW" = (
@@ -36660,10 +36655,6 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/station/hallway/primary/aft)
-"jXz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/turf/closed/wall/r_wall,
-/area/station/engineering/atmos)
 "jXA" = (
 /obj/structure/table,
 /obj/item/stack/ore/iron,
@@ -38979,7 +38970,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/spawner/random/trash/grime,
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "lRD" = (
@@ -40727,6 +40717,10 @@
 /obj/structure/tank_dispenser,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/science/ordnance/testlab)
+"noR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos)
 "noT" = (
 /obj/effect/spawner/random/epic_loot/random_maint_loot_structure,
 /turf/open/floor/plating,
@@ -41909,7 +41903,6 @@
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 4
 	},
-/obj/effect/spawner/random/trash/grime,
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
 "omR" = (
@@ -44641,7 +44634,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/spawner/random/trash/grime,
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "qkf" = (
@@ -48187,6 +48179,11 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
+"sRP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "sSd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/plating,
@@ -49097,11 +49094,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/abandoned_gambling_den)
-"tvq" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
 "tvr" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
@@ -52280,7 +52272,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/spawner/random/trash/grime,
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "vPa" = (
@@ -91006,7 +90997,7 @@ xhP
 xhP
 qbv
 mkS
-tvq
+sRP
 bZL
 caC
 jOk
@@ -91777,7 +91768,7 @@ bOk
 wCz
 mvA
 qIz
-jXz
+noR
 bZL
 bJP
 bJP
@@ -92805,7 +92796,7 @@ pyH
 wCz
 pyH
 mkS
-tvq
+sRP
 abI
 bJP
 bJP

--- a/_maps/map_files/Pubbystation/pubbystation.dmm
+++ b/_maps/map_files/Pubbystation/pubbystation.dmm
@@ -4922,9 +4922,8 @@
 /turf/closed/wall,
 /area/station/command/heads_quarters/captain)
 "auI" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/iron/white,
 /area/station/engineering/atmos/hfr_room)
 "auJ" = (
 /obj/structure/disposalpipe/segment,
@@ -14384,8 +14383,8 @@
 /obj/structure/window/spawner/directional/west,
 /obj/machinery/camera/autoname/motion/directional/north,
 /obj/machinery/button/door/directional/north{
-	id_tag = "exam";
-	name = "Entrance Lockdown"
+	name = "Entrance Lockdown";
+	id = "exam"
 	},
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/treatment_center)
@@ -27930,12 +27929,6 @@
 	dir = 8
 	},
 /area/station/engineering/main)
-"cDx" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/engineering/atmos/hfr_room)
 "cEI" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/cup/soda_cans/dr_gibb,
@@ -28238,13 +28231,6 @@
 	},
 /turf/open/floor/iron/white/small,
 /area/station/science/research)
-"cTn" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/blue/half/contrasted,
-/turf/open/floor/iron/white/textured_edge{
-	dir = 1
-	},
-/area/station/engineering/atmos/hfr_room)
 "cTr" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -28903,6 +28889,13 @@
 "dAa" = (
 /turf/closed/wall/r_wall,
 /area/station/security/lockers)
+"dAd" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/turf/open/floor/iron/white/textured_edge{
+	dir = 1
+	},
+/area/station/engineering/atmos/hfr_room)
 "dAF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -33183,6 +33176,13 @@
 "gZl" = (
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/medbay/central)
+"gZm" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white/textured_edge,
+/area/station/engineering/atmos/hfr_room)
 "gZx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -34309,8 +34309,8 @@
 /obj/effect/turf_decal/tile/pine_green,
 /obj/effect/landmark/start/hangover,
 /obj/machinery/button/door/directional/south{
-	id_tag = "exam";
-	name = "Entrance Lockdown"
+	name = "Entrance Lockdown";
+	id = "exam"
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
@@ -35107,6 +35107,13 @@
 /obj/item/reagent_containers/cup/bucket,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/storage_shared)
+"iFR" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/structure/cable,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/engineering/atmos/hfr_room)
 "iGi" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/window/spawner/directional/south,
@@ -36213,12 +36220,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "jFQ" = (
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 1
-	},
 /obj/structure/cable,
-/obj/machinery/light/dim/directional/west,
-/turf/open/floor/iron/white/textured,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white/textured_edge{
+	dir = 4
+	},
 /area/station/engineering/atmos/hfr_room)
 "jFW" = (
 /obj/structure/maintenance_loot_structure/grenade_box/random,
@@ -37631,9 +37639,13 @@
 /turf/open/floor/plating,
 /area/station/security/range)
 "kJU" = (
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
 /obj/structure/cable,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white/textured_edge{
+	dir = 4
+	},
 /area/station/engineering/atmos/hfr_room)
 "kKf" = (
 /obj/item/kirbyplants/organic/plant8,
@@ -38702,7 +38714,7 @@
 "lEX" = (
 /obj/effect/turf_decal/tile/pine_green/fourcorners,
 /obj/machinery/door/poddoor/shutters/colony_fabricator/preopen{
-	id_tag = "exam"
+	id = "exam"
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white/smooth_edge{
@@ -39078,15 +39090,6 @@
 "lWy" = (
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
-"lWD" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white/textured_edge{
-	dir = 4
-	},
-/area/station/engineering/atmos/hfr_room)
 "lWJ" = (
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/storage_shared)
@@ -45056,13 +45059,6 @@
 /obj/structure/flora/bush/grassy/style_random,
 /turf/open/floor/grass,
 /area/station/hallway/primary/central/fore)
-"qyg" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white/textured_edge,
-/area/station/engineering/atmos/hfr_room)
 "qyz" = (
 /obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 8;
@@ -45733,7 +45729,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /obj/machinery/door/poddoor/shutters/colony_fabricator/preopen{
-	id_tag = "exam"
+	id = "exam"
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
@@ -45830,13 +45826,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
 /area/station/maintenance/department/engine)
-"ric" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted,
-/obj/structure/cable,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/engineering/atmos/hfr_room)
 "rie" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -49004,6 +48993,14 @@
 /obj/effect/turf_decal/tile/dark/diagonal_edge,
 /turf/open/floor/iron/white/diagonal,
 /area/station/ai_monitored/turret_protected/ai_upload)
+"tsh" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 8
+	},
+/obj/machinery/light/dim/directional/west,
+/turf/open/floor/iron/white/textured,
+/area/station/engineering/atmos/hfr_room)
 "tsq" = (
 /obj/structure/cable,
 /obj/structure/table,
@@ -49712,12 +49709,10 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "tSV" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 8
-	},
-/obj/machinery/light/dim/directional/west,
-/turf/open/floor/iron/white/textured,
+/turf/open/floor/plating,
 /area/station/engineering/atmos/hfr_room)
 "tTB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -50430,6 +50425,14 @@
 /obj/effect/turf_decal/siding/wood/corner,
 /turf/open/floor/iron/white/smooth_edge,
 /area/station/command/bridge)
+"utj" = (
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/light/dim/directional/west,
+/turf/open/floor/iron/white/textured,
+/area/station/engineering/atmos/hfr_room)
 "utT" = (
 /obj/effect/spawner/random/glass_debris,
 /obj/structure/window/reinforced/spawner/directional/east,
@@ -51058,13 +51061,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "uTc" = (
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white/textured_edge{
-	dir = 4
-	},
+/turf/open/floor/iron/white,
 /area/station/engineering/atmos/hfr_room)
 "uTt" = (
 /obj/machinery/firealarm/directional/north,
@@ -53587,7 +53586,7 @@
 "wJL" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/colony_fabricator/preopen{
-	id_tag = "exam"
+	id = "exam"
 	},
 /turf/open/floor/plating,
 /area/station/medical/treatment_center)
@@ -53765,8 +53764,9 @@
 /turf/open/floor/carpet/red,
 /area/station/medical/psychology)
 "wQE" = (
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/turf/open/floor/iron/white,
+/turf/open/floor/plating,
 /area/station/engineering/atmos/hfr_room)
 "wQU" = (
 /obj/effect/spawner/random/maintenance,
@@ -92279,11 +92279,11 @@ svD
 bJP
 hzr
 hzr
-auI
-auI
-auI
-auI
-auI
+wQE
+wQE
+wQE
+wQE
+wQE
 hzr
 hzr
 aaa
@@ -92535,13 +92535,13 @@ cbu
 cbu
 bJP
 hzr
+utj
+kJU
+xJb
+xJb
+xJb
 jFQ
-lWD
-xJb
-xJb
-xJb
-uTc
-tSV
+tsh
 hzr
 pDW
 pDW
@@ -92791,15 +92791,15 @@ bJP
 bJP
 bJP
 bJP
-auI
-qyg
+wQE
+gZm
 jQB
 jQB
 jQB
 jQB
 jQB
-cTn
-auI
+dAd
+wQE
 aaa
 aaa
 aaa
@@ -93048,7 +93048,7 @@ gGn
 cby
 afp
 bJP
-auI
+wQE
 iGR
 jQB
 azm
@@ -93056,7 +93056,7 @@ azN
 evU
 jQB
 ijt
-auI
+wQE
 aaa
 aaa
 aaa
@@ -93305,7 +93305,7 @@ cbx
 cco
 lag
 bJP
-auI
+wQE
 iGR
 jQB
 rsy
@@ -93313,7 +93313,7 @@ rjl
 syt
 jQB
 ijt
-auI
+wQE
 aaa
 aaa
 aaa
@@ -93562,7 +93562,7 @@ oCb
 cby
 cby
 bJP
-auI
+wQE
 iGR
 jQB
 evU
@@ -93570,7 +93570,7 @@ ssU
 azm
 jQB
 ijt
-auI
+wQE
 aaa
 aaa
 aaa
@@ -93819,15 +93819,15 @@ bJP
 bJP
 bJP
 bJP
-auI
-qyg
+wQE
+gZm
 jQB
 jQB
 jQB
 jQB
 jQB
 ijt
-auI
+wQE
 aaa
 aaa
 aaa
@@ -94084,7 +94084,7 @@ pjM
 pjM
 pjM
 hCg
-auI
+wQE
 aaa
 aaa
 aaa
@@ -94341,7 +94341,7 @@ pjM
 pjM
 pjM
 wfp
-cDx
+tSV
 aaa
 aaa
 aaa
@@ -94597,8 +94597,8 @@ pjM
 pjM
 pjM
 pjM
-ric
-auI
+iFR
+wQE
 aaa
 aaa
 aaa
@@ -94853,8 +94853,8 @@ rfm
 sxs
 tlU
 wMm
-wQE
-kJU
+auI
+uTc
 hzr
 aaa
 aaa

--- a/_maps/map_files/Pubbystation/pubbystation.dmm
+++ b/_maps/map_files/Pubbystation/pubbystation.dmm
@@ -3980,13 +3980,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/station/security/brig)
-"aro" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "arq" = (
 /obj/structure/disposalpipe/junction{
 	dir = 4
@@ -14486,10 +14479,6 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/station/hallway/primary/aft)
-"bko" = (
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space)
 "bkp" = (
 /obj/item/kirbyplants/organic/plant22,
 /turf/open/floor/iron/small,
@@ -29161,6 +29150,13 @@
 /obj/effect/spawner/random/maintenance/four,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/maintenance/department/medical)
+"dLX" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 5
+	},
+/turf/open/space,
+/area/space/nearstation)
 "dLY" = (
 /obj/structure/table,
 /obj/item/assembly/igniter,
@@ -29660,6 +29656,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/maintenance/department/medical)
+"ehE" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
+/turf/open/space,
+/area/space/nearstation)
 "ehK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -30503,13 +30506,6 @@
 	},
 /turf/open/floor/iron/white/smooth_edge,
 /area/station/engineering/atmos)
-"eSK" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/turf/open/space,
-/area/space/nearstation)
 "eSL" = (
 /turf/closed/wall/r_wall,
 /area/station/science/breakroom)
@@ -30673,10 +30669,6 @@
 	},
 /turf/open/space,
 /area/space/nearstation)
-"eYf" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
 "eYM" = (
 /obj/machinery/disposal/delivery_chute{
 	dir = 4
@@ -31765,13 +31757,6 @@
 	},
 /turf/open/floor/iron/dark/small,
 /area/station/science/ordnance)
-"fML" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 6
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
 "fNg" = (
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den)
@@ -32030,6 +32015,13 @@
 /obj/effect/mapping_helpers/airlock/access/any/service/hydroponics,
 /turf/open/floor/iron,
 /area/station/service/kitchen)
+"gbe" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "gbi" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /mob/living/basic/butterfly,
@@ -35106,9 +35098,13 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "iFA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/engineering/atmos/hfr_room)
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
+/turf/open/space,
+/area/space/nearstation)
 "iFI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -35401,6 +35397,13 @@
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/iron,
 /area/station/security/eva)
+"iUg" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 9
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "iUi" = (
 /turf/open/floor/wood/large,
 /area/station/command/bridge)
@@ -35480,6 +35483,13 @@
 /obj/structure/window/reinforced/plasma/fulltile,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
+"iYS" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "iZl" = (
 /obj/effect/turf_decal/tile/yellow/half{
 	dir = 8
@@ -36017,13 +36027,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
-"juF" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 5
-	},
-/turf/open/space,
-/area/space/nearstation)
 "juU" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor/heavy,
@@ -36217,14 +36220,6 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/station/hallway/primary/aft)
-"jFm" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
-/turf/open/space/basic,
-/area/space/nearstation)
 "jFu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -36235,6 +36230,13 @@
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
+"jFK" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 10
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "jFQ" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
@@ -37672,6 +37674,21 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
+"kKq" = (
+/obj/machinery/door/window/right/directional/north{
+	name = "Medbay Front Desk";
+	req_access = list("medical")
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
+/obj/structure/table/reinforced,
+/obj/item/storage/medkit/civil_defense/comfort/stocked,
+/obj/item/storage/medkit/civil_defense/comfort/stocked{
+	pixel_x = 8;
+	pixel_y = 0
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "kKz" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/lattice,
@@ -38577,12 +38594,13 @@
 /turf/open/floor/iron/dark,
 /area/station/service/library/lounge)
 "lxx" = (
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
+/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
+/turf/open/space/basic,
+/area/space/nearstation)
 "lyd" = (
 /obj/effect/landmark/start/security_officer,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
@@ -39200,14 +39218,6 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/storage_shared)
-"mbx" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/turf/open/space,
-/area/space/nearstation)
 "mbJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -40505,6 +40515,15 @@
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/space/basic,
 /area/space/nearstation)
+"ndR" = (
+/obj/effect/turf_decal/tile/pine_green/half/contrasted{
+	dir = 8
+	},
+/obj/structure/bed/medical/emergency,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 4
+	},
+/area/station/medical/medbay/lobby)
 "ndU" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/piratepad/civilian,
@@ -41110,6 +41129,14 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
+"nFD" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
+/turf/open/space/basic,
+/area/space/nearstation)
 "nFT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -41371,15 +41398,6 @@
 /obj/structure/sign/poster/official/there_is_no_gas_giant/directional/north,
 /turf/open/floor/engine,
 /area/station/science/ordnance/storage)
-"nRd" = (
-/obj/effect/turf_decal/tile/pine_green/half/contrasted{
-	dir = 8
-	},
-/obj/structure/bed/medical/emergency,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 4
-	},
-/area/station/medical/medbay/lobby)
 "nSe" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/paramedic,
@@ -42807,6 +42825,12 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/medbay/lobby)
+"oSb" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/obj/structure/transit_tube/crossing,
+/turf/open/space/basic,
+/area/space/nearstation)
 "oSc" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -45595,6 +45619,13 @@
 /obj/effect/turf_decal/tile/office_blue/half/contrasted,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
+"qWb" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 6
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "qWG" = (
 /obj/structure/closet/emcloset/anchored,
 /turf/open/floor/plating,
@@ -46585,11 +46616,12 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/maintenance/disposal/incinerator)
 "rGo" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable,
-/obj/structure/transit_tube,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "rGD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/effect/spawner/structure/window/reinforced,
@@ -46736,6 +46768,10 @@
 	dir = 4
 	},
 /area/station/science/robotics/lab)
+"rKW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/engineering/atmos/hfr_room)
 "rLi" = (
 /obj/machinery/button/door/directional/east{
 	id = "shootshut";
@@ -46919,11 +46955,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
-"rRq" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/turf/open/space/basic,
-/area/space/nearstation)
 "rSH" = (
 /obj/item/trash/can,
 /turf/open/floor/wood,
@@ -47024,21 +47055,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
-"rWd" = (
-/obj/machinery/door/window/right/directional/north{
-	name = "Medbay Front Desk";
-	req_access = list("medical")
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
-/obj/structure/table/reinforced,
-/obj/item/storage/medkit/civil_defense/comfort/stocked,
-/obj/item/storage/medkit/civil_defense/comfort/stocked{
-	pixel_x = 8;
-	pixel_y = 0
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
 "rWE" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -48060,13 +48076,6 @@
 /obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/grass,
 /area/station/medical/psychology)
-"sHX" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "sIq" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/line{
@@ -48171,13 +48180,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"sOt" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 9
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "sOB" = (
 /turf/closed/wall,
 /area/station/medical/psychology)
@@ -49542,12 +49544,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
-"tIt" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable,
-/obj/structure/transit_tube/crossing,
-/turf/open/space/basic,
-/area/space/nearstation)
 "tIx" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
@@ -51856,6 +51852,13 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/engineering/atmos)
+"vsS" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 9
+	},
+/turf/open/space,
+/area/space/nearstation)
 "vtl" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -53070,10 +53073,7 @@
 /area/station/maintenance/department/crew_quarters/dorms)
 "wnh" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/space/basic,
 /area/space/nearstation)
 "wns" = (
@@ -54210,10 +54210,9 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/engineering/atmos)
 "xca" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 10
-	},
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/obj/structure/transit_tube,
 /turf/open/space/basic,
 /area/space/nearstation)
 "xci" = (
@@ -55722,13 +55721,6 @@
 /obj/item/target/syndicate,
 /turf/open/floor/plating,
 /area/station/security/range)
-"ycu" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 9
-	},
-/turf/open/space,
-/area/space/nearstation)
 "ycT" = (
 /obj/machinery/conveyor_switch/oneway{
 	dir = 8;
@@ -73545,7 +73537,7 @@ aHz
 aTM
 aHz
 abI
-bko
+cdm
 abI
 aHz
 aTM
@@ -85134,10 +85126,10 @@ lEs
 gMY
 xIP
 vPE
-rWd
+kKq
 lOw
-nRd
-nRd
+ndR
+ndR
 bvl
 bwO
 aIr
@@ -89690,13 +89682,13 @@ agE
 agS
 agS
 ahs
-rGo
-rGo
-tIt
-rGo
-rGo
-rGo
-rGo
+xca
+xca
+oSb
+xca
+xca
+xca
+xca
 ahR
 ahs
 ahs
@@ -92364,7 +92356,7 @@ wCz
 wwr
 sEx
 vrw
-juF
+dLX
 mkf
 cbv
 ccn
@@ -92877,8 +92869,8 @@ pyH
 wCz
 pyH
 uWA
-fML
-ycu
+qWb
+vsS
 bJP
 bJP
 bJP
@@ -94431,8 +94423,8 @@ bOZ
 pGV
 pjM
 pjM
-iFA
-iFA
+rKW
+rKW
 wfp
 lnK
 rLJ
@@ -94923,15 +94915,15 @@ xgG
 wWR
 pFG
 vzg
-lxx
+rGo
 fBp
 pFG
 vzg
-lxx
+rGo
 iQR
 pFG
 vzg
-lxx
+rGo
 vLx
 hzr
 ssZ
@@ -95177,7 +95169,7 @@ fBp
 avD
 abI
 mDo
-eSK
+ehE
 avD
 abI
 mDo
@@ -95189,7 +95181,7 @@ wLU
 oln
 cAO
 mOH
-mbx
+iFA
 aor
 eTY
 aqp
@@ -95431,22 +95423,22 @@ buz
 seI
 mBU
 aht
-sHX
+gbe
 aht
-aro
-xca
+iYS
+jFK
+nFD
 wnh
-rRq
-jFm
-rRq
+lxx
 wnh
-rRq
-jFm
-rRq
+nFD
 wnh
-rRq
-jFm
-sOt
+lxx
+wnh
+nFD
+wnh
+lxx
+iUg
 bYw
 tfh
 aAu
@@ -96742,7 +96734,7 @@ bYw
 klp
 njg
 ryS
-eYf
+aht
 gYo
 aaa
 aaa

--- a/_maps/map_files/Pubbystation/pubbystation.dmm
+++ b/_maps/map_files/Pubbystation/pubbystation.dmm
@@ -3980,6 +3980,13 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/station/security/brig)
+"aro" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "arq" = (
 /obj/structure/disposalpipe/junction{
 	dir = 4
@@ -14419,6 +14426,7 @@
 /obj/effect/mapping_helpers/requests_console/assistance,
 /obj/effect/mapping_helpers/requests_console/information,
 /obj/machinery/requests_console/auto_name/directional/north,
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/medical)
 "bkd" = (
@@ -14478,6 +14486,10 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/station/hallway/primary/aft)
+"bko" = (
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space)
 "bkp" = (
 /obj/item/kirbyplants/organic/plant22,
 /turf/open/floor/iron/small,
@@ -29273,15 +29285,6 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/command/bridge)
-"dQO" = (
-/obj/effect/turf_decal/tile/pine_green/half/contrasted{
-	dir = 8
-	},
-/obj/structure/bed/medical/emergency,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 4
-	},
-/area/station/medical/medbay/lobby)
 "dQU" = (
 /obj/effect/turf_decal/siding/corner{
 	dir = 4
@@ -30500,6 +30503,13 @@
 	},
 /turf/open/floor/iron/white/smooth_edge,
 /area/station/engineering/atmos)
+"eSK" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
+/turf/open/space,
+/area/space/nearstation)
 "eSL" = (
 /turf/closed/wall/r_wall,
 /area/station/science/breakroom)
@@ -30663,6 +30673,10 @@
 	},
 /turf/open/space,
 /area/space/nearstation)
+"eYf" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
 "eYM" = (
 /obj/machinery/disposal/delivery_chute{
 	dir = 4
@@ -30798,6 +30812,7 @@
 	pixel_x = -8;
 	pixel_y = 12
 	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/chem_storage)
 "fcK" = (
@@ -31750,6 +31765,13 @@
 	},
 /turf/open/floor/iron/dark/small,
 /area/station/science/ordnance)
+"fML" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 6
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "fNg" = (
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den)
@@ -32557,10 +32579,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
-"gzs" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
 "gzy" = (
 /obj/structure/sign/poster/official/random/directional/south,
 /obj/effect/turf_decal/tile/red{
@@ -33088,13 +33106,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
-"gUH" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 6
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
 "gUJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -33890,13 +33901,6 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/station/hallway/primary/aft)
-"hEW" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/turf/open/space,
-/area/space/nearstation)
 "hEX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -34391,13 +34395,6 @@
 "hXW" = (
 /turf/closed/wall,
 /area/station/hallway/secondary/entry)
-"hYv" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "hYR" = (
 /obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 4
@@ -35109,13 +35106,9 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "iFA" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/engineering/atmos/hfr_room)
 "iFI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -36024,6 +36017,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
+"juF" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 5
+	},
+/turf/open/space,
+/area/space/nearstation)
 "juU" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor/heavy,
@@ -36217,6 +36217,14 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/station/hallway/primary/aft)
+"jFm" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
+/turf/open/space/basic,
+/area/space/nearstation)
 "jFu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -36552,11 +36560,6 @@
 /obj/structure/sign/departments/science,
 /turf/closed/wall,
 /area/station/maintenance/department/medical)
-"jSE" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/turf/open/space/basic,
-/area/space/nearstation)
 "jSF" = (
 /turf/closed/wall/r_wall,
 /area/station/hallway/secondary/command)
@@ -36676,14 +36679,6 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/medbay/lobby)
-"jWR" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/turf/open/space,
-/area/space/nearstation)
 "jXw" = (
 /obj/effect/landmark/start/hangover,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -36929,21 +36924,6 @@
 	},
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/secondary/entry)
-"kiw" = (
-/obj/machinery/door/window/right/directional/north{
-	name = "Medbay Front Desk";
-	req_access = list("medical")
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
-/obj/structure/table/reinforced,
-/obj/item/storage/medkit/civil_defense/comfort/stocked,
-/obj/item/storage/medkit/civil_defense/comfort/stocked{
-	pixel_x = 8;
-	pixel_y = 0
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
 "kjm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -38240,13 +38220,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"ljp" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 5
-	},
-/turf/open/space,
-/area/space/nearstation)
 "ljs" = (
 /obj/effect/spawner/random/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -38604,11 +38577,12 @@
 /turf/open/floor/iron/dark,
 /area/station/service/library/lounge)
 "lxx" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable,
-/obj/structure/transit_tube,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "lyd" = (
 /obj/effect/landmark/start/security_officer,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
@@ -39226,6 +39200,14 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/storage_shared)
+"mbx" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
+/turf/open/space,
+/area/space/nearstation)
 "mbJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -40016,10 +39998,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
 /turf/open/floor/iron/white,
 /area/station/maintenance/disposal/incinerator)
-"mHO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/engineering/atmos/hfr_room)
 "mIa" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -41393,6 +41371,15 @@
 /obj/structure/sign/poster/official/there_is_no_gas_giant/directional/north,
 /turf/open/floor/engine,
 /area/station/science/ordnance/storage)
+"nRd" = (
+/obj/effect/turf_decal/tile/pine_green/half/contrasted{
+	dir = 8
+	},
+/obj/structure/bed/medical/emergency,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 4
+	},
+/area/station/medical/medbay/lobby)
 "nSe" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/paramedic,
@@ -41722,13 +41709,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
-"odk" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 10
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "odp" = (
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 8
@@ -46606,8 +46586,10 @@
 /area/station/maintenance/disposal/incinerator)
 "rGo" = (
 /obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/obj/structure/transit_tube,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "rGD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/effect/spawner/structure/window/reinforced,
@@ -46937,6 +46919,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"rRq" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/turf/open/space/basic,
+/area/space/nearstation)
 "rSH" = (
 /obj/item/trash/can,
 /turf/open/floor/wood,
@@ -47037,6 +47024,21 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
+"rWd" = (
+/obj/machinery/door/window/right/directional/north{
+	name = "Medbay Front Desk";
+	req_access = list("medical")
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
+/obj/structure/table/reinforced,
+/obj/item/storage/medkit/civil_defense/comfort/stocked,
+/obj/item/storage/medkit/civil_defense/comfort/stocked{
+	pixel_x = 8;
+	pixel_y = 0
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "rWE" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -47345,13 +47347,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
-"shY" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
 "sij" = (
 /obj/structure/closet,
 /obj/item/food/meat/slab/monkey,
@@ -48065,6 +48060,13 @@
 /obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/grass,
 /area/station/medical/psychology)
+"sHX" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "sIq" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/line{
@@ -48169,6 +48171,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"sOt" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 9
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "sOB" = (
 /turf/closed/wall,
 /area/station/medical/psychology)
@@ -49533,6 +49542,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
+"tIt" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/obj/structure/transit_tube/crossing,
+/turf/open/space/basic,
+/area/space/nearstation)
 "tIx" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
@@ -49874,13 +49889,6 @@
 /obj/structure/reflector/box/anchored,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
-"tZy" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "tZU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/closed/wall/r_wall,
@@ -53062,9 +53070,10 @@
 /area/station/maintenance/department/crew_quarters/dorms)
 "wnh" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
 /turf/open/space/basic,
 /area/space/nearstation)
 "wns" = (
@@ -54202,10 +54211,9 @@
 /area/station/engineering/atmos)
 "xca" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
 /turf/open/space/basic,
 /area/space/nearstation)
 "xci" = (
@@ -55613,12 +55621,6 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/engineering/atmos)
-"xXw" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable,
-/obj/structure/transit_tube/crossing,
-/turf/open/space/basic,
-/area/space/nearstation)
 "xXQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -55720,6 +55722,13 @@
 /obj/item/target/syndicate,
 /turf/open/floor/plating,
 /area/station/security/range)
+"ycu" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 9
+	},
+/turf/open/space,
+/area/space/nearstation)
 "ycT" = (
 /obj/machinery/conveyor_switch/oneway{
 	dir = 8;
@@ -55826,13 +55835,6 @@
 	dir = 1
 	},
 /area/station/maintenance/department/medical)
-"ygK" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 9
-	},
-/turf/open/space,
-/area/space/nearstation)
 "ygW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -73543,7 +73545,7 @@ aHz
 aTM
 aHz
 abI
-rGo
+bko
 abI
 aHz
 aTM
@@ -85132,10 +85134,10 @@ lEs
 gMY
 xIP
 vPE
-kiw
+rWd
 lOw
-dQO
-dQO
+nRd
+nRd
 bvl
 bwO
 aIr
@@ -89688,13 +89690,13 @@ agE
 agS
 agS
 ahs
-lxx
-lxx
-xXw
-lxx
-lxx
-lxx
-lxx
+rGo
+rGo
+tIt
+rGo
+rGo
+rGo
+rGo
 ahR
 ahs
 ahs
@@ -92362,7 +92364,7 @@ wCz
 wwr
 sEx
 vrw
-ljp
+juF
 mkf
 cbv
 ccn
@@ -92875,8 +92877,8 @@ pyH
 wCz
 pyH
 uWA
-gUH
-ygK
+fML
+ycu
 bJP
 bJP
 bJP
@@ -94429,8 +94431,8 @@ bOZ
 pGV
 pjM
 pjM
-mHO
-mHO
+iFA
+iFA
 wfp
 lnK
 rLJ
@@ -94921,15 +94923,15 @@ xgG
 wWR
 pFG
 vzg
-shY
+lxx
 fBp
 pFG
 vzg
-shY
+lxx
 iQR
 pFG
 vzg
-shY
+lxx
 vLx
 hzr
 ssZ
@@ -95175,7 +95177,7 @@ fBp
 avD
 abI
 mDo
-hEW
+eSK
 avD
 abI
 mDo
@@ -95187,7 +95189,7 @@ wLU
 oln
 cAO
 mOH
-jWR
+mbx
 aor
 eTY
 aqp
@@ -95429,22 +95431,22 @@ buz
 seI
 mBU
 aht
-tZy
+sHX
 aht
-hYv
-odk
+aro
 xca
-jSE
-iFA
-jSE
-xca
-jSE
-iFA
-jSE
-xca
-jSE
-iFA
 wnh
+rRq
+jFm
+rRq
+wnh
+rRq
+jFm
+rRq
+wnh
+rRq
+jFm
+sOt
 bYw
 tfh
 aAu
@@ -96740,7 +96742,7 @@ bYw
 klp
 njg
 ryS
-gzs
+eYf
 gYo
 aaa
 aaa

--- a/_maps/map_files/Pubbystation/pubbystation.dmm
+++ b/_maps/map_files/Pubbystation/pubbystation.dmm
@@ -26446,6 +26446,12 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plating,
 /area/station/engineering/storage_shared)
+"crj" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/obj/structure/transit_tube/crossing,
+/turf/open/space/basic,
+/area/space/nearstation)
 "crk" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/dark,
@@ -29150,13 +29156,6 @@
 /obj/effect/spawner/random/maintenance/four,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/maintenance/department/medical)
-"dLX" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 5
-	},
-/turf/open/space,
-/area/space/nearstation)
 "dLY" = (
 /obj/structure/table,
 /obj/item/assembly/igniter,
@@ -29656,13 +29655,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/maintenance/department/medical)
-"ehE" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/turf/open/space,
-/area/space/nearstation)
 "ehK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -32015,13 +32007,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/service/hydroponics,
 /turf/open/floor/iron,
 /area/station/service/kitchen)
-"gbe" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "gbi" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /mob/living/basic/butterfly,
@@ -33614,6 +33599,13 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/science/research)
+"hrx" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 5
+	},
+/turf/open/space,
+/area/space/nearstation)
 "hsQ" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -35098,13 +35090,12 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "iFA" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
 	},
-/turf/open/space,
-/area/space/nearstation)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "iFI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -35271,6 +35262,13 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/station/security/eva)
+"iKT" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 10
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "iLl" = (
 /obj/structure/sink{
 	pixel_y = 29
@@ -35397,13 +35395,6 @@
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/iron,
 /area/station/security/eva)
-"iUg" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 9
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "iUi" = (
 /turf/open/floor/wood/large,
 /area/station/command/bridge)
@@ -35457,6 +35448,21 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"iXh" = (
+/obj/machinery/door/window/right/directional/north{
+	name = "Medbay Front Desk";
+	req_access = list("medical")
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
+/obj/structure/table/reinforced,
+/obj/item/storage/medkit/civil_defense/comfort/stocked,
+/obj/item/storage/medkit/civil_defense/comfort/stocked{
+	pixel_x = 8;
+	pixel_y = 0
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "iYH" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Bay"
@@ -35483,13 +35489,6 @@
 /obj/structure/window/reinforced/plasma/fulltile,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
-"iYS" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "iZl" = (
 /obj/effect/turf_decal/tile/yellow/half{
 	dir = 8
@@ -36230,13 +36229,6 @@
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
-"jFK" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 10
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "jFQ" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
@@ -36823,6 +36815,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
+"kfA" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "kfS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -37674,21 +37673,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
-"kKq" = (
-/obj/machinery/door/window/right/directional/north{
-	name = "Medbay Front Desk";
-	req_access = list("medical")
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
-/obj/structure/table/reinforced,
-/obj/item/storage/medkit/civil_defense/comfort/stocked,
-/obj/item/storage/medkit/civil_defense/comfort/stocked{
-	pixel_x = 8;
-	pixel_y = 0
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
 "kKz" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/lattice,
@@ -37778,6 +37762,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/eva)
+"kPQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/engineering/atmos/hfr_room)
 "kQy" = (
 /obj/machinery/computer/records/medical,
 /obj/effect/turf_decal/tile/pine_green{
@@ -38595,7 +38583,7 @@
 /area/station/service/library/lounge)
 "lxx" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
@@ -40515,15 +40503,6 @@
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/space/basic,
 /area/space/nearstation)
-"ndR" = (
-/obj/effect/turf_decal/tile/pine_green/half/contrasted{
-	dir = 8
-	},
-/obj/structure/bed/medical/emergency,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 4
-	},
-/area/station/medical/medbay/lobby)
 "ndU" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/piratepad/civilian,
@@ -41129,14 +41108,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
-"nFD" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
-/turf/open/space/basic,
-/area/space/nearstation)
 "nFT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -42825,12 +42796,6 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/medbay/lobby)
-"oSb" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable,
-/obj/structure/transit_tube/crossing,
-/turf/open/space/basic,
-/area/space/nearstation)
 "oSc" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -43326,6 +43291,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"pkt" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 9
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "pku" = (
 /obj/structure/sign/departments/exam_room/directional/east,
 /obj/structure/bed/medical{
@@ -45619,13 +45591,6 @@
 /obj/effect/turf_decal/tile/office_blue/half/contrasted,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
-"qWb" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 6
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
 "qWG" = (
 /obj/structure/closet/emcloset/anchored,
 /turf/open/floor/plating,
@@ -46377,6 +46342,11 @@
 	dir = 1
 	},
 /area/station/science/xenobiology)
+"rzm" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/turf/open/space/basic,
+/area/space/nearstation)
 "rzp" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/layer_manifold/supply,
@@ -46616,12 +46586,12 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/maintenance/disposal/incinerator)
 "rGo" = (
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
+	dir = 9
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
+/turf/open/space,
+/area/space/nearstation)
 "rGD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/effect/spawner/structure/window/reinforced,
@@ -46768,10 +46738,6 @@
 	dir = 4
 	},
 /area/station/science/robotics/lab)
-"rKW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/engineering/atmos/hfr_room)
 "rLi" = (
 /obj/machinery/button/door/directional/east{
 	id = "shootshut";
@@ -47038,6 +47004,13 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/main)
+"rVH" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
+/turf/open/space,
+/area/space/nearstation)
 "rVU" = (
 /turf/open/floor/iron/chapel{
 	dir = 1
@@ -48158,6 +48131,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/command/bridge)
+"sNn" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/obj/structure/transit_tube,
+/turf/open/space/basic,
+/area/space/nearstation)
 "sNv" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding{
@@ -48250,6 +48229,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
+"sRP" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 6
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "sSd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/plating,
@@ -48411,6 +48397,14 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
+"sXC" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
+/turf/open/space,
+/area/space/nearstation)
 "sXK" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -49477,6 +49471,13 @@
 	dir = 1
 	},
 /area/station/engineering/main)
+"tEd" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "tEB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -51852,13 +51853,6 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/engineering/atmos)
-"vsS" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 9
-	},
-/turf/open/space,
-/area/space/nearstation)
 "vtl" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -53073,7 +53067,10 @@
 /area/station/maintenance/department/crew_quarters/dorms)
 "wnh" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
 /turf/open/space/basic,
 /area/space/nearstation)
 "wns" = (
@@ -54210,11 +54207,14 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/engineering/atmos)
 "xca" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable,
-/obj/structure/transit_tube,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/effect/turf_decal/tile/pine_green/half/contrasted{
+	dir = 8
+	},
+/obj/structure/bed/medical/emergency,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 4
+	},
+/area/station/medical/medbay/lobby)
 "xci" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 1
@@ -85126,10 +85126,10 @@ lEs
 gMY
 xIP
 vPE
-kKq
+iXh
 lOw
-ndR
-ndR
+xca
+xca
 bvl
 bwO
 aIr
@@ -89682,13 +89682,13 @@ agE
 agS
 agS
 ahs
-xca
-xca
-oSb
-xca
-xca
-xca
-xca
+sNn
+sNn
+crj
+sNn
+sNn
+sNn
+sNn
 ahR
 ahs
 ahs
@@ -92356,7 +92356,7 @@ wCz
 wwr
 sEx
 vrw
-dLX
+hrx
 mkf
 cbv
 ccn
@@ -92869,8 +92869,8 @@ pyH
 wCz
 pyH
 uWA
-qWb
-vsS
+sRP
+rGo
 bJP
 bJP
 bJP
@@ -94423,8 +94423,8 @@ bOZ
 pGV
 pjM
 pjM
-rKW
-rKW
+kPQ
+kPQ
 wfp
 lnK
 rLJ
@@ -94915,15 +94915,15 @@ xgG
 wWR
 pFG
 vzg
-rGo
+iFA
 fBp
 pFG
 vzg
-rGo
+iFA
 iQR
 pFG
 vzg
-rGo
+iFA
 vLx
 hzr
 ssZ
@@ -95169,7 +95169,7 @@ fBp
 avD
 abI
 mDo
-ehE
+rVH
 avD
 abI
 mDo
@@ -95181,7 +95181,7 @@ wLU
 oln
 cAO
 mOH
-iFA
+sXC
 aor
 eTY
 aqp
@@ -95423,22 +95423,22 @@ buz
 seI
 mBU
 aht
-gbe
+tEd
 aht
-iYS
-jFK
-nFD
-wnh
+kfA
+iKT
 lxx
+rzm
 wnh
-nFD
-wnh
+rzm
 lxx
+rzm
 wnh
-nFD
-wnh
+rzm
 lxx
-iUg
+rzm
+wnh
+pkt
 bYw
 tfh
 aAu

--- a/_maps/map_files/Pubbystation/pubbystation.dmm
+++ b/_maps/map_files/Pubbystation/pubbystation.dmm
@@ -19206,12 +19206,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/service/chapel/dock)
-"bGG" = (
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/machinery/atmospherics/components/unary/passive_vent/layer2,
-/turf/open/floor/plating/airless,
-/area/station/service/chapel/dock)
 "bGH" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/space,
@@ -19592,13 +19586,6 @@
 /area/station/service/chapel/dock)
 "bIW" = (
 /obj/machinery/computer/shuttle/monastery_shuttle,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/service/chapel/dock)
-"bIX" = (
-/obj/machinery/atmospherics/components/tank/air,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/dock)
 "bIY" = (
@@ -23081,10 +23068,6 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white/smooth_large,
-/area/station/engineering/atmos)
-"bXx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
 "bXy" = (
 /obj/effect/decal/cleanable/dirt,
@@ -29349,6 +29332,12 @@
 "dUh" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/sand/plating,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/service/chapel/asteroid/monastery)
 "dUw" = (
@@ -33593,6 +33582,10 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/science/research)
+"hrx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos)
 "hsQ" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -36671,10 +36664,6 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/station/hallway/primary/aft)
-"jXz" = (
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/service/chapel/dock)
 "jXA" = (
 /obj/structure/table,
 /obj/item/stack/ore/iron,
@@ -41692,6 +41681,12 @@
 	name = "Chapel"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/dock)
 "odG" = (
@@ -43709,6 +43704,12 @@
 /obj/machinery/door/airlock/grunge{
 	name = "Chapel"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "pCf" = (
@@ -44745,13 +44746,6 @@
 /obj/machinery/door/poddoor/massdriver_ordnance,
 /turf/open/floor/plating,
 /area/station/science/ordnance/testlab)
-"qny" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/station/service/chapel/dock)
 "qnJ" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Paramedic Dispatch Room"
@@ -48203,6 +48197,11 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
+"sRP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "sSd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/plating,
@@ -49113,11 +49112,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/abandoned_gambling_den)
-"tvq" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
 "tvr" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
@@ -54839,10 +54833,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
-"xwy" = (
-/obj/structure/cable,
-/turf/open/floor/carpet,
-/area/station/service/chapel)
 "xwX" = (
 /obj/machinery/door/airlock/security{
 	name = "Equipment Room"
@@ -70709,14 +70699,14 @@ aaa
 aaa
 aaa
 aaa
-bGG
-qny
+cre
+bHL
 bIW
 tCV
 xlh
 eAP
 hCj
-jXz
+hCj
 odF
 dUh
 dUh
@@ -70728,11 +70718,11 @@ dUh
 dUh
 dUh
 pBT
-oTb
-xwy
-xwy
-xwy
-xwy
+fHn
+qJI
+qJI
+qJI
+qJI
 qJI
 qJI
 tBs
@@ -70968,8 +70958,8 @@ aaa
 aaa
 bGH
 bHL
-bIX
-dPk
+bMu
+bMu
 xlh
 dQg
 bNv
@@ -91026,7 +91016,7 @@ xhP
 xhP
 qbv
 mkS
-tvq
+sRP
 bZL
 caC
 jOk
@@ -91797,7 +91787,7 @@ bOk
 wCz
 mvA
 qIz
-bXx
+hrx
 bZL
 bJP
 bJP
@@ -92825,7 +92815,7 @@ pyH
 wCz
 pyH
 mkS
-tvq
+sRP
 abI
 bJP
 bJP

--- a/_maps/map_files/Pubbystation/pubbystation.dmm
+++ b/_maps/map_files/Pubbystation/pubbystation.dmm
@@ -23084,10 +23084,6 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/engineering/atmos)
-"bXx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/engineering/atmos)
 "bXy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold/general/visible{
@@ -23620,7 +23616,7 @@
 /area/space/nearstation)
 "bZL" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/space,
 /area/space/nearstation)
 "bZT" = (
@@ -29066,6 +29062,9 @@
 	name = "O2 Outlet Pump"
 	},
 /obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
+	dir = 4
+	},
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1
 	},
@@ -30654,9 +30653,6 @@
 "eYd" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
-/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
-	dir = 4
-	},
 /turf/open/space,
 /area/space/nearstation)
 "eYM" = (
@@ -33597,13 +33593,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/science/research)
-"hrx" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 5
-	},
-/turf/open/space,
-/area/space/nearstation)
 "hsQ" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -40759,11 +40748,6 @@
 /obj/structure/tank_dispenser,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/science/ordnance/testlab)
-"noR" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
 "noT" = (
 /obj/effect/spawner/random/epic_loot/random_maint_loot_structure,
 /turf/open/floor/plating,
@@ -45314,6 +45298,7 @@
 "qIz" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1
 	},
@@ -46582,12 +46567,9 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/maintenance/disposal/incinerator)
 "rGo" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 9
-	},
-/turf/open/space,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos)
 "rGD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/effect/spawner/structure/window/reinforced,
@@ -47967,11 +47949,11 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "sEx" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
 /obj/machinery/computer/atmos_control/oxygen_tank{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1
 	},
@@ -48225,13 +48207,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
-"sRP" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 6
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
 "sSd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/plating,
@@ -51782,11 +51757,6 @@
 "vpC" = (
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/funeral)
-"vrw" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
 "vrx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
@@ -53291,10 +53261,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "wwr" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/turf/open/space,
-/area/space/nearstation)
+/turf/open/floor/iron/white/smooth_large,
+/area/station/engineering/atmos)
 "wwG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -91066,7 +91035,7 @@ xhP
 qbv
 mkS
 tvq
-wwr
+bZL
 caC
 jOk
 cbs
@@ -91834,10 +91803,10 @@ eKY
 wUN
 bOk
 wCz
-bXx
+mvA
 qIz
-fBp
-abI
+rGo
+bZL
 bJP
 bJP
 bJP
@@ -92091,9 +92060,9 @@ ksv
 sGc
 eUb
 wCz
-mvA
-mkS
-noR
+wwr
+uWA
+vzg
 bZL
 caC
 cRY
@@ -92348,10 +92317,10 @@ bXC
 sGc
 bpQ
 wCz
-bXx
+wwr
 sEx
-vrw
-hrx
+vzg
+abI
 mkf
 cbv
 ccn
@@ -92863,9 +92832,9 @@ eLN
 pyH
 wCz
 pyH
-uWA
-sRP
-rGo
+mkS
+tvq
+abI
 bJP
 bJP
 bJP

--- a/_maps/map_files/Pubbystation/pubbystation.dmm
+++ b/_maps/map_files/Pubbystation/pubbystation.dmm
@@ -11169,13 +11169,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/service)
-"aWe" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 6
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
 "aWf" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Bar Access"
@@ -22958,6 +22951,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "bXd" = (
@@ -27228,6 +27222,7 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "cwF" = (
@@ -30187,6 +30182,13 @@
 /obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
+"eFe" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "eFj" = (
 /obj/effect/turf_decal/tile/pine_green{
 	dir = 4
@@ -30329,14 +30331,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"eKN" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/turf/open/space,
-/area/space/nearstation)
 "eKY" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
@@ -30368,6 +30362,21 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
+"eNf" = (
+/obj/machinery/door/window/right/directional/north{
+	name = "Medbay Front Desk";
+	req_access = list("medical")
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
+/obj/structure/table/reinforced,
+/obj/item/storage/medkit/civil_defense/comfort/stocked,
+/obj/item/storage/medkit/civil_defense/comfort/stocked{
+	pixel_x = 8;
+	pixel_y = 0
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "eNo" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/heater{
 	dir = 8
@@ -31352,6 +31361,13 @@
 /obj/item/beacon,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"fvY" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 9
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "fwe" = (
 /obj/machinery/firealarm/directional/west,
 /obj/structure/chair/office{
@@ -31368,6 +31384,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "fwi" = (
@@ -31797,13 +31814,6 @@
 /obj/effect/turf_decal/tile/dark/diagonal_edge,
 /turf/open/floor/iron/white/diagonal,
 /area/station/ai_monitored/turret_protected/ai_upload)
-"fPW" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 9
-	},
-/turf/open/space,
-/area/space/nearstation)
 "fQd" = (
 /obj/machinery/conveyor{
 	id = "CargoLoad"
@@ -31904,6 +31914,7 @@
 	dir = 4
 	},
 /obj/effect/spawner/random/engineering/atmospherics_portable,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "fVJ" = (
@@ -34525,10 +34536,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"igz" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
 "igC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/structure/lattice,
@@ -35097,12 +35104,12 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "iFA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
 	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/station/maintenance/department/engine)
+/area/station/engineering/atmos)
 "iFI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -36825,6 +36832,13 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/dock)
+"khj" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 10
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "khk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -37615,6 +37629,14 @@
 /obj/structure/maintenance_loot_structure/toolbox/random,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"kIB" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
+/turf/open/space/basic,
+/area/space/nearstation)
 "kJm" = (
 /obj/item/clothing/gloves/color/fyellow,
 /obj/item/wrench,
@@ -37911,6 +37933,13 @@
 /obj/effect/spawner/random/structure/steam_vent,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
+"kZi" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "kZq" = (
 /obj/effect/spawner/random/food_or_drink/donkpockets,
 /obj/item/wallframe/telescreen/entertainment{
@@ -38556,9 +38585,8 @@
 /turf/open/floor/iron/dark,
 /area/station/service/library/lounge)
 "lxx" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable,
-/obj/structure/transit_tube/crossing,
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/space/basic,
 /area/space/nearstation)
 "lyd" = (
@@ -38590,13 +38618,6 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/science/lab)
-"lzT" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 5
-	},
-/turf/open/space,
-/area/space/nearstation)
 "lAa" = (
 /obj/machinery/computer/records/security,
 /obj/machinery/requests_console/directional/east{
@@ -39937,13 +39958,6 @@
 /obj/machinery/light/dim/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/service/library/artgallery)
-"mFA" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 9
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "mFJ" = (
 /obj/effect/turf_decal/tile/electric_yellow,
 /obj/effect/turf_decal/stripes/corner{
@@ -40108,11 +40122,6 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/command/bridge)
-"mOm" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/turf/open/space/basic,
-/area/space/nearstation)
 "mOt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -40136,21 +40145,6 @@
 /obj/effect/spawner/random/glass_debris,
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical)
-"mOy" = (
-/obj/machinery/door/window/right/directional/north{
-	name = "Medbay Front Desk";
-	req_access = list("medical")
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
-/obj/structure/table/reinforced,
-/obj/item/storage/medkit/civil_defense/comfort/stocked,
-/obj/item/storage/medkit/civil_defense/comfort/stocked{
-	pixel_x = 8;
-	pixel_y = 0
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
 "mOH" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
@@ -41567,6 +41561,10 @@
 	},
 /turf/closed/wall/r_wall,
 /area/station/science/ordnance/burnchamber)
+"nXt" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
 "nXy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -41635,6 +41633,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"oaD" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 9
+	},
+/turf/open/space,
+/area/space/nearstation)
 "oaI" = (
 /turf/open/floor/iron/dark/small,
 /area/station/science/lab)
@@ -42612,6 +42617,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "oLR" = (
@@ -43065,13 +43071,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/station/medical/psychology)
-"pde" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/turf/open/space,
-/area/space/nearstation)
 "pdq" = (
 /obj/effect/decal/cleanable/oil,
 /obj/structure/maintenance_loot_structure/military_case/random,
@@ -44856,6 +44855,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "qqa" = (
@@ -45029,6 +45029,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "qvR" = (
@@ -45957,13 +45958,6 @@
 /obj/structure/flora/bush/large/style_random,
 /turf/open/floor/grass,
 /area/station/science/genetics)
-"rlA" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
 "rlR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -46591,9 +46585,11 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/maintenance/disposal/incinerator)
 "rGo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/engineering/atmos/hfr_room)
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/obj/structure/transit_tube,
+/turf/open/space/basic,
+/area/space/nearstation)
 "rGD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/effect/spawner/structure/window/reinforced,
@@ -47252,12 +47248,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
-"seF" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable,
-/obj/structure/transit_tube,
-/turf/open/space/basic,
-/area/space/nearstation)
 "seI" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -47656,6 +47646,13 @@
 	dir = 1
 	},
 /area/station/science/ordnance)
+"suG" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
+/turf/open/space,
+/area/space/nearstation)
 "suN" = (
 /obj/effect/turf_decal/siding/green{
 	dir = 4
@@ -47994,6 +47991,13 @@
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
+"sFl" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 5
+	},
+/turf/open/space,
+/area/space/nearstation)
 "sFA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -48820,13 +48824,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/bar)
-"tkm" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "tko" = (
 /turf/closed/wall,
 /area/station/cargo/drone_bay)
@@ -49358,15 +49355,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
 /area/station/service/library/artgallery)
-"tBo" = (
-/obj/effect/turf_decal/tile/pine_green/half/contrasted{
-	dir = 8
-	},
-/obj/structure/bed/medical/emergency,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 4
-	},
-/area/station/medical/medbay/lobby)
 "tBs" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/cup/glass/trophy{
@@ -51993,6 +51981,14 @@
 /obj/structure/table/reinforced/plasmarglass,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
+"vyl" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
+/turf/open/space/basic,
+/area/space/nearstation)
 "vyn" = (
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 1
@@ -52049,6 +52045,14 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/storage)
+"vBT" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
+/turf/open/space,
+/area/space/nearstation)
 "vBZ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -52376,6 +52380,13 @@
 /obj/effect/mapping_helpers/airlock/access/any/supply/general,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
+"vQX" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 6
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "vRi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -52515,6 +52526,15 @@
 "vTg" = (
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/chem_storage)
+"vTF" = (
+/obj/effect/turf_decal/tile/pine_green/half/contrasted{
+	dir = 8
+	},
+/obj/structure/bed/medical/emergency,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 4
+	},
+/area/station/medical/medbay/lobby)
 "vTL" = (
 /obj/machinery/vending/tool,
 /turf/open/floor/iron/dark,
@@ -52685,13 +52705,6 @@
 /obj/machinery/vending/boozeomat,
 /turf/closed/wall,
 /area/station/service/bar)
-"wav" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 10
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "waG" = (
 /obj/structure/table/optable,
 /obj/effect/turf_decal/tile/pine_green/half/contrasted{
@@ -53062,12 +53075,9 @@
 /turf/closed/wall,
 /area/station/maintenance/department/crew_quarters/dorms)
 "wnh" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
-/turf/open/space/basic,
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon/burgundy,
+/turf/open/space,
 /area/space/nearstation)
 "wns" = (
 /obj/structure/closet/crate/freezer/surplus_limbs,
@@ -53287,6 +53297,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "wwr" = (
@@ -53395,6 +53406,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "wAI" = (
@@ -54201,11 +54213,9 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/engineering/atmos)
 "xca" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/obj/structure/transit_tube/crossing,
 /turf/open/space/basic,
 /area/space/nearstation)
 "xci" = (
@@ -54477,13 +54487,6 @@
 /obj/structure/cable,
 /turf/open/floor/plastic,
 /area/station/security/lockers)
-"xjV" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "xjZ" = (
 /obj/effect/landmark/start/hangover,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -55021,6 +55024,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
+"xzs" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/engineering/atmos/hfr_room)
 "xzF" = (
 /turf/closed/wall/mineral/iron,
 /area/station/service/chapel/storage)
@@ -78736,7 +78743,7 @@ oKD
 fwg
 qvM
 wAA
-iFA
+iyC
 cwC
 bWZ
 nWP
@@ -85126,10 +85133,10 @@ lEs
 gMY
 xIP
 vPE
-mOy
+eNf
 lOw
-tBo
-tBo
+vTF
+vTF
 bvl
 bwO
 aIr
@@ -89682,13 +89689,13 @@ agE
 agS
 agS
 ahs
-seF
-seF
-lxx
-seF
-seF
-seF
-seF
+rGo
+rGo
+xca
+rGo
+rGo
+rGo
+rGo
 ahR
 ahs
 ahs
@@ -92356,7 +92363,7 @@ wCz
 wwr
 sEx
 vrw
-lzT
+sFl
 mkf
 cbv
 ccn
@@ -92869,8 +92876,8 @@ pyH
 wCz
 pyH
 uWA
-aWe
-fPW
+vQX
+oaD
 bJP
 bJP
 bJP
@@ -94423,8 +94430,8 @@ bOZ
 pGV
 pjM
 pjM
-rGo
-rGo
+xzs
+xzs
 wfp
 lnK
 rLJ
@@ -94915,15 +94922,15 @@ xgG
 wWR
 pFG
 vzg
-rlA
+iFA
 fBp
 pFG
 vzg
-rlA
+iFA
 iQR
 pFG
 vzg
-rlA
+iFA
 vLx
 hzr
 ssZ
@@ -95169,7 +95176,7 @@ fBp
 avD
 abI
 mDo
-pde
+suG
 avD
 abI
 mDo
@@ -95181,7 +95188,7 @@ wLU
 oln
 cAO
 mOH
-eKN
+vBT
 aor
 eTY
 aqp
@@ -95423,22 +95430,22 @@ buz
 seI
 mBU
 aht
-tkm
+eFe
 aht
-xjV
-wav
-xca
-mOm
-wnh
-mOm
-xca
-mOm
-wnh
-mOm
-xca
-mOm
-wnh
-mFA
+kZi
+khj
+kIB
+lxx
+vyl
+lxx
+kIB
+lxx
+vyl
+lxx
+kIB
+lxx
+vyl
+fvY
 bYw
 tfh
 aAu
@@ -96734,7 +96741,7 @@ bYw
 klp
 njg
 ryS
-igz
+nXt
 gYo
 aaa
 aaa
@@ -99311,7 +99318,7 @@ aaa
 aaa
 aaa
 aaa
-hRF
+wnh
 dKA
 cjv
 cjv
@@ -99568,7 +99575,7 @@ aaa
 aaa
 aaa
 aaa
-abI
+ahi
 bHN
 cnq
 cjV
@@ -99797,7 +99804,23 @@ xjC
 xjC
 aht
 abI
-hRF
+wnh
+abI
+abI
+abI
+wnh
+abI
+abI
+abI
+wnh
+abI
+abI
+abI
+wnh
+abI
+abI
+abI
+wnh
 abI
 abI
 abI
@@ -99805,23 +99828,7 @@ hRF
 abI
 abI
 abI
-hRF
-abI
-abI
-abI
-hRF
-abI
-abI
-abI
-hRF
-abI
-abI
-abI
-hRF
-abI
-abI
-abI
-hRF
+wnh
 abI
 abI
 abI
@@ -100311,7 +100318,23 @@ xjC
 xjC
 abI
 abI
-hRF
+wnh
+abI
+abI
+abI
+wnh
+abI
+abI
+abI
+wnh
+abI
+abI
+abI
+wnh
+abI
+abI
+abI
+wnh
 abI
 abI
 abI
@@ -100319,23 +100342,7 @@ hRF
 abI
 abI
 abI
-hRF
-abI
-abI
-abI
-hRF
-abI
-abI
-abI
-hRF
-abI
-abI
-abI
-hRF
-abI
-abI
-abI
-hRF
+wnh
 abI
 abI
 abI
@@ -100596,7 +100603,7 @@ aaa
 aaa
 aaa
 aaa
-abI
+ahi
 bHN
 cnq
 cjx
@@ -100853,7 +100860,7 @@ aaa
 aaa
 aaa
 aaa
-hRF
+wnh
 dKA
 cjv
 cjv


### PR DESCRIPTION
Woo! Going back into Pubby for another round of dopplerfying.

Here's the highlights:
-Armory: Civilian-Issue lockers have been moved to EVA Storage. An empty Grenade Launcher, an Empty grenade Belt, and three empty bandoliers have been added.
-EVA Storage: The airlock now requires no access on Red Alert. Contents have been changed to help crew assist with threats. The Civilian Issue Gear (six sets of Frontier Armor, Frontier Helmet, and Mini-Egun) are in security-access lockers, requiring a secoff or a command member with appropriate access to open. There is now two biohazard lockers and two radiation lockers.
-Medical: Switched the location of Paramedic Dispatch and Security office. Shrank New Security office for more Treatment Center room. Treatment center now has a crew-facing airlock that requires no access on Red Alert. A set of shutters are available on medical access if this needs to be locked.
-Chemistry: Returned the chem factory room to maintenance. R.I.P. Pharmacy now has a storage room with some bulk chemical bags from reliable sources.
-Library: Adds three docking ports(!) to the library to bring life to this desolate, remote part of the station. Shuttle owners rejoice, you might be able to find parking.
-Telecoms: Moved the whole Telecoms sat further away from the station. Connected the sat to the distro network. Vent-crawlers rejoice! You can make it to Communications.
-Monastery: Also Connected to distro.
-Cargo: Added a "Sikth & Kurabi Stationery Supplies ™ Uplink" Console to the lobby, right in the view of the security checkpoint.  It's legal! All the best lawyers say so! Also moved the frontier fabricator next to the protolathe.
-Entertainment Monitors: Added monitors in/around break rooms and public areas. Remember that you can mute them if you get annoyed.
-Shared Gas Storage: Replaced 3 Oxygen Canisters with 3 Water Vapour Canisters
-Atmospherics: Placed gas miners of same type in each gas tank. (O2,N2,C02,N20,Plasma)