### PR TITLE
Bug blood fix

### DIFF
--- a/modular_doppler/modular_medical/reagents/bug_blood.dm
+++ b/modular_doppler/modular_medical/reagents/bug_blood.dm
@@ -7,7 +7,7 @@
 	taste_mult = 5
 	color = "#82fac6" //rgb 130,250,198
 	ph = 7.4
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_DEAD_PROCESS
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_DEAD_PROCESS | REAGENT_IGNORE_STASIS
 
 
 /datum/chemical_reaction/bug_blood


### PR DESCRIPTION
Bug Fix (hahalolgetitbecausebugs)

Had a snail on stasis be stuck at a very low blood level despite having 200 units of hemolymph injected into them. Adding 'ignore stasis' to allow for transfusions while on a stasis table.
