### PR TITLE
Android limbs brute/burn mod bugfix

### DIFF
--- a/modular_doppler/modular_species/species_types/android/android_parts.dm
+++ b/modular_doppler/modular_species/species_types/android/android_parts.dm
@@ -36,6 +36,8 @@
 ///
 // head
 /obj/item/bodypart/head/robot/android
+	burn_modifier = 0.8
+	brute_modifier = 0.8
 	biological_state = (BIO_ROBOTIC|BIO_BLOODED)
 	// var for monitor heads and their emissive states
 	var/monitor_state
@@ -67,6 +69,8 @@
 
 // chest
 /obj/item/bodypart/chest/robot/android
+	burn_modifier = 0.8
+	brute_modifier = 0.8
 	biological_state = (BIO_ROBOTIC|BIO_BLOODED)
 
 /obj/item/bodypart/chest/robot/android/Initialize(mapload)
@@ -86,6 +90,8 @@
 
 // right arm
 /obj/item/bodypart/arm/right/robot/android
+	burn_modifier = 0.8
+	brute_modifier = 0.8
 	biological_state = (BIO_ROBOTIC|BIO_BLOODED)
 
 /obj/item/bodypart/arm/right/robot/android/Initialize(mapload)
@@ -102,6 +108,8 @@
 
 // left arm
 /obj/item/bodypart/arm/left/robot/android
+	burn_modifier = 0.8
+	brute_modifier = 0.8
 	biological_state = (BIO_ROBOTIC|BIO_BLOODED)
 
 /obj/item/bodypart/arm/left/robot/android/Initialize(mapload)
@@ -118,6 +126,8 @@
 
 // right leg
 /obj/item/bodypart/leg/right/robot/android
+	burn_modifier = 0.8
+	brute_modifier = 0.8
 	biological_state = (BIO_ROBOTIC|BIO_BLOODED)
 
 /obj/item/bodypart/leg/right/robot/android/Initialize(mapload)
@@ -134,6 +144,8 @@
 
 // left leg
 /obj/item/bodypart/leg/left/robot/android
+	burn_modifier = 0.8
+	brute_modifier = 0.8
 	biological_state = (BIO_ROBOTIC|BIO_BLOODED)
 
 /obj/item/bodypart/leg/left/robot/android/Initialize(mapload)


### PR DESCRIPTION
## About The Pull Request

Androids unintentionally inherited the robot limbs' damage resist, and are currently sitting at a 0.6x mod for **all** brute/burn damage taken. Noticed by someone in discord, everyone seemed to agree that this was probably a bit too good, and it seemed like more an oopsie than anything anyhow.

## Why It's Good For The Game

Despite the name, this isn't really a balancejak thing, although I do think it's ultimately good to not have such crazy damage disparity. Bugs r bad I think.

## Changelog

:cl:
fix: androids now take 0.8x damage instead of the (probably unintended?) 0.6x
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
