### PR TITLE
Normalizes sec's armor datum insanity going on.

### DIFF
--- a/modular_doppler/sec_armor_normalization/sec_armor_normalization.dm
+++ b/modular_doppler/sec_armor_normalization/sec_armor_normalization.dm
@@ -1,6 +1,6 @@
-//head_helmet should be for the helmet and headgear with no gimmicks.
-//cosmetic_sec should be used for headwear and chestwear that have gimmicks and aren't HoS or Warden exclusive (EG, they cover more than just the chest) its slightly less protective by like 5 on all values
-//and suit_armor is for armor that covers the chest and nothing else.
+//head_helmet should be for helmets and headgear with no gimmicks.
+//cosmetic_sec should be used for headwear and chestwear that have gimmicks and aren't HoS or Warden exclusive (EG, they cover more than just the chest and groin) its slightly less protective by like 5 on all values
+//and suit_armor is for body armor without gimmicks.
 
 /obj/item/clothing/suit/jacket/det_suit
 	armor_type = /datum/armor/cosmetic_sec

--- a/modular_doppler/sec_armor_normalization/sec_armor_normalization.dm
+++ b/modular_doppler/sec_armor_normalization/sec_armor_normalization.dm
@@ -1,0 +1,15 @@
+//head_helmet should be for the helmet and headgear with no gimmicks.
+//cosmetic_sec should be used for headwear and chestwear that have gimmicks and aren't HoS or Warden exclusive (EG, they cover more than just the chest) its slightly less protective by like 5 on all values
+//and suit_armor is for armor that covers the chest and nothing else.
+
+/obj/item/clothing/suit/jacket/det_suit
+	armor_type = /datum/armor/cosmetic_sec
+
+/obj/item/clothing/suit/armor/vest/secjacket
+	armor_type = /datum/armor/cosmetic_sec
+
+/obj/item/clothing/suit/hooded/wintercoat/security
+	armor_type = /datum/armor/cosmetic_sec
+
+/obj/item/clothing/head/hooded/winterhood/security
+	armor_type = /datum/armor/cosmetic_sec

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7377,6 +7377,7 @@
 #include "modular_doppler\research\techweb\roundstart_techweb_nodes.dm"
 #include "modular_doppler\ruins_but_epic\code\space_junk.dm"
 #include "modular_doppler\scream_b_gone\code\human.dm"
+#include "modular_doppler\sec_armor_normalization\sec_armor_normalization.dm"
 #include "modular_doppler\ship_captain\code\announcer.dm"
 #include "modular_doppler\ship_captain\code\globals.dm"
 #include "modular_doppler\ship_captain\code\preferences.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
did you know that for some insane reason, sec winter coats had 2 seperate armor datums with literally the same values for the chest and hood?
did you know that for some insane reason, detective jackets, sec winter coats, and the sec jacket all had seperate different armor values despite ostensibly doing the same thing?
why?
im changing it now finally. I'm also setting in place some expectations to how you guys should probably armor sec equipment going forward. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
its good for my mental state i don't think it has much effect on the game besides in practice making some slightly better.
cosmetic_sec is for gimmick armor (protects arms or does the cowboy hat thing where it can take a bullet for you)
head_helmet is for helmets and headgears with no gimmicks
suit_armor is the basic armor datum for sec vests and should be used on armor that covers bodyparts in line with that until we decide otherwise (Because I think kitty was working on elbow pads and kneepads and those might be armored idk?)

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: balanced the scales of sec armor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
