### PR TITLE
Updates our input prefs to use `onBlur` instead

### DIFF
--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/base.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/base.tsx
@@ -304,6 +304,7 @@ export function FeatureShortTextInput(
     <Input
       disabled={!serverData}
       fluid
+      expensive// DOPPLER EDIT ADDITION: Preferences text inputs don't explode the server
       value={value}
       maxLength={serverData?.maximum_length}
       onChange={handleSetValue}

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/base.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/base.tsx
@@ -304,7 +304,7 @@ export function FeatureShortTextInput(
     <Input
       disabled={!serverData}
       fluid
-      expensive// DOPPLER EDIT ADDITION: Preferences text inputs don't explode the server
+      expensive // DOPPLER EDIT ADDITION: Preferences text inputs don't explode the server
       value={value}
       maxLength={serverData?.maximum_length}
       onChange={handleSetValue}

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/base.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/base.tsx
@@ -304,7 +304,6 @@ export function FeatureShortTextInput(
     <Input
       disabled={!serverData}
       fluid
-      expensive
       value={value}
       maxLength={serverData?.maximum_length}
       onChange={handleSetValue}

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/base.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/base.tsx
@@ -304,10 +304,10 @@ export function FeatureShortTextInput(
     <Input
       disabled={!serverData}
       fluid
-      expensive // DOPPLER EDIT ADDITION: Preferences text inputs don't explode the server
+      expensive
       value={value}
       maxLength={serverData?.maximum_length}
-      onChange={handleSetValue}
+      onBlur={handleSetValue} // DOPPLER EDIT CHANGE: Preferences text inputs don't explode the server. Original: onChange={handleSetValue}
     />
   );
 }
@@ -325,10 +325,9 @@ export const FeatureTextInput = (
     <TextArea
       height="100px"
       width="100%"
-      expensive
       value={props.value}
       maxLength={props.serverData.maximum_length}
-      onChange={(value) => props.handleSetValue(value)}
+      onBlur={(value) => props.handleSetValue(value)}
     />
   );
 };

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/base.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/base.tsx
@@ -307,7 +307,7 @@ export function FeatureShortTextInput(
       expensive
       value={value}
       maxLength={serverData?.maximum_length}
-      onBlur={handleSetValue} // DOPPLER EDIT CHANGE: Preferences text inputs don't explode the server. Original: onChange={handleSetValue}
+      onChange={handleSetValue}
     />
   );
 }

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/base.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/base.tsx
@@ -324,6 +324,7 @@ export const FeatureTextInput = (
     <TextArea
       height="100px"
       width="100%"
+      expensive
       value={props.value}
       maxLength={props.serverData.maximum_length}
       onChange={(value) => props.handleSetValue(value)}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

A TGUI update changed how `onChange` works. What we *actually* want here, now, is `onBlur`.

This fixes that.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Good when the server doesn't explode.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: [DOPPLER] Typing in the large text inputs no longer makes the server explode.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
