### PR TITLE
Restore detective brown/noir trenchcoat/blazer loadout items

### DIFF
--- a/modular_doppler/loadout_categories/categories/clothing.dm
+++ b/modular_doppler/loadout_categories/categories/clothing.dm
@@ -55,12 +55,20 @@
 *	SUITS / SUIT JACKETS
 */
 
+/datum/loadout_item/suit/detective_black
+	name = "Noir Trenchcoat"
+	item_path = /obj/item/clothing/suit/toggle/jacket/det_trench/noir
+
 /datum/loadout_item/suit/detective_black_short
 	name = "Noir Suit Jacket"
 	item_path = /obj/item/clothing/suit/jacket/det_suit/noir
 
 /datum/loadout_item/suit/detective_brown
 	name = "Trenchcoat"
+	item_path = /obj/item/clothing/suit/toggle/jacket/det_trench
+
+/datum/loadout_item/suit/detective_brown_short
+	name = "Brown Suit Jacket"
 	item_path = /obj/item/clothing/suit/jacket/det_suit
 
 /datum/loadout_item/suit/its_pronounced_stow_ic_not_stoike


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

In the merging of an upstream pr for adding a gags blazer and trenchcoat, the brown and noir trenchcoats.
The intent in parity I believe was to replace these two with the gags versions by removing their colour subtypes, but the types in the loadout are actually their own icon states and not the gags types.
This re-adds those.

In the above process it seems the brown trenchcoat also got replaced with the brown suit jacket, due to some repathing shenanigans, this fixes that.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Good to fix, good for people's loadout prefs to not accidentally be swapped with a different thing.

The gags options aren't a suitable replacement for these, as no degree of colour-selection on those maintains the shading of these two items, and you instead get something that looks more like washed out bathrobes.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: [DOPPLER] Noir and brown trenchcoat are restored to the loadout.
fix: [DOPPLER] Brown suit jacket is no longer called "trenchcoat" in the loadout menu, and no longer replaces previously selected trenchcoats.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
