### PR TITLE
Makes the IRC tguisay thingy not pitch black and unreadable again

### DIFF
--- a/tgui/packages/tgui-say/styles/colors.scss
+++ b/tgui/packages/tgui-say/styles/colors.scss
@@ -30,7 +30,7 @@ $_channel_map: (
   // DOPPLER EDIT ADDITION START
   'LOOC': hsl(20, 100%, 86%),
   'Whis': hsl(238, 55%, 67%),
-  'Do': hsl(137, 64%, 60%), 
+  'Do': hsl(137, 64%, 60%),
   'IRC': hsl(312.8, 74.4%, 45.9%), // DOPPLER EDIT ADDITION END
 );
 

--- a/tgui/packages/tgui-say/styles/colors.scss
+++ b/tgui/packages/tgui-say/styles/colors.scss
@@ -30,7 +30,8 @@ $_channel_map: (
   // DOPPLER EDIT ADDITION START
   'LOOC': hsl(20, 100%, 86%),
   'Whis': hsl(238, 55%, 67%),
-  'Do': hsl(137, 64%, 60%), // DOPPLER EDIT ADDITION END
+  'Do': hsl(137, 64%, 60%), 
+  'IRC': hsl(312.8, 74.4%, 45.9%), // DOPPLER EDIT ADDITION END
 );
 
 $channel_keys: map.keys($_channel_map) !default;


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The tguisay window for the IRC quicktype had become pitch black and unreadable.
Seems the colour for this got lost in a parity update.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Less jank

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: [DOPPLER] The shift-y IRC tguisay is no longer pitch black and unreadable, and back to its original colour.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
