### PR TITLE
Adds screen-tip for accessable storage items/organs

### DIFF
--- a/code/modules/mob/living/carbon/carbon_context.dm
+++ b/code/modules/mob/living/carbon/carbon_context.dm
@@ -18,10 +18,24 @@
 		if (get_bodypart(human_user.zone_selected)?.get_modified_bleed_rate())
 			context[SCREENTIP_CONTEXT_CTRL_LMB] = "Grab limb"
 
+		// DOPPLER ADDITION START
+		var/obj/item/organ/tail/tail = human_user.get_organ_by_type(/obj/item/organ/tail)
+		var/obj/item/storage/backpack/backpack = human_user.get_item_by_slot(ITEM_SLOT_BACK)
+		if (tail && tail.GetComponent(/datum/component/accessable_storage))
+			context[SCREENTIP_CONTEXT_ALT_LMB] = "Open tail-slot"
+		else if (backpack && backpack.GetComponent(/datum/component/accessable_storage))
+			context[SCREENTIP_CONTEXT_ALT_LMB] = "Open storage"
+		// DOPPLER ADDITION END
+
 	if (human_user != src)
 		context[SCREENTIP_CONTEXT_RMB] = "Shove"
 
 		if (!human_user.combat_mode)
+			// DOPPLER ADDITION START
+			var/obj/item/storage/backpack/backpack = get_item_by_slot(ITEM_SLOT_BACK)
+			if (backpack && backpack.GetComponent(/datum/component/accessable_storage))
+				context[SCREENTIP_CONTEXT_ALT_LMB] = "Open storage"
+			// DOPPLER ADDITION END
 			if (body_position == STANDING_UP)
 				if(check_zone(user.zone_selected) == BODY_ZONE_HEAD && get_bodypart(BODY_ZONE_HEAD))
 					context[SCREENTIP_CONTEXT_LMB] = "Headpat"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Tin.

## Why It's Good For The Game

Just another attempt to make players aware some tails can store items.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Tails with storage and saddlebags with storage now give screen-tips when appropriate
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
