### PR TITLE
fixes that really annoying shuttle powernet bug in a probably really bad way

### DIFF
--- a/modular_doppler/shuttle_gear/code/wirefix.dm
+++ b/modular_doppler/shuttle_gear/code/wirefix.dm
@@ -1,0 +1,3 @@
+/obj/structure/cable/onShuttleMove(turf/newT, turf/oldT, list/movement_force, move_dir, obj/docking_port/stationary/old_dock, obj/docking_port/mobile/moving_dock)
+	cut_cable_from_powernet(FALSE)
+	return ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7514,6 +7514,7 @@
 #include "modular_doppler\ships_r_us\code\shuttle_templates\incomplete.dm"
 #include "modular_doppler\ships_r_us\code\shuttle_templates\mining.dm"
 #include "modular_doppler\shuttle_gear\code\ore_scoop.dm"
+#include "modular_doppler\shuttle_gear\code\wirefix.dm"
 #include "modular_doppler\soulcatcher\code\attachable_soulcatcher.dm"
 #include "modular_doppler\soulcatcher\code\handheld_soulcatcher.dm"
 #include "modular_doppler\soulcatcher\code\preferences.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

forces all power cables on a shuttle to reset themselves like they were just built again to prevent shuttles from losing power when rotated

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

there's a lot of bad mouthfeel when your shuttle powernet needs to be rebuilt just because you foolishly rotated your shuttle, players shouldn't have to deal with such things

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixes that kinda annoying shuttle powernet bug
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
