### PR TITLE
Fixes hand markings layering over gloves

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -757,7 +757,7 @@ GLOBAL_LIST_INIT(human_heights_to_offsets, list(
 /// Layer for bodyparts that should appear above every other bodypart - Currently only used for hands
 #define BODYPARTS_HIGH_LAYER 25
 /// DOPPLER SHIFT ADDITION BEGIN - For hand markings :3c
-#define BODY_HAND_LAYER 23.99
+#define BODY_HAND_LAYER 24.99
 /// DOPPLER SHIFT ADDITION END
 /// Gloves layer
 #define GLOVES_LAYER 24


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Tin.
`BODY_HAND_LAYER` was set to `23.99`, despite this being below `GLOVES_LAYER` and lower numbers meaning it gets layered higher.
This pr sets it to `24.99` instead, putting it back between `GLOVES_LAYER 24` and `BODYPARTS_HIGH_LAYER 25` (hands).

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

less jank

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: [DOPPLER] Hand markings no longer layer on top of gloves.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
