### PR TITLE
Antag Cantina Revision 2: Less comms (for now), mapping fixes, account fixes

### DIFF
--- a/_maps/doppler/cantina/badguyzone.dmm
+++ b/_maps/doppler/cantina/badguyzone.dmm
@@ -232,23 +232,36 @@
 /obj/structure/sign/poster/contraband/donk_co/directional/north,
 /obj/structure/table,
 /obj/item/reagent_containers/cup/beaker{
-	pixel_x = 5;
+	pixel_x = 0;
 	pixel_y = 12
 	},
 /obj/item/reagent_containers/condiment/soysauce{
-	pixel_x = -7;
-	pixel_y = 9
+	pixel_x = -8;
+	pixel_y = 15
 	},
 /obj/item/reagent_containers/condiment/enzyme{
-	pixel_y = 3;
-	pixel_x = -7
+	pixel_y = 10;
+	pixel_x = -9
 	},
 /obj/item/reagent_containers/cup/beaker{
-	pixel_x = 5;
+	pixel_x = 0;
 	pixel_y = 12
 	},
 /obj/item/reagent_containers/cup/glass/mug{
-	pixel_x = 8
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/cup/glass/mug{
+	pixel_y = -1;
+	pixel_x = 1
+	},
+/obj/item/storage/box/coffeepack/robusta{
+	pixel_x = 11;
+	pixel_y = 6
+	},
+/obj/item/storage/box/coffeepack{
+	pixel_y = 13;
+	pixel_x = 11
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/powered)
@@ -641,17 +654,6 @@
 "nf" = (
 /obj/structure/table,
 /obj/machinery/coffeemaker/impressa,
-/obj/item/storage/box/coffeepack{
-	pixel_y = 4;
-	pixel_x = 10
-	},
-/obj/item/storage/box/coffeepack/robusta{
-	pixel_x = 6
-	},
-/obj/item/reagent_containers/cup/glass/mug{
-	pixel_y = 2;
-	pixel_x = -5
-	},
 /obj/machinery/light/dim/directional/north,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/powered)
@@ -689,6 +691,7 @@
 /area/ruin/space/has_grav/powered)
 "nT" = (
 /obj/machinery/griddle,
+/obj/item/radio/intercom/cantina/directional/north,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/powered)
 "oo" = (
@@ -737,7 +740,14 @@
 "oY" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/cup/glass/shaker,
+/obj/item/reagent_containers/cup/glass/shaker{
+	pixel_x = 6;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/dropper{
+	pixel_x = -2;
+	pixel_y = 8
+	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/powered)
 "pi" = (
@@ -1097,6 +1107,8 @@
 /obj/item/storage/box/cantina_sweeteners,
 /obj/item/storage/box/rxglasses/spyglasskit,
 /obj/item/clothing/glasses/sunglasses/reagent,
+/obj/item/storage/medkit/surgery_syndie,
+/obj/item/defibrillator/compact/combat/loaded,
 /turf/open/floor/wood/parquet,
 /area/ruin/space/has_grav/powered)
 "yE" = (

--- a/_maps/doppler/cantina/badguyzone.dmm
+++ b/_maps/doppler/cantina/badguyzone.dmm
@@ -1894,6 +1894,7 @@
 /obj/machinery/light/dim/directional/south,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/radio/intercom/cantina/directional/south,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered)
 "Rw" = (

--- a/_maps/doppler/cantina/badguyzone.dmm
+++ b/_maps/doppler/cantina/badguyzone.dmm
@@ -368,7 +368,7 @@
 	pixel_x = 5
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/powered)
 "hO" = (
 /obj/item/storage/toolbox/guncase/smartgun{
@@ -401,7 +401,7 @@
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/vending/cola/red,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/powered)
 "ig" = (
 /obj/machinery/chem_master/condimaster{
@@ -971,7 +971,7 @@
 /turf/open/misc/asteroid/airless,
 /area/space)
 "vF" = (
-/obj/machinery/holopad,
+/obj/machinery/holopad/secure,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/powered)
@@ -1222,7 +1222,7 @@
 	},
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/powered)
 "Bd" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1722,7 +1722,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/powered)
 "MP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,

--- a/_maps/doppler/cantina/badguyzone.dmm
+++ b/_maps/doppler/cantina/badguyzone.dmm
@@ -1535,6 +1535,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/detectiveboard/directional/east,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered)
 "HM" = (

--- a/code/__DEFINES/radio.dm
+++ b/code/__DEFINES/radio.dm
@@ -142,3 +142,7 @@
 #define RADIO_SPECIAL_CENTCOM (1<<1)
 ///Bitflag for if a headset can use the binary radio channel
 #define RADIO_SPECIAL_BINARY (1<<2)
+// DOPPLER EDIT ADDITION START - CANTINA_COMMS
+///Bitflag for if a radio can use the syndicate radio channel, without the side-effects
+#define RADIO_SPECIAL_CANTINA_HEADSET (1<<3)
+// DOPPLER EDIT ADDITION END - CANTINA_COMMS

--- a/code/game/machinery/telecomms/broadcasting.dm
+++ b/code/game/machinery/telecomms/broadcasting.dm
@@ -143,6 +143,11 @@
 			// Syndicate radios can hear all well-known radio channels
 			if (num2text(frequency) in GLOB.reverseradiochannels)
 				for(var/obj/item/radio/syndicate_radios in GLOB.all_radios["[FREQ_SYNDICATE]"])
+					// DOPPLER EDIT ADDITION START - CANTINA_COMMS
+					// Cantina encryption key ONLY works for syndicate comms.
+					if((syndicate_radios.special_channels & RADIO_SPECIAL_CANTINA_HEADSET) && (frequency != FREQ_SYNDICATE))
+						continue
+					// DOPPLER EDIT ADDITION END - CANTINA_COMMS
 					if(syndicate_radios.can_receive(FREQ_SYNDICATE, RADIO_NO_Z_LEVEL_RESTRICTION))
 						radios |= syndicate_radios
 

--- a/modular_doppler/modular_antagonists/cantina/cantina_items.dm
+++ b/modular_doppler/modular_antagonists/cantina/cantina_items.dm
@@ -155,6 +155,7 @@
 	icon_off = "intercom_command-p"
 	freerange = TRUE
 	subspace_transmission = TRUE
+	canhear_range = 13
 	keyslot = /obj/item/encryptionkey/syndicate/cantina_intercom
 
 /obj/item/radio/intercom/cantina/Initialize(mapload, ndir, building)

--- a/modular_doppler/modular_antagonists/cantina/cantina_items.dm
+++ b/modular_doppler/modular_antagonists/cantina/cantina_items.dm
@@ -125,7 +125,8 @@
 
 /obj/item/encryptionkey/syndicate/cantina_headset
 	name = "undisclosed encryption key"
-	desc = "An encryption key for a radio headset, allowing use of the Curfew and Sundown's network."
+	desc = "An encryption key for a radio headset, allowing use of the Curfew and Sundown's network. \
+	To avoid any long-term interference, the actual key changes on the regular."
 	channels = list(RADIO_CHANNEL_SYNDICATE = 1)
 	special_channels = RADIO_SPECIAL_CANTINA_HEADSET
 
@@ -147,7 +148,9 @@
 
 /obj/item/radio/intercom/cantina
 	name = "listening ear intercom"
-	desc = "The Curfew and Sundown's special free-frequency intercom. It's a versatile tool that can be tuned to any frequency, granting you access to channels you're not supposed to be on. Plus, it comes equipped with a built-in voice amplifier for crystal-clear communication."
+	desc = "The Curfew and Sundown's special free-frequency intercom, \
+	allowing you to snoop in on practically any local frequency. \
+	To maintain customer privacy, however, it is functionally incapable of sending anything."
 	icon_state = "intercom_command"
 	icon_off = "intercom_command-p"
 	freerange = TRUE

--- a/modular_doppler/modular_antagonists/cantina/cantina_items.dm
+++ b/modular_doppler/modular_antagonists/cantina/cantina_items.dm
@@ -116,3 +116,64 @@
 	visible_to_network = !visible_to_network
 	balloon_alert(user, (visible_to_network ? "fax unhidden" : "fax hidden"))
 	return CLICK_ACTION_SUCCESS
+
+
+/*
+ * Cantina Encryption Key. edit key: CANTINA_COMMS
+ * Traitor comms only, doesn't block radio, doesn't show station comms.
+ */
+
+/obj/item/encryptionkey/syndicate/cantina_headset
+	name = "undisclosed encryption key"
+	desc = "An encryption key for a radio headset, allowing use of the Curfew and Sundown's network."
+	channels = list(RADIO_CHANNEL_SYNDICATE = 1)
+	special_channels = RADIO_SPECIAL_CANTINA_HEADSET
+
+/obj/item/radio/headset/can_receive(input_frequency, list/levels)
+	. = ..()
+	if(input_frequency != FREQ_SYNDICATE)
+		return
+	if(special_channels & RADIO_SPECIAL_CANTINA_HEADSET)
+		return TRUE
+
+
+/*
+ * Cantina Intercom
+ * Allows for listening in on station comms from the cantina.
+ */
+
+/obj/item/encryptionkey/syndicate/cantina_intercom
+	channels = list(RADIO_CHANNEL_SYNDICATE = 0, RADIO_CHANNEL_COMMAND = 0, RADIO_CHANNEL_SECURITY = 0, RADIO_CHANNEL_ENGINEERING = 0, RADIO_CHANNEL_SCIENCE = 0, RADIO_CHANNEL_MEDICAL = 0, RADIO_CHANNEL_SUPPLY = 0, RADIO_CHANNEL_SERVICE = 0)
+
+/obj/item/radio/intercom/cantina
+	name = "listening ear intercom"
+	desc = "The Curfew and Sundown's special free-frequency intercom. It's a versatile tool that can be tuned to any frequency, granting you access to channels you're not supposed to be on. Plus, it comes equipped with a built-in voice amplifier for crystal-clear communication."
+	icon_state = "intercom_command"
+	icon_off = "intercom_command-p"
+	freerange = TRUE
+	subspace_transmission = TRUE
+	keyslot = /obj/item/encryptionkey/syndicate/cantina_intercom
+
+/obj/item/radio/intercom/cantina/Initialize(mapload, ndir, building)
+	. = ..()
+	recalculateChannels()
+	set_broadcasting(FALSE)
+	set_listening(FALSE)
+
+/obj/item/radio/intercom/cantina/talk_into_impl(atom/movable/talking_movable, message, channel, list/spans, datum/language/language, list/message_mods)
+	return // Can't talked through. Use the holopad, or go to the station!
+
+#define FREQ_LISTENING (1<<0) // Local define in the nonmodular radio file, so, we redo it here.
+
+/obj/item/radio/intercom/cantina/can_receive(input_frequency, list/levels)
+	if (input_frequency == frequency)
+		return TRUE
+	for(var/ch_name in channels)
+		if(channels[ch_name] & FREQ_LISTENING)
+			if(GLOB.radiochannels[ch_name] == text2num(input_frequency))
+				return TRUE
+	return FALSE
+
+#undef FREQ_LISTENING
+
+MAPPING_DIRECTIONAL_HELPERS(/obj/item/radio/intercom/cantina, 27)

--- a/modular_doppler/modular_antagonists/cantina/cantina_roles.dm
+++ b/modular_doppler/modular_antagonists/cantina/cantina_roles.dm
@@ -23,8 +23,8 @@
 	shoes = /obj/item/clothing/shoes/jackboots/frontier_colonist
 	gloves = /obj/item/clothing/gloves/combat
 	back = /obj/item/storage/backpack/industrial/frontier_colonist
-	ears = /obj/item/radio/headset/syndicate/alt
-	l_pocket = /obj/item/modular_computer/pda
+	ears = /obj/item/radio/headset/chameleon
+	l_pocket = /obj/item/modular_computer/pda/chameleon
 	r_pocket = /obj/item/pen/edagger
 	id = /obj/item/card/id/advanced/chameleon
 	belt = /obj/item/storage/belt/utility/frontier_colonist
@@ -41,7 +41,7 @@
 	gloves = /obj/item/clothing/gloves/combat
 	back = /obj/item/storage/backpack/industrial/frontier_colonist
 	ears = /obj/item/radio/headset/syndicate/alt
-	l_pocket = /obj/item/modular_computer/pda
+	l_pocket = /obj/item/modular_computer/pda/chameleon
 	r_pocket = /obj/item/pen/edagger
 	id = /obj/item/card/id/advanced/chameleon
 	belt = /obj/item/storage/belt/utility/frontier_colonist

--- a/modular_doppler/modular_antagonists/cantina/cantina_roles.dm
+++ b/modular_doppler/modular_antagonists/cantina/cantina_roles.dm
@@ -32,6 +32,7 @@
 	implants = /obj/item/implant/weapons_auth
 	backpack_contents = list(
 		/obj/item/stack/spacecash/c1000 = 2,
+		/obj/item/encryptionkey/syndicate,
 		)
 
 /datum/outfit/cantina_bartender

--- a/modular_doppler/modular_antagonists/cantina/cantina_roles.dm
+++ b/modular_doppler/modular_antagonists/cantina/cantina_roles.dm
@@ -32,7 +32,7 @@
 	implants = /obj/item/implant/weapons_auth
 	backpack_contents = list(
 		/obj/item/stack/spacecash/c1000 = 2,
-		/obj/item/encryptionkey/syndicate,
+		/obj/item/encryptionkey/syndicate/cantina_headset,
 		)
 
 /datum/outfit/cantina_bartender

--- a/modular_doppler/modular_antagonists/cantina/spawners.dm
+++ b/modular_doppler/modular_antagonists/cantina/spawners.dm
@@ -22,7 +22,7 @@
 
 /obj/effect/mob_spawn/ghost_role/human/cantina/special(mob/living/new_spawn)
 	. = ..()
-	var/datum/bank_account/remote/bank_account = new(new_spawn.real_name)
+	var/datum/bank_account/remote/bank_account = new(new_spawn.real_name, SSjob.get_job_type(/datum/job/unassigned))
 	bank_account.replaceable = FALSE
 	new_spawn.add_mob_memory(/datum/memory/key/account, remembered_id = bank_account.account_id)
 
@@ -48,6 +48,6 @@
 
 /obj/effect/mob_spawn/ghost_role/human/cantina_bartender/special(mob/living/new_spawn)
 	. = ..()
-	var/datum/bank_account/remote/bank_account = new(new_spawn.real_name)
+	var/datum/bank_account/remote/bank_account = new(new_spawn.real_name, SSjob.get_job_type(/datum/job/unassigned))
 	bank_account.replaceable = FALSE
 	new_spawn.add_mob_memory(/datum/memory/key/account, remembered_id = bank_account.account_id)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Simply removes airless tiles, makes the holopad secure, and gives the cantina regulars/bartenders unassigned jobs to their bank accounts so they're technically real. The bank account bit would require an upstream refactor of bank accounts in general to work any better than that, sadly.

This also changes regular syndicate bowman headsets into chameleon headsets, without all the comms channels and flashbang protection immediately.
~~I do want to look into a solution that lets the cantina in general hear station comms so they can coordinate based on such while in the cantina, but that it outside of the scope of this pr.~~
Edit: The syndicate comms ONLY encryption key has been added to their backpacks, making it still spawned with but opt-in. Annoyingly syndicate comms only encryption keys requires some non-modular edits due to how it's implemented upstream, but weren't too hard to implement.
Edit 2: We also add an intercom with all crew frequencies toggleable, that cannot be talked into, for keeping track of station chaos levels and potential ideas to jump in on from the cantina.

As a side it makes the PDAs chameleon too.

Edit 2: Besides that, we add a surgical medkit and combat defib to the bartender by popular request of needing to do bar revivals not uncommonly. We add a dropper for drinks, and shuffle around some items for sanity's sake.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Mapping fixes are obvious

Chameleon uplink items for style reasons.

I think it's more interesting if regulars have imperfect information relayed to them by the bartender mission command.
It helps encourage teamwork with the bartender, too- rather than the comms help being unneeded, because everyone already hears all other comms themselves by default.
Besides that, it's less interesting if all crew comms are compromised roundstart, and all antag comms are potentially compromised the moment any random antag falls into security hands.

Flashbang protection for everyone is just a bit over the top, I'd rather have that be explicitly opt-in by the antag than a default thing.

Edit 2: Surgical medkit and combat defib are so the bartender can actually revive the rowdy customers they poisoned, or provide (or withhold) medical attention.
The intercom helps coordinate from the cantina without invalidating crew comms by default, so regulars that take a bit to RP with the bartender or each other still have a rough idea of station chaos before hopping down.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: [DOPPLER] Cantina holopad is now secure, so crew heads of staff can no longer auto-connect to it.
fix: [DOPPLER] Cantina phone booth no longer trips the air alarms.
fix: [DOPPLER] Cantina bank accounts are real accounts now.
balance: [DOPPLER] Cantina regulars start with chameleon headsets, instead of syndicate bowman headset.
balance: [DOPPLER] A traitor comms ONLY encryption key has been added to the regulars' backpacks.
balance: [DOPPLER] Cantina bartender and regulars start with chameleon PDAs.
balance: [DOPPLER] Cantina bartender closet starts with a syndicate surgical medkit and combat defib.
balance: [DOPPLER] Cantina starts with a dropper. How balanceful.
balance: [DOPPLER] Cantina has an intercom with toggleable station frequencies.
balance: [DOPPLER] Cantina has a detective board in the backroom, for scheming.
mapping: [DOPPLER] Some items have been visually shuffled around for less overlap.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
