### PR TITLE
BLATANT mining powercreep that WILL unbalance the game and make it unfun for everybody

### DIFF
--- a/modular_doppler/mining/equipment/trophies_misc.dm
+++ b/modular_doppler/mining/equipment/trophies_misc.dm
@@ -13,13 +13,11 @@
 /obj/item/crusher_trophy/skill_check/add_to(obj/item/kinetic_crusher/pkc, mob/living/user)
 	. = ..()
 
-	pkc.detonation_damage *=0.8
 	pkc.backstab_bonus *= 2
 
 /obj/item/crusher_trophy/skill_check/remove_from(obj/item/kinetic_crusher/pkc, mob/living/user)
 	. = ..()
 
-	pkc.detonation_damage /=0.8
 	pkc.backstab_bonus /= 2
 
 


### PR DESCRIPTION
## About The Pull Request

removes the 20% detonation damage penalty on the skillchecker

## Why It's Good For The Game

after you stack all your upgrades, it actually becomes flat-out better to just not have the skillchecker on the weapon, and that's kind of weird. so, just removes the stat penalty

## Changelog

:cl:
balance: skill checker no longer lowers normal detonation damage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
