### PR TITLE
changes some species descnames around

### DIFF
--- a/modular_doppler/flavortext_and_records/code/physiology.dm
+++ b/modular_doppler/flavortext_and_records/code/physiology.dm
@@ -4,7 +4,7 @@
 // Lore people will probably want to change some of these.
 
 /datum/species/human
-	name = "Anthropoid" // i have a feeling people won't like this
+	name = "Hominin" // i have a feeling people still won't like this
 
 /datum/species/monkey
 	name = "Primate"
@@ -30,4 +30,5 @@
 /datum/species/pod
 	name = "Viridian"
 
-
+/datum/species/human/genemod
+	name = "Splicer"


### PR DESCRIPTION
## About The Pull Request
anthropoid was kinda weird yeah; also adds one for genemods because 'genemodder' has no swag.

## Why It's Good For The Game
'anthropoid' was clunky and sounds like some sort of esoteric slur for the great human race, bit we do still need it to be equivalent to 'reptilian' and 'crystalline' incase you wanna do cool stuff with it that isn't just a normal guy.

## Changelog
:cl:
add: 'Anthropoid' is swapped out for 'Hominin,' 'Genemodder' is swapped out for 'Splicer.'
/:cl: