### PR TITLE
Allows admins to recall the end of shift shuttle

### DIFF
--- a/code/modules/admin/verbs/adminshuttle.dm
+++ b/code/modules/admin/verbs/adminshuttle.dm
@@ -53,6 +53,10 @@ ADMIN_VERB(cancel_shuttle, R_ADMIN, "Cancel Shuttle", "Recall the shuttle, regar
 
 	if(tgui_alert(user, "You sure?", "Confirm", list("Yes", "No")) != "Yes")
 		return
+	// DOPPLER EDIT START - Revert auto-transfer shuttle
+	if(SSshuttle.endvote_passed)
+		SSshuttle.revert_end_of_shift()
+	// DOPPLER EDIT END
 	SSshuttle.admin_emergency_no_recall = FALSE
 	SSshuttle.emergency.cancel()
 	BLACKBOX_LOG_ADMIN_VERB("Cancel Shuttle")

--- a/modular_doppler/autotransfer/autotransfer.dm
+++ b/modular_doppler/autotransfer/autotransfer.dm
@@ -36,7 +36,7 @@ SUBSYSTEM_DEF(autotransfer)
 		targettime = targettime + voteinterval
 		curvotes++
 	else
-		SSshuttle.autoEnd()
+		SSshuttle.call_end_of_shift_shuttle()
 
 /**
  * At shift start, pulls the autotransfer interval from config and applies

--- a/modular_doppler/autotransfer/shuttle.dm
+++ b/modular_doppler/autotransfer/shuttle.dm
@@ -1,10 +1,11 @@
 /// ADDITIONAL PROC EDITS AS FOLLOWS:
 // - code/modules/shuttle/emergency.dm - /obj/docking_port/mobile/emergency/request
+// - code/modules/admin/verbs/adminshuttle.dm - cancel_shuttle ADMIN_VERB
 
 /datum/controller/subsystem/shuttle
 	var/endvote_passed = FALSE
 
-/datum/controller/subsystem/shuttle/proc/autoEnd()
+/datum/controller/subsystem/shuttle/proc/call_end_of_shift_shuttle()
 	if(EMERGENCY_IDLE_OR_RECALLED)
 		SSshuttle.emergency.request(silent = TRUE)
 		priority_announce("The shift has come to an end and the shuttle called. [SSsecurity_level.get_current_level_as_number() == SEC_LEVEL_RED ? "Red Alert state confirmed: Dispatching priority shuttle. " : "" ]It will arrive in [emergency.timeLeft(600)] minutes.", null, ANNOUNCER_SHUTTLECALLED, "Priority", color_override = "orange")
@@ -13,3 +14,8 @@
 	emergency_no_recall = TRUE
 	endvote_passed = TRUE
 	SSevents.can_fire = FALSE // we're going home
+
+/datum/controller/subsystem/shuttle/proc/revert_end_of_shift()
+	emergency_no_recall = FALSE
+	endvote_passed = FALSE
+	SSevents.can_fire = TRUE

--- a/modular_doppler/autotransfer/transfer_vote.dm
+++ b/modular_doppler/autotransfer/transfer_vote.dm
@@ -35,7 +35,7 @@
 		return
 
 	if(winning_option == CHOICE_TRANSFER)
-		SSshuttle.autoEnd()
+		SSshuttle.call_end_of_shift_shuttle()
 		var/obj/machinery/computer/communications/comms_console = locate() in GLOB.shuttle_caller_list
 		if(comms_console)
 			comms_console.post_status("shuttle")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Sooooooo in one of the recent rounds the transfer shuttle passed unintentionally, and as an admin attempted to recall it- it just didn't do anything.
Even if you could, it'd still brick the events subsystem!
This just makes the Cancel Shuttle admin verb reset the end of shift changes when you use it, allowing it to actually be recalled and unbricking the events subsystem.

We also rename `autoEnd()` to `call_end_of_shift_shuttle()` to be slightly clearer.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

less jank :+1:

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
admin: [DOPPLER] Cancel Shuttle admin verb can actually cancel the end of shift shuttle.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
