### PR TITLE
Assorted ammo fixes

### DIFF
--- a/code/datums/storage/subtypes/holsters.dm
+++ b/code/datums/storage/subtypes/holsters.dm
@@ -66,6 +66,10 @@
 		/obj/item/gun/energy/laser/captain,
 		/obj/item/gun/energy/e_gun/hos,
 		/obj/item/gun/ballistic/rifle/boltaction, //fits if you make it an obrez
+		// DOPPLER ADDITION START - New ammo types for the detective revolver
+		/obj/item/ammo_box/magazine/ammo_stack/c6ng,
+		/obj/item/ammo_casing/c6ng,
+		// DOPPLER ADDITION END
 	)
 
 	return ..()

--- a/modular_doppler/modular_weapons/code/ammo/detective_holster.dm
+++ b/modular_doppler/modular_weapons/code/ammo/detective_holster.dm
@@ -1,0 +1,10 @@
+
+// Paired with non-modular edits to:
+// - `code/datums/storage/subtypes/holsters.dm`, detective holster storage
+
+// Spawn ammo stacks used for replacement detective revolver.
+/obj/item/storage/belt/holster/detective/full/PopulateContents()
+	generate_items_inside(list(
+		/obj/item/ammo_box/magazine/ammo_stack/c6ng/full = 2,
+		/obj/item/gun/ballistic/revolver/c38/detective = 1,
+	), src)

--- a/modular_doppler/modular_weapons/code/ammo_stacks/ammo_stack_base.dm
+++ b/modular_doppler/modular_weapons/code/ammo_stacks/ammo_stack_base.dm
@@ -5,25 +5,16 @@
 	icon = 'modular_doppler/modular_weapons/icons/obj/ammo_stacks.dmi'
 	icon_state = "stack_regular"
 	base_icon_state = "ammo_stack"
+	appearance_flags = parent_type::appearance_flags | KEEP_TOGETHER
 	w_class = WEIGHT_CLASS_SMALL
 	multiple_sprites = AMMO_BOX_ONE_SPRITE
 	multiload = FALSE
 	start_empty = TRUE
 	max_ammo = 12
-	/// Every x position we use for casings, change based on the size of the casing being put into the stack
-	var/list/casing_x_positions = list(
-		-2,
-		-1,
-		0,
-		1,
-		2,
-	)
-	/// How much space vertically should we leave for casings in random casing y pixel shifts
-	var/casing_y_padding = 3
-
-/obj/item/ammo_box/magazine/ammo_stack/Initialize(mapload)
-	. = ..()
-	AddElement(/datum/element/can_shatter, number_of_shards = 0, shattering_sound = 'sound/items/weapons/gun/general/mag_bullet_remove.ogg', shatters_as_weapon = TRUE)
+	/// Spacing between random w offsets of casings. Change based on the size of the casing being put into the stack.
+	var/casing_w_spacing = 1
+	/// How much space vertically should we leave for casings in random casing z pixel shifts.
+	var/casing_z_padding = 3
 
 /obj/item/ammo_box/magazine/ammo_stack/attack_self(mob/user)
 	. = ..()
@@ -41,22 +32,83 @@
 	. = ..()
 	check_empty()
 
+/obj/item/ammo_box/magazine/ammo_stack/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
+	. = ..()
+	if(.) // They caught all the bullets. Powerful.
+		return
+	scatter(hit_atom, 48)
+
+/obj/item/ammo_box/magazine/ammo_stack/onZImpact(turf/impacted_turf, levels, impact_flags)
+	. = ..()
+	scatter(impacted_turf, 48)
+
+/obj/item/ammo_box/magazine/ammo_stack/afterattack(atom/target, mob/user, list/modifiers, list/attack_modifiers)
+	scatter(target, 48)
+
 /// Checks the shells in the ammo stack to make sure it isn't empty, if it is, the stack is deleted
 /obj/item/ammo_box/magazine/ammo_stack/proc/check_empty()
 	if(!ammo_count(TRUE) && !QDELING(src))
 		qdel(src)
 
+/obj/item/ammo_box/magazine/ammo_stack/proc/scatter(atom/hit_atom, pixel_distance = 48)
+	var/turf/scatter_turf = get_turf(hit_atom)
+	if(!hit_atom.CanPass(src, get_dir(src, hit_atom))) //Object is too dense to fall apart on
+		scatter_turf = get_turf(src)
+
+	var/generator/scatter_gen = generator(GEN_CIRCLE, 0, pixel_distance, NORMAL_RAND)
+	for(var/obj/item/ammo_casing/scattered_casing as anything in ammo_list())
+		scattered_casing.forceMove(scatter_turf)
+		var/list/scatter_vector = scatter_gen.Rand()
+		scatter_individual_casing(scattered_casing, scatter_vector[1], scatter_vector[2])
+
+	playsound(scatter_turf, 'sound/items/weapons/gun/general/mag_bullet_remove.ogg', 60, TRUE)
+	check_empty()
+
+/obj/item/ammo_box/magazine/ammo_stack/proc/scatter_individual_casing(obj/item/ammo_casing/scattered_casing, pixel_x_offset = 0, pixel_y_offset = 0)
+	if(prob(50)) // Randomize order, avoid bias to one axis if stepping is blocked
+		pixelmove_casing(scattered_casing, pixel_y_offset, x_axis = FALSE)
+		pixelmove_casing(scattered_casing, pixel_x_offset, x_axis = TRUE)
+	else
+		pixelmove_casing(scattered_casing, pixel_x_offset, x_axis = TRUE)
+		pixelmove_casing(scattered_casing, pixel_y_offset, x_axis = FALSE)
+	scattered_casing.bounce_away(FALSE, rand(0, 3))
+
+/obj/item/ammo_box/magazine/ammo_stack/proc/pixelmove_casing(obj/item/ammo_casing/scattered_casing, pixel_offset = 0, x_axis = TRUE)
+	var/positive_dir = x_axis ? EAST : NORTH
+	var/negative_dir = x_axis ? WEST : SOUTH
+	var/per_step = x_axis ? ICON_SIZE_X : ICON_SIZE_Y
+	var/half_step = per_step / 2
+
+	if(abs(pixel_offset) > half_step)
+		var/positive_offset = (pixel_offset > 0)
+		var/offset_correction = positive_offset ? -half_step : half_step
+		var/step_dir = positive_offset ? positive_dir : negative_dir
+		for(var/i in 1 to floor(abs(pixel_offset) + half_step) / per_step)
+			step(scattered_casing, step_dir)
+		pixel_offset = (pixel_offset % half_step) + offset_correction
+
+	if(x_axis)
+		scattered_casing.pixel_x = pixel_offset
+	else
+		scattered_casing.pixel_y = pixel_offset
+
 /obj/item/ammo_box/magazine/ammo_stack/update_appearance()
 	. = ..()
-	cut_overlays()
-	if(!ammo_count(TRUE))
+	if(!ammo_count())
 		return
-
 	icon_state = base_icon_state
 
+/obj/item/ammo_box/magazine/ammo_stack/update_overlays()
+	. = ..()
+	if(!ammo_count())
+		return
+
 	for(var/obj/item/ammo_casing/iterated_casing as anything in stored_ammo)
-		var/image/overlayed_item = image(icon = iterated_casing.icon, icon_state = "[initial(iterated_casing.icon_state)]-live", pixel_x = pick(casing_x_positions), pixel_y = rand((-16 + casing_y_padding), (16 - casing_y_padding)))
-		add_overlay(overlayed_item)
+		var/mutable_appearance/overlayed_casing = mutable_appearance(icon = iterated_casing.icon, icon_state = "[initial(iterated_casing.icon_state)]-live")
+		overlayed_casing.pixel_w = rand(-2, 2) * casing_w_spacing
+		var/z_offset_range = 16 - casing_z_padding
+		overlayed_casing.pixel_z = rand(-z_offset_range, z_offset_range)
+		. += overlayed_casing
 
 // Allows ammo casings to be attacked together to make a new stack
 /obj/item/ammo_casing
@@ -69,33 +121,26 @@
 		. += span_notice("[src] can be stacked with other casings of a similar type.")
 	return .
 
-/obj/item/ammo_casing/attackby(obj/item/attacking_item, mob/user, params)
-	. = ..()
+/obj/item/ammo_casing/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(!istype(tool, /obj/item/ammo_casing))
+		return NONE
 
-	if(!istype(attacking_item, /obj/item/ammo_casing))
-		return
-
-	var/obj/item/ammo_casing/ammo_casing = attacking_item
-	if(!ammo_casing.ammo_stack_type)
-		balloon_alert(user, "[ammo_casing] can't stack")
-		return
+	var/obj/item/ammo_casing/used_casing = tool
+	if(!used_casing.ammo_stack_type)
+		balloon_alert(user, "used casing can't stack")
+		return ITEM_INTERACT_BLOCKING
 	if(!ammo_stack_type)
-		balloon_alert(user, "[src] can't stack")
-		return
-	if(caliber != ammo_casing.caliber)
-		balloon_alert(user, "can't stack different calibers")
-		return
-	if(ammo_stack_type != ammo_casing.ammo_stack_type)
-		balloon_alert(user, "can't stack [src] with [ammo_casing]")
-		return
-	if(!loaded_projectile || !ammo_casing.loaded_projectile)
-		balloon_alert(user, "can't stack empty casings")
-		return
+		balloon_alert(user, "target can't stack!")
+		return ITEM_INTERACT_BLOCKING
+	if(ammo_stack_type != used_casing.ammo_stack_type)
+		balloon_alert(user, "can't stack together!")
+		return ITEM_INTERACT_BLOCKING
+	if(!loaded_projectile || !used_casing.loaded_projectile)
+		balloon_alert(user, "can't stack empty casings!")
+		return ITEM_INTERACT_BLOCKING
 
 	var/obj/item/ammo_box/magazine/ammo_stack = new ammo_stack_type(drop_location())
-	//user.transferItemToLoc(src, ammo_stack, silent = TRUE)
 	ammo_stack.give_round(src)
-	//user.transferItemToLoc(ammo_casing, ammo_stack, silent = TRUE)
-	ammo_stack.give_round(ammo_casing)
+	ammo_stack.give_round(used_casing)
 	user.put_in_hands(ammo_stack)
 	ammo_stack.update_appearance()

--- a/modular_doppler/modular_weapons/code/ammo_stacks/europa_25.dm
+++ b/modular_doppler/modular_weapons/code/ammo_stacks/europa_25.dm
@@ -4,14 +4,8 @@
 	caliber = CALIBER_25EUROPA
 	ammo_type = /obj/item/ammo_casing/c25euro
 	max_ammo = 5
-	casing_x_positions = list(
-		-4,
-		-2,
-		0,
-		2,
-		4,
-	)
-	casing_y_padding = 6
+	casing_w_spacing = 2
+	casing_z_padding = 6
 
 /obj/item/ammo_box/magazine/ammo_stack/c25euro/full
 	start_empty = FALSE

--- a/modular_doppler/modular_weapons/code/ammo_stacks/gibraltar.dm
+++ b/modular_doppler/modular_weapons/code/ammo_stacks/gibraltar.dm
@@ -4,14 +4,8 @@
 	caliber = CALIBER_6MMGIBRALTAR
 	ammo_type = /obj/item/ammo_casing/c6ng
 	max_ammo = 14
-	casing_x_positions = list(
-		-4,
-		-2,
-		0,
-		2,
-		4,
-	)
-	casing_y_padding = 6
+	casing_w_spacing = 2
+	casing_z_padding = 6
 
 /obj/item/ammo_box/magazine/ammo_stack/c6ng/full
 	start_empty = FALSE

--- a/modular_doppler/modular_weapons/code/ammo_stacks/naraka_585.dm
+++ b/modular_doppler/modular_weapons/code/ammo_stacks/naraka_585.dm
@@ -6,14 +6,8 @@
 	ammo_type = /obj/item/ammo_casing/c585naraka
 	casing_phrasing = "casing"
 	max_ammo = 6
-	casing_x_positions = list(
-		-6,
-		-3,
-		0,
-		3,
-		6,
-	)
-	casing_y_padding = 9
+	casing_w_spacing = 3
+	casing_z_padding = 9
 
 /obj/item/ammo_box/magazine/ammo_stack/c585naraka/full
 	start_empty = FALSE

--- a/modular_doppler/modular_weapons/code/ammo_stacks/nb_34.dm
+++ b/modular_doppler/modular_weapons/code/ammo_stacks/nb_34.dm
@@ -4,14 +4,8 @@
 	caliber = CALIBER_34NB
 	ammo_type = /obj/item/ammo_casing/c34nb
 	max_ammo = 5
-	casing_x_positions = list(
-		-4,
-		-2,
-		0,
-		2,
-		4,
-	)
-	casing_y_padding = 6
+	casing_w_spacing = 2
+	casing_z_padding = 6
 
 /datum/design/c34nb
 	name = ".34 NB casing (Lethal)"

--- a/modular_doppler/modular_weapons/code/ammo_stacks/shotgun_12ga.dm
+++ b/modular_doppler/modular_weapons/code/ammo_stacks/shotgun_12ga.dm
@@ -5,14 +5,8 @@
 	ammo_type = /obj/item/ammo_casing/shotgun
 	casing_phrasing = "shell"
 	max_ammo = 8
-	casing_x_positions = list(
-		-6,
-		-3,
-		0,
-		3,
-		6,
-	)
-	casing_y_padding = 4
+	casing_w_spacing = 3
+	casing_z_padding = 4
 
 /obj/item/ammo_casing/shotgun
 	ammo_stack_type = /obj/item/ammo_box/magazine/ammo_stack/s12gauge

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7478,6 +7478,7 @@
 #include "modular_doppler\modular_weapons\code\melee.dm"
 #include "modular_doppler\modular_weapons\code\weapon_overrides.dm"
 #include "modular_doppler\modular_weapons\code\ammo\bandolier.dm"
+#include "modular_doppler\modular_weapons\code\ammo\detective_holster.dm"
 #include "modular_doppler\modular_weapons\code\ammo\europa_25.dm"
 #include "modular_doppler\modular_weapons\code\ammo\gibraltar.dm"
 #include "modular_doppler\modular_weapons\code\ammo\naraka_585.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

So yeah, assorted fixes to the gun pr in post.

Refactors `attackby(...)` to `item_interaction(...)`, removes the commented out code, and updates its balloon alerts closer to standards. Balloon alerts shouldn't fill in names to avoid being too long, and blocking balloon alerts should have an exclamation point. I feel some of these weren't actually useful to the player, i.e. caliber mismatch should never come up unless the dev also applies a mismatched ammo stack.

Overlays should be done on `update_overlays(...)` instead of cutting and adding them. We also add `KEEP_TOGETHER` such that it renders as one pile, and thus gets an outline. We also use a single var and some math instead of a list for every ammo stack type.

The `can_shatter` element isn't actually perfect for what we want here. For one it's got some issues upstream causing items to be spilled into walls, but besides that ammo magazines get their contents lazyloaded for performance reasons and thus wouldn't actually spawn in these cases. To fix the latter part we'd need need to either not lazyload, or properly load them in at every point before the shatter element can run-- in which case, we're better off just doing our own implementation.

Yeag :+1:

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Less jank.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: [DOPPLER] The ammo casings for the new revolver and their stacks fit in the detective's holster.
fix: [DOPPLER] The detective's holster spawns with ammo stacks for the new revolver instead of the old unused speedloaders.
fix: [DOPPLER] The ammo stacks actually have an outline when hovered over in your inventory.
fix: [DOPPLER] A newly created ammo stack actually drops ammo when thrown.
fix: [DOPPLER] Ammo stacks no longer pixel offset into walls or other dense objects.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
