### PR TITLE
Grrr, Chitten, Bug Powercreep (Allows non moths to emote the moth variant of *chitter)

### DIFF
--- a/modular_doppler/emotes/code/added_emotes/animal_sounds.dm
+++ b/modular_doppler/emotes/code/added_emotes/animal_sounds.dm
@@ -52,6 +52,15 @@
 	else
 		return 'sound/mobs/non-humanoids/insect/chitter.ogg'
 
+/datum/emote/living/moth_chitter
+	key = "mchitter"
+	key_third_person = "chitters"
+	message = "chitters!"
+	emote_type = EMOTE_AUDIBLE
+	mob_type_allowed_typecache = list(/mob/living/carbon, /mob/living/silicon/pai)
+	vary = TRUE
+	sound = 'modular_doppler/emotes/sound/mothchitter.ogg'
+
 /datum/emote/living/flutter
 	key = "flutter"
 	key_third_person = "rapidly flutters their wings!"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Normally when you type *chitter it checks if you're a moth and makes the doppler moth chitter sound if you are indeed a fluffy lepidopteran based species and just makes the INSECT chitter if you're anynthing else.

I have left this functionality the same, but non-moths can now force the alternative sound by using *mchitter instead
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
IDK i play silicons but some bug lover seemed really pleased by the idea
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
sound: non-moths can moth chitter.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
