### PR TITLE
Adds a tally of joinable soulcatchers to ghost's hud

### DIFF
--- a/code/__DEFINES/~doppler_defines/signals.dm
+++ b/code/__DEFINES/~doppler_defines/signals.dm
@@ -23,5 +23,7 @@
 #define COMSIG_SOULCATCHER_CHECK_SOUL "soulcatcher_check_soul"
 /// Whenever we need to get the soul of the mob inside of the soulcatcher.
 #define COMSIG_SOULCATCHER_SCAN_BODY "soulcatcher_scan_body"
+/// When a soulcatcher room's joinability is updated by opening the room, closing the room, allowing ghosts, etc
+#define COMSIG_SOULCATCHER_UPDATE_JOINABILITY "soulcatcher_update_joinability"
 /// For modifying a mob holder based on what it's holding
 #define COMSIG_ADDING_MOB_HOLDER_SPECIALS "adding_mob_holder_specials"

--- a/modular_doppler/soulcatcher/code/soulcatcher_component.dm
+++ b/modular_doppler/soulcatcher/code/soulcatcher_component.dm
@@ -40,6 +40,8 @@ GLOBAL_LIST_EMPTY(soulcatchers)
 	create_room()
 	targeted_soulcatcher_room = soulcatcher_rooms[1]
 	GLOB.soulcatchers += src
+	if(ghost_joinable)
+		send_joinability_signal()
 
 	var/obj/item/soulcatcher_holder/soul_holder = parent
 	if(istype(soul_holder) && ismob(soul_holder.loc))
@@ -51,6 +53,8 @@ GLOBAL_LIST_EMPTY(soulcatchers)
 
 /datum/component/soulcatcher/Destroy(force)
 	GLOB.soulcatchers -= src
+	if(ghost_joinable)
+		send_joinability_signal()
 
 	targeted_soulcatcher_room = null
 	for(var/datum/soulcatcher_room as anything in soulcatcher_rooms)
@@ -376,6 +380,41 @@ GLOBAL_LIST_EMPTY(soulcatchers)
 	name = "Enter Soulcatcher"
 	icon = 'modular_doppler/modular_hud/icons/screen_ghost.dmi'
 	icon_state = "soulcatcher"
+	/// MA for maptext overlay showing how many soulcatchers there are
+	var/atom/movable/screen/num_overlay
+
+/atom/movable/screen/ghost/join_soulcatcher/New()
+	. = ..()
+	RegisterSignal(hud?.mymob, COMSIG_SOULCATCHER_UPDATE_JOINABILITY, PROC_REF(refresh_tally))
+	num_overlay = new()
+	num_overlay.layer = layer+1
+	num_overlay.screen_loc = ui_ghost_soulcatcher
+	num_overlay.maptext = MAPTEXT("<span style='text-align: right; color: aqua'>[get_soulcatcher_count()]</span>")
+	num_overlay.transform = num_overlay.transform.Translate(-4, 2)
+	vis_contents += num_overlay
+
+/atom/movable/screen/ghost/join_soulcatcher/Destroy()
+	UnregisterSignal(hud?.mymob, COMSIG_SOULCATCHER_UPDATE_JOINABILITY)
+	vis_contents -= num_overlay
+	QDEL_NULL(num_overlay)
+	return ..()
+
+/atom/movable/screen/ghost/join_soulcatcher/proc/get_soulcatcher_count()
+	var/amount = 0
+	for(var/datum/component/soulcatcher/soulcatcher as anything in GLOB.soulcatchers)
+		if(!soulcatcher.ghost_joinable || !isobj(soulcatcher.parent) || !soulcatcher.check_for_vacancy())
+			continue
+		amount++
+	return amount
+
+/atom/movable/screen/ghost/join_soulcatcher/proc/refresh_tally()
+	SIGNAL_HANDLER
+	if(!num_overlay)
+		return
+	var/original_transform = num_overlay.transform
+	animate(num_overlay, transform = num_overlay.transform.Translate(0, 4), time = 0.1 SECONDS, flags = ANIMATION_PARALLEL)
+	animate(transform = original_transform, time = 0.1 SECONDS)
+	num_overlay.maptext = MAPTEXT("<span style='text-align: right; color: aqua'>[get_soulcatcher_count()]</span>")
 
 /atom/movable/screen/ghost/join_soulcatcher/Click()
 	var/mob/dead/observer/observer = usr

--- a/modular_doppler/soulcatcher/code/soulcatcher_tgui.dm
+++ b/modular_doppler/soulcatcher/code/soulcatcher_tgui.dm
@@ -124,6 +124,7 @@
 
 		if("toggle_joinable")
 			ghost_joinable = !ghost_joinable
+			send_joinability_signal()
 			return TRUE
 
 		if("toggle_approval")
@@ -251,6 +252,11 @@
 
 			remove_self()
 			return TRUE
+
+/datum/component/soulcatcher/proc/send_joinability_signal()
+	var/list/all_observers = GLOB.dead_player_list + GLOB.current_observers_list
+	for(var/mob/observer as anything in all_observers)
+		SEND_SIGNAL(observer, COMSIG_SOULCATCHER_UPDATE_JOINABILITY)
 
 /datum/component/soulcatcher_user/New()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Adds an overlay to the ghost hud's soulcatcher element that tallies joinable soulcatchers.

## How This Contributes To The Nova Sector Roleplay Experience

Pulls eyes to an underused gameplay element.
Speaking of, we haven't actually implemented any way to use soulcatchers without admin spawning.

## Changelog

:cl:
qol: The 'Enter Soulcatcher' button on the ghost hud now has a live tally of joinable soulcatchers
/:cl:
