### PR TITLE
Assorted temporary flavortext fixes/improvements.

### DIFF
--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -318,11 +318,7 @@
 		. += "<b>Quirks:</b> [get_quirk_string(FALSE, CAT_QUIRK_ALL)]"
 
 	// DOPPLER ADDITION BEGIN: temporary flavor text
-	if(temporary_flavor_text)
-		if(length_char(temporary_flavor_text) < TEMPORARY_FLAVOR_PREVIEW_LIMIT)
-			. += span_revennotice("<br>They look different than usual: [temporary_flavor_text]")
-		else
-			. += span_revennotice("<br>They look different than usual: [copytext_char(temporary_flavor_text, 1, TEMPORARY_FLAVOR_PREVIEW_LIMIT)]... <a href='byond://?src=[REF(src)];temporary_flavor=1'>More...</a>")
+	get_examine_temporary_flavor(.)
 	// DOPPLER ADDITION END
 
 	SEND_SIGNAL(src, COMSIG_ATOM_EXAMINE, user, .)

--- a/code/modules/mob/living/silicon/ai/examine.dm
+++ b/code/modules/mob/living/silicon/ai/examine.dm
@@ -37,14 +37,6 @@
 		var/custom_model_name = READ_PREFS(src, text/silicon_model_name)
 		if (custom_model_name)
 			. += "It is [prefix_a_or_an(custom_model_name)] <em>[get_species_description_href(custom_model_name)]</em> model construct."
-
-		//Temp Flavor text DLC
-		if(temporary_flavor_text)
-			if(length_char(temporary_flavor_text) < TEMPORARY_FLAVOR_PREVIEW_LIMIT)
-				. += span_revennotice("<br>They look different than usual: [temporary_flavor_text]")
-			else
-				. += span_revennotice("<br>They look different than usual: [copytext_char(temporary_flavor_text, 1, TEMPORARY_FLAVOR_PREVIEW_LIMIT)]... <a href='byond://?src=[REF(src)];temporary_flavor=1'>More...</a>")
-
 		// DOPPLER EDIT END
 
 	. += ..()

--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -15,14 +15,6 @@
 	var/custom_model_name = READ_PREFS(src, text/silicon_model_name)
 	if (custom_model_name)
 		. += "It is [prefix_a_or_an(custom_model_name)] <em>[get_species_description_href(custom_model_name)]</em> model construct."
-
-	//Temp Flavor Text DLC
-	if(temporary_flavor_text)
-		if(length_char(temporary_flavor_text) < TEMPORARY_FLAVOR_PREVIEW_LIMIT)
-			. += span_revennotice("<br>They look different than usual: [temporary_flavor_text]")
-		else
-			. += span_revennotice("<br>They look different than usual: [copytext_char(temporary_flavor_text, 1, TEMPORARY_FLAVOR_PREVIEW_LIMIT)]... <a href='byond://?src=[REF(src)];temporary_flavor=1'>More...</a>")
-
 	// DOPPLER EDIT END
 
 	var/model_name = model ? "\improper [model.name]" : "\improper Default"

--- a/modular_doppler/temporary_flavor_text/temp_flavor_text.dm
+++ b/modular_doppler/temporary_flavor_text/temp_flavor_text.dm
@@ -25,6 +25,25 @@ GLOBAL_VAR_INIT(temporary_flavor_text_indicator, generate_temporary_flavor_text_
 	var/result = msg || null
 	temporary_flavor_text = result
 	update_appearance(UPDATE_ICON|UPDATE_OVERLAYS)
+	update_holder_appearance()
+
+/// Hook for subtypes to potentially adjust their own appearance.
+/mob/living/proc/update_holder_appearance()
+	return
+
+/mob/living/proc/get_examine_temporary_flavor(list/examine_list)
+	if(!temporary_flavor_text)
+		return
+
+	var/tempflavorpart
+	if(length_char(temporary_flavor_text) < TEMPORARY_FLAVOR_PREVIEW_LIMIT)
+		tempflavorpart = temporary_flavor_text
+	else
+		tempflavorpart = "[copytext_char(temporary_flavor_text, 1, TEMPORARY_FLAVOR_PREVIEW_LIMIT)]... <a href='byond://?src=[REF(src)];temporary_flavor=1'>More...</a>"
+
+	if(length(examine_list) > 0 && examine_list[length(examine_list)])
+		examine_list += "" // Add a newline if needed.
+	examine_list += span_revennotice("They look different from usual: [tempflavorpart]")
 
 /mob/living/update_overlays()
 	. = ..()
@@ -42,3 +61,59 @@ GLOBAL_VAR_INIT(temporary_flavor_text_indicator, generate_temporary_flavor_text_
 		popup.set_content(text("<HTML><HEAD><TITLE>[]</TITLE></HEAD><BODY><TT>[]</TT></BODY></HTML>", "[name]'s temporary flavor text", replacetext(temporary_flavor_text, "\n", "<BR>")))
 		popup.open()
 		return
+
+/**
+ * Simple examine addition. Carbons need a specialcase override.
+ */
+
+/mob/living/examine(mob/user)
+	. = ..()
+	get_examine_temporary_flavor(.)
+
+
+/**
+ * Silicon overrides, needed due to specialcased code.
+ */
+
+/mob/living/silicon/Topic(href, href_list)
+	. = ..()
+	if(href_list["temporary_flavor"])
+		show_temp_ftext(usr)
+
+/mob/living/silicon/robot/update_icons()
+	. = ..()
+	if(temporary_flavor_text)
+		add_overlay(GLOB.temporary_flavor_text_indicator)
+
+/**
+ * Temporary flavortext visible on the pAI card and AI intellicard.
+ */
+
+/mob/living/silicon/pai/update_holder_appearance()
+	if(card)
+		card.update_appearance(UPDATE_ICON|UPDATE_OVERLAYS)
+
+/obj/item/pai_card/update_overlays()
+	. = ..()
+	if(pai?.temporary_flavor_text)
+		. += GLOB.temporary_flavor_text_indicator
+
+/obj/item/pai_card/examine(mob/user)
+	. = ..()
+	if(pai)
+		pai.get_examine_temporary_flavor(.)
+
+
+/mob/living/silicon/ai/update_holder_appearance()
+	if(istype(loc, /obj/item/aicard))
+		loc.update_appearance(UPDATE_ICON|UPDATE_OVERLAYS)
+
+/obj/item/aicard/update_overlays()
+	. = ..()
+	if(AI?.temporary_flavor_text)
+		. += GLOB.temporary_flavor_text_indicator
+
+/obj/item/aicard/examine(mob/user)
+	. = ..()
+	if(AI)
+		AI.get_examine_temporary_flavor(.)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Really just a pile of assorted fixes as on the tin.
We first replace the examine code for temporary flavortexts with a single proc we re-use, and apply what's needed there.

Silicons need some specialcased code, as silicon topics don't carry over the parent topics and borg overlays aren't handled the same way as for other objects or living beings.

Broadly this reduces the amount of non-modular code though, because we lower the silicon temporary flavortext examines to `/mob/living`.

We also allow for pAI/AI cards to handle their silicon's temporary flavortext with a new hook for updating holder appearance, but this is mostly just modular overrides.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It's good when things actually work.

Dead AIs still having their temporary flavortext feels fitting as it sometimes may be related to the core itself, for example.

Proxying the temporary flavortext to pAI/AI cards allows them to still use it even while carried in item form.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: [DOPPLER] Basic/simple mobs properly show temporary flavortext in their examine description.
fix: [DOPPLER] Borgs no longer lose the temporary flavortext overlay when sitting/blinking/etc.
fix: [DOPPLER] AI temporary flavortext doesn't disappear when they die.
fix: [DOPPLER] pAIs have functional temporary flavortext.
fix: [DOPPLER] Silicon temporary flavortext that's too long can actually be read.
fix: [DOPPLER] Temporary flavortext no longer has an unnecessary newline before it in some cases.
qol: [DOPPLER] pAI/AI temporary flavortext shows on the pAI/AI card as well.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
