### PR TITLE
Update fluoride_stare.dm | lengthen from 3 minutes to 15

### DIFF
--- a/code/datums/quirks/negative_quirks/fluoride_stare.dm
+++ b/code/datums/quirks/negative_quirks/fluoride_stare.dm
@@ -28,7 +28,7 @@
 
 /datum/quirk/item_quirk/fluoride_stare/add(client/client_source)
 	ADD_TRAIT(quirk_holder, TRAIT_NO_EYELIDS, QUIRK_TRAIT)
-	quirk_holder.AddComponent(/datum/component/manual_blinking, 0.5, 15 MINUTES, 20 MINUTES, FALSE) //DOPPLER EDIT - ORIGINAL 3 MINUTES, 30 SECONDS,
+	quirk_holder.AddComponent(/datum/component/manual_blinking, 0.5, 15 MINUTES, 30 SECONDS, FALSE) //DOPPLER EDIT - ORIGINAL 3 MINUTES, 30 SECONDS,
 
 /datum/quirk/item_quirk/fluoride_stare/remove()
 	REMOVE_TRAIT(quirk_holder, TRAIT_NO_EYELIDS, QUIRK_TRAIT)

--- a/code/datums/quirks/negative_quirks/fluoride_stare.dm
+++ b/code/datums/quirks/negative_quirks/fluoride_stare.dm
@@ -28,7 +28,7 @@
 
 /datum/quirk/item_quirk/fluoride_stare/add(client/client_source)
 	ADD_TRAIT(quirk_holder, TRAIT_NO_EYELIDS, QUIRK_TRAIT)
-	quirk_holder.AddComponent(/datum/component/manual_blinking, 0.5, 15 MINUTES, 30 SECONDS, FALSE)
+	quirk_holder.AddComponent(/datum/component/manual_blinking, 0.5, 15 MINUTES, 30 SECONDS, FALSE) //DOPPLER EDIT - ORIGINAL 3 MINUTES, 30 SECONDS,
 
 /datum/quirk/item_quirk/fluoride_stare/remove()
 	REMOVE_TRAIT(quirk_holder, TRAIT_NO_EYELIDS, QUIRK_TRAIT)

--- a/code/datums/quirks/negative_quirks/fluoride_stare.dm
+++ b/code/datums/quirks/negative_quirks/fluoride_stare.dm
@@ -28,7 +28,7 @@
 
 /datum/quirk/item_quirk/fluoride_stare/add(client/client_source)
 	ADD_TRAIT(quirk_holder, TRAIT_NO_EYELIDS, QUIRK_TRAIT)
-	quirk_holder.AddComponent(/datum/component/manual_blinking, 0.5, 15 MINUTES, 30 SECONDS, FALSE) //DOPPLER EDIT - ORIGINAL 3 MINUTES, 30 SECONDS,
+	quirk_holder.AddComponent(/datum/component/manual_blinking, 0.5, 15 MINUTES, 20 MINUTES, FALSE) //DOPPLER EDIT - ORIGINAL 3 MINUTES, 30 SECONDS,
 
 /datum/quirk/item_quirk/fluoride_stare/remove()
 	REMOVE_TRAIT(quirk_holder, TRAIT_NO_EYELIDS, QUIRK_TRAIT)

--- a/code/datums/quirks/negative_quirks/fluoride_stare.dm
+++ b/code/datums/quirks/negative_quirks/fluoride_stare.dm
@@ -28,7 +28,7 @@
 
 /datum/quirk/item_quirk/fluoride_stare/add(client/client_source)
 	ADD_TRAIT(quirk_holder, TRAIT_NO_EYELIDS, QUIRK_TRAIT)
-	quirk_holder.AddComponent(/datum/component/manual_blinking, 0.5, 3 MINUTES, 30 SECONDS, FALSE)
+	quirk_holder.AddComponent(/datum/component/manual_blinking, 0.5, 15 MINUTES, 30 SECONDS, FALSE)
 
 /datum/quirk/item_quirk/fluoride_stare/remove()
 	REMOVE_TRAIT(quirk_holder, TRAIT_NO_EYELIDS, QUIRK_TRAIT)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

extends flouride stare grace period to 15 mins

## Why It's Good For The Game

wild it's like this in basecode honestly let me stop rping every 3 minutes to mechanically give myself eyedrops

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:

qol: flouride stare can be used without losing will to live

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
