### PR TITLE
Fixes modular synth medicine pill bottles spawning empty.

### DIFF
--- a/modular_doppler/modular_medical/reagents/pill_bottles.dm
+++ b/modular_doppler/modular_medical/reagents/pill_bottles.dm
@@ -3,19 +3,23 @@
 	name = "bottle of liquid solder pills"
 	desc = "Contains pills used to treat synthetic brain damage."
 	spawn_type = /obj/item/reagent_containers/applicator/pill/liquid_solder
+	spawn_count = 7
 
 // Contains 4 liquid_solder pills instead of 7, and 10u pills instead of 50u.
 // 50u pills heal 375 brain damage, 10u pills heal 75.
 /obj/item/storage/pill_bottle/liquid_solder/braintumor
 	desc = "Contains diluted pills used to treat synthetic brain damage symptoms. Take one when feeling lightheaded."
 	spawn_type = /obj/item/reagent_containers/applicator/pill/liquid_solder/braintumor
+	spawn_count = 4
 
 /obj/item/storage/pill_bottle/nanite_slurry
 	name = "bottle of nanite slurry pills"
 	desc = "Contains pills used to treat robotic bodyparts."
 	spawn_type = /obj/item/reagent_containers/applicator/pill/nanite_slurry
+	spawn_count = 7
 
 /obj/item/storage/pill_bottle/system_cleaner
 	name = "bottle of system cleaner pills"
 	desc = "Contains pills used to detoxify synthetic bodies."
 	spawn_type = /obj/item/reagent_containers/applicator/pill/system_cleaner
+	spawn_count = 7


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

During one of the parity prs, where pill bottles got refactored, we forgot to add `spawn_count` var to given pill bottles.
This fixes that.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes #682.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Synthetic medicine pill bottles no longer spawn empty.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
