### PR TITLE
Fix crusader belt not having space for a sword, minor code cleanup

### DIFF
--- a/modular_doppler/modular_cosmetics/code/belt/crusaderbelt.dm
+++ b/modular_doppler/modular_cosmetics/code/belt/crusaderbelt.dm
@@ -6,30 +6,94 @@
 	icon_state = "crusader_belt"
 	worn_icon_state = "crusader_belt"
 	inhand_icon_state = "utility"
-	w_class = WEIGHT_CLASS_BULKY //Cant fit a sheath in your bag
+	w_class = WEIGHT_CLASS_BULKY // Can't fit a sheath in your bag.
 	interaction_flags_click = NEED_DEXTERITY
+	storage_type = /datum/storage/belt/crusader
 
 /obj/item/storage/belt/crusader/Initialize(mapload)
 	. = ..()
+	AddElement(/datum/element/update_icon_updates_onmob)
 
-	create_storage(
-		max_slots = 2,
-		max_specific_storage = WEIGHT_CLASS_BULKY,	//This makes sure swords and the pouches can fit in here - the whitelist keeps the bad stuff out
-		storage_type = /datum/storage/belt/crusader,
-		canhold = list(
+/obj/item/storage/belt/crusader/PopulateContents()
+	. = ..()
+	new /obj/item/storage/belt/storage_pouch(src)
+
+/// Gets our sword item, if any.
+/obj/item/storage/belt/crusader/proc/get_sword_item()
+	if(length(contents) < 2)
+		return null
+	return contents[2]
+
+// Makes ctrl-click also open the inventory,
+// so that you can open it with full hands without dropping the sword.
+/obj/item/storage/belt/crusader/item_ctrl_click(mob/user)
+	. = ..()
+	atom_storage.show_contents(user)
+	return CLICK_ACTION_SUCCESS
+
+// This is basically the same as the normal sheath,
+// but because there's always an item locked in the first slot it uses the second slot for swords.
+/obj/item/storage/belt/crusader/click_alt(mob/user)
+	var/obj/item/drawn_item = get_sword_item()
+	if(isnull(drawn_item))
+		to_chat(user, span_warning("[src] is empty!"))
+		return CLICK_ACTION_BLOCKING
+
+	add_fingerprint(user)
+	playsound(src, 'sound/items/unsheath.ogg', 50, TRUE, -5)
+	if(!user.put_in_hands(drawn_item))
+		to_chat(user, span_notice("You fumble for [drawn_item] and it falls on the floor."))
+		update_appearance()
+		return CLICK_ACTION_SUCCESS
+
+	user.visible_message(span_notice("[user] takes [drawn_item] out of [src]."), span_notice("You take [drawn_item] out of [src]."))
+	update_appearance()
+	return CLICK_ACTION_SUCCESS
+
+// Checks for a sword/rod in the sheath slot, changes the sprite accordingly.
+/obj/item/storage/belt/crusader/update_icon(updates)
+	. = ..()
+	if(get_sword_item())
+		icon_state = "crusader_belt_sheathed"
+		worn_icon_state = "crusader_belt_sheathed"
+	else
+		icon_state = "crusader_belt"
+		worn_icon_state = "crusader_belt"
+
+/obj/item/storage/belt/crusader/examine(mob/user)
+	. = ..()
+	.+= span_notice("[EXAMINE_HINT("Ctrl-Click")] it to easily open its inventory.")
+	// If there's no sword/rod in the sheath slot, we don't display the alt-click instruction.
+	if(get_sword_item())
+		. += span_notice("[EXAMINE_HINT("Alt-Click")] it to quickly draw the blade.")
+		return
+
+
+/datum/storage/belt/crusader
+	max_slots = 2
+	max_specific_storage = WEIGHT_CLASS_BULKY //This makes sure swords and the pouches can fit in here - the whitelist keeps the bad stuff out.
+	allow_big_nesting = TRUE // Lets the pouch work
+	do_rustle = FALSE
+	click_alt_open = FALSE
+
+/datum/storage/belt/crusader/New(atom/parent, max_slots, max_specific_storage, max_total_storage, rustle_sound, remove_rustle_sound)
+	. = ..()
+		set_holdable(
+		can_hold_list = list(
 			/obj/item/storage/belt/storage_pouch,
 			/obj/item/forging/reagent_weapon/sword,
 			/obj/item/forging/reagent_weapon/katana,
 			/obj/item/forging/reagent_weapon/bokken,
 			/obj/item/forging/reagent_weapon/dagger,
 			/obj/item/melee/sabre,
+			/obj/item/melee/parsnip_sabre,
 			/obj/item/claymore,
 			/obj/item/melee/cleric_mace,
 			/obj/item/knife,
 			/obj/item/melee/baton,
 			/obj/item/nullrod,	//holds any subset of nullrod in the sheath-storage - - -
 		),
-		canthold = list(	// - - - except the second list's items (no fedora in the sheath)
+		cant_hold_list = list(	// - - - except the second list's items (no fedora in the sheath)
 			/obj/item/nullrod/armblade,
 			/obj/item/nullrod/carp,
 			/obj/item/nullrod/chainsaw,
@@ -45,9 +109,6 @@
 			/obj/item/nullrod/whip,
 		),
 	)
-	atom_storage.allow_big_nesting = TRUE // Lets the pouch work
-	AddElement(/datum/element/update_icon_updates_onmob)
-	PopulateContents()
 
 //Overrides normal dumping code to instead dump from the pouch item inside
 /datum/storage/belt/crusader/dump_content_at(atom/dest_object, mob/dumping_mob)
@@ -63,71 +124,40 @@
 		return
 	pouch.atom_storage.dump_content_at(dest_object, dumping_mob)
 
-/obj/item/storage/belt/crusader/item_ctrl_click(mob/user)	//Makes ctrl-click also open the inventory, so that you can open it with full hands without dropping the sword
-	. = ..()
-	atom_storage.show_contents(user)
-	return CLICK_ACTION_SUCCESS
 
-/obj/item/storage/belt/crusader/click_alt(mob/user)	//This is basically the same as the normal sheath, but because there's always an item locked in the first slot it uses the second slot for swords
-	if(contents.len == 2)
-		var/obj/item/drawn_item = contents[2]
-		add_fingerprint(user)
-		playsound(src, 'sound/items/unsheath.ogg', 50, TRUE, -5)
-		if(!user.put_in_hands(drawn_item))
-			to_chat(user, span_notice("You fumble for [drawn_item] and it falls on the floor."))
-			update_appearance()
-			return CLICK_ACTION_SUCCESS
-		user.visible_message(span_notice("[user] takes [drawn_item] out of [src]."), span_notice("You take [drawn_item] out of [src]."))
-		update_appearance()
-	else
-		to_chat(user, span_warning("[src] is empty!"))
-	return CLICK_ACTION_SUCCESS
-
-/obj/item/storage/belt/crusader/update_icon(updates)
-	if(contents.len == 2)	//Checks for a sword/rod in the sheath slot, changes the sprite accordingly
-		icon_state = "crusader_belt_sheathed"
-		worn_icon_state = "crusader_belt_sheathed"
-	else
-		icon_state = "crusader_belt"
-		worn_icon_state = "crusader_belt"
-	. = ..()
-
-/obj/item/storage/belt/crusader/examine(mob/user)
-	. = ..()
-	.+= span_notice("Ctrl-click it to easily open its inventory.")
-	if(contents.len == 2)	//If there's no sword/rod in the sheath slot it doesnt display the alt-click instruction
-		. += span_notice("Alt-click it to quickly draw the blade.")
-		return
-
-/obj/item/storage/belt/crusader/PopulateContents()
-	. = ..()
-	new /obj/item/storage/belt/storage_pouch(src)
-
-/obj/item/storage/belt/storage_pouch	//seperate mini-storage inside the belt, leaving room for only one sword. Inspired by a (very poorly implemented) belt on Desert Rose
+/// Separate mini-storage inside the belt, leaving room for only one sword.
+/// Inspired by a (very poorly implemented) belt on Desert Rose.
+/obj/item/storage/belt/storage_pouch
 	icon = 'modular_doppler/modular_cosmetics/icons/obj/belt/crusaderbelt.dmi'
 	worn_icon = 'modular_doppler/modular_cosmetics/icons/mob/belt/crusaderbelt.dmi'
 	name = "storage pouch"
 	desc = span_notice("Click on this to open your belt's inventory!")
 	icon_state = "storage_pouch_icon"
 	worn_icon_state = "storage_pouch_icon"
-	w_class = WEIGHT_CLASS_BULKY //Still cant put it in your bags, it's technically a belt
-	anchored = 1	//Dont want people taking it out with their hands
+	w_class = WEIGHT_CLASS_BULKY // Still cant put it in your bags, it's technically a belt.
+	anchored = TRUE // Don't want people taking it out with their hands.
+	storage_type = /datum/storage/belt/storage_pouch
 
-/obj/item/storage/belt/storage_pouch/attack_hand(mob/user, list/modifiers)	//Opens the bag on click - considering it's already anchored, this makes it function similar to how ghosts can open all nested inventories
+// Opens the bag on click - considering it's already anchored, this makes it function similarly to how ghosts can open all nested inventories.
+/obj/item/storage/belt/storage_pouch/attack_hand(mob/user, list/modifiers)
 	. = ..()
-
 	atom_storage.show_contents(user)
 
-/obj/item/storage/belt/storage_pouch/Initialize(mapload)
-	. = ..()
 
-	atom_storage.max_slots = 6
-	atom_storage.max_specific_storage = WEIGHT_CLASS_SMALL //Rather than have a huge whitelist, the belt can simply hold anything a pocket can hold - Can easily be changed if it somehow becomes an issue
+/datum/storage/belt/storage_pouch
+	max_slots = 6
+	max_specific_storage = WEIGHT_CLASS_SMALL //Rather than have a huge whitelist, the belt can simply hold anything a pocket can hold - Can easily be changed if it somehow becomes an issue.
+
 
 /datum/crafting_recipe/crusader_belt
 	name = "Sword Belt and Sheath"
 	result = /obj/item/storage/belt/crusader
-	reqs = list(/obj/item/storage/belt/utility = 1, /obj/item/stack/sheet/leather = 3, /obj/item/stack/sheet/cloth = 2, /obj/item/stack/sheet/mineral/gold = 1)
-	tool_behaviors = list(TOOL_WIRECUTTER, TOOL_SCREWDRIVER, TOOL_WELDER)	//To cut the leather and fasten/weld the sheath detailing
-	time = 30
+	reqs = list(
+		/obj/item/storage/belt/utility = 1,
+		/obj/item/stack/sheet/leather = 3,
+		/obj/item/stack/sheet/cloth = 2,
+		/obj/item/stack/sheet/mineral/gold = 1,
+	)
+	tool_behaviors = list(TOOL_WIRECUTTER, TOOL_SCREWDRIVER, TOOL_WELDER) // To cut the leather and fasten/weld the sheath detailing.
+	time = 3 SECONDS
 	category = CAT_CLOTHING

--- a/modular_doppler/modular_cosmetics/code/belt/crusaderbelt.dm
+++ b/modular_doppler/modular_cosmetics/code/belt/crusaderbelt.dm
@@ -78,7 +78,7 @@
 
 /datum/storage/belt/crusader/New(atom/parent, max_slots, max_specific_storage, max_total_storage, rustle_sound, remove_rustle_sound)
 	. = ..()
-		set_holdable(
+	set_holdable(
 		can_hold_list = list(
 			/obj/item/storage/belt/storage_pouch,
 			/obj/item/forging/reagent_weapon/sword,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

So the loadout crusader belt was calling `PopulateContents()` manually, meaning it got called twice and caused both slots to be filled with pouches.
This fixes that!

We also do some minor code cleanup, but not a full refactor cause oauaaoaugh that'd be a mess. Parsnip sabres though.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

less jank good :+1:

Parsnip sabres should probably be on the list of swords, given the whole recent thing upstream for parsnip sabre sheaths and whatever.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Parsnip sabres can be stored in the crusader belt.
fix: Crusader belts once again have one pouch and one slot for a sword.
code: Crusader belts have been minorly cleaned up code-wise. Please report any issues.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
