### PR TITLE
Pubby cytology + minor fixes

### DIFF
--- a/_maps/map_files/Pubbystation/pubbystation.dmm
+++ b/_maps/map_files/Pubbystation/pubbystation.dmm
@@ -4563,6 +4563,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
+/obj/effect/turf_decal/trimline/pine_green/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white/smooth_half,
 /area/station/medical/medbay/central)
 "atw" = (
@@ -7629,7 +7632,9 @@
 	network = list("ss13","medbay")
 	},
 /obj/machinery/vending/drugs,
-/turf/open/floor/iron/white/smooth_large,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
 /area/station/medical/break_room)
 "aFb" = (
 /obj/machinery/light_switch/directional/north,
@@ -8593,6 +8598,9 @@
 "aJY" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/machinery/camera/autoname/motion/directional/east,
+/obj/effect/turf_decal/tile/pine_green/half/contrasted{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/coldroom)
 "aKa" = (
@@ -14131,6 +14139,9 @@
 /obj/effect/turf_decal/siding{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/pine_green/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white/smooth_corner,
 /area/station/medical/medbay/central)
 "biw" = (
@@ -15708,6 +15719,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
+/obj/effect/turf_decal/trimline/pine_green/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white/smooth_corner{
 	dir = 8
 	},
@@ -15717,6 +15731,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/siding{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/pine_green/line{
 	dir = 1
 	},
 /turf/open/floor/iron/white/smooth_half,
@@ -16325,6 +16342,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/pine_green/half/contrasted{
 	dir = 8
 	},
 /turf/open/floor/iron/white/smooth_large,
@@ -17769,9 +17789,7 @@
 /area/station/medical/medbay/central)
 "bAi" = (
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
-/turf/open/floor/iron/white/smooth_corner{
-	dir = 1
-	},
+/turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "bAl" = (
 /obj/structure/sign/directions/cryo/directional/west{
@@ -18194,6 +18212,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/siding{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/pine_green/line{
 	dir = 1
 	},
 /turf/open/floor/iron/white/smooth_half,
@@ -18716,6 +18737,9 @@
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "bEI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 8
 	},
@@ -19289,7 +19313,8 @@
 "bHY" = (
 /obj/machinery/vending/medical,
 /obj/structure/sign/departments/psychology/directional/east,
-/turf/open/floor/iron/white/smooth_large,
+/obj/effect/turf_decal/tile/green/anticorner/contrasted,
+/turf/open/floor/iron/white,
 /area/station/medical/break_room)
 "bIi" = (
 /obj/structure/cable,
@@ -19688,6 +19713,9 @@
 /area/station/medical/virology)
 "bKp" = (
 /obj/machinery/light/no_nightlight/directional/north,
+/obj/effect/turf_decal/tile/pine_green/half/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/coldroom)
 "bKq" = (
@@ -20390,6 +20418,9 @@
 "bNO" = (
 /obj/machinery/suit_storage_unit/medical,
 /obj/machinery/light/no_nightlight/directional/east,
+/obj/effect/turf_decal/tile/pine_green/half/contrasted{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/coldroom)
 "bNP" = (
@@ -28274,10 +28305,10 @@
 /area/station/maintenance/department/science/xenobiology)
 "djh" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/turf_decal/tile/pine_green/half/contrasted{
 	dir = 1
 	},
-/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/white/smooth_edge,
 /area/station/medical/medbay/central)
 "dkg" = (
@@ -28592,6 +28623,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/pine_green/line{
 	dir = 4
 	},
 /turf/open/floor/iron/white/smooth_large,
@@ -30437,9 +30471,7 @@
 	dir = 4
 	},
 /obj/machinery/limbgrower/fullupgrade,
-/turf/open/floor/iron/white/smooth_corner{
-	dir = 8
-	},
+/turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "eVW" = (
 /obj/structure/disposalpipe/segment{
@@ -30630,9 +30662,6 @@
 /area/station/science/ordnance/testlab)
 "fby" = (
 /obj/structure/sign/poster/official/no_erp/directional/east,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
 	},
@@ -30857,6 +30886,9 @@
 /obj/structure/disposalpipe/junction{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/pine_green/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/medbay/central)
 "fhk" = (
@@ -30945,7 +30977,12 @@
 /area/station/science/lab)
 "flq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/white/smooth_large,
+/obj/effect/turf_decal/tile/pine_green/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 8
+	},
 /area/station/medical/break_room)
 "flQ" = (
 /obj/structure/disposalpipe/segment{
@@ -31686,6 +31723,10 @@
 	},
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
+"fQB" = (
+/obj/effect/turf_decal/trimline/pine_green/line,
+/turf/open/floor/iron/dark,
+/area/station/medical/coldroom)
 "fQH" = (
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/plating,
@@ -31893,7 +31934,7 @@
 /obj/structure/flatpack_cart,
 /obj/item/stack/sheet/iron/twenty,
 /obj/item/stack/sheet/glass/fifty,
-/turf/open/floor/iron/white/smooth_large,
+/turf/open/floor/iron/white/smooth_edge,
 /area/station/medical/chemistry)
 "gbu" = (
 /obj/structure/cable,
@@ -32348,6 +32389,9 @@
 /area/station/maintenance/department/security/brig)
 "gum" = (
 /obj/structure/closet/l3closet,
+/obj/effect/turf_decal/tile/pine_green/anticorner/contrasted{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/coldroom)
 "gur" = (
@@ -33929,6 +33973,12 @@
 	dir = 1
 	},
 /area/station/medical/medbay/central)
+"hMw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/chem_storage)
 "hNd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -34055,11 +34105,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/pine_green/half/contrasted{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/pine_green/line{
+	dir = 8
 	},
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 4
@@ -35067,6 +35117,9 @@
 	pixel_x = -6;
 	pixel_y = 0
 	},
+/obj/effect/turf_decal/tile/pine_green/half/contrasted{
+	dir = 8
+	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/medbay/central)
 "iIB" = (
@@ -35642,6 +35695,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
+"jfs" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/chem_storage)
 "jgr" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Library"
@@ -36138,6 +36197,17 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"jBp" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/pine_green/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/medbay/central)
 "jBx" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "telelab";
@@ -37108,6 +37178,9 @@
 /obj/structure/window/reinforced/spawner/directional/west{
 	pixel_x = -7;
 	pixel_y = 0
+	},
+/obj/effect/turf_decal/tile/pine_green/half/contrasted{
+	dir = 8
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/medbay/central)
@@ -38275,6 +38348,17 @@
 /obj/structure/punching_bag,
 /turf/open/floor/plastic,
 /area/station/security/lockers)
+"llL" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/pine_green/line,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/medical/medbay/central)
 "llS" = (
 /obj/structure/water_source/puddle,
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -38968,7 +39052,12 @@
 /area/station/medical/medbay/lobby)
 "lOK" = (
 /obj/machinery/light/directional/east,
-/turf/open/floor/iron/white/smooth_large,
+/obj/effect/turf_decal/tile/pine_green/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 8
+	},
 /area/station/medical/medbay/central)
 "lPe" = (
 /obj/structure/grille/broken,
@@ -39022,8 +39111,13 @@
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "lRD" = (
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/medbay/central)
+/obj/effect/turf_decal/tile/pine_green/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 8
+	},
+/area/station/medical/break_room)
 "lRN" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/medical)
@@ -39054,6 +39148,17 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
+"lTz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/pine_green/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/medical/coldroom)
 "lTC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -39705,6 +39810,17 @@
 /obj/machinery/holopad,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/qm)
+"mss" = (
+/obj/effect/turf_decal/tile/pine_green/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 8
+	},
+/area/station/medical/medbay/central)
 "msw" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio4";
@@ -40141,6 +40257,9 @@
 "mMd" = (
 /obj/structure/window/spawner/directional/north,
 /obj/machinery/portable_atmospherics/canister/anesthetic_mix,
+/obj/effect/turf_decal/box/white{
+	color = "#9FED58"
+	},
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/medical/coldroom)
 "mMh" = (
@@ -43060,11 +43179,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/aft)
 "oXU" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/iron/white/smooth_large,
+/obj/effect/turf_decal/siding{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/pine_green/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/white/smooth_half,
 /area/station/medical/medbay/central)
 "oXV" = (
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -43169,6 +43294,9 @@
 "pcH" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/pine_green/half/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/coldroom)
 "pda" = (
@@ -43903,6 +44031,9 @@
 /area/space/nearstation)
 "pDZ" = (
 /obj/machinery/recharge_station,
+/obj/effect/turf_decal/tile/pine_green/half/contrasted{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/coldroom)
 "pEa" = (
@@ -44719,6 +44850,9 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/tile/pine_green/half/contrasted{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/coldroom)
 "qib" = (
@@ -45112,6 +45246,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"qvo" = (
+/obj/structure/closet/secure_closet/medical3,
+/obj/effect/turf_decal/tile/pine_green/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/medical/coldroom)
 "qvx" = (
 /obj/item/kirbyplants/organic/plant21,
 /obj/machinery/light/small/directional/north,
@@ -46305,6 +46446,9 @@
 "rtk" = (
 /obj/structure/cable,
 /obj/machinery/firealarm/directional/north,
+/obj/effect/turf_decal/tile/pine_green/half/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/coldroom)
 "rtA" = (
@@ -47810,7 +47954,12 @@
 /area/station/ai_monitored/turret_protected/ai_upload)
 "suU" = (
 /obj/machinery/door/firedoor,
-/turf/open/floor/iron/white/smooth_half,
+/obj/effect/turf_decal/tile/pine_green/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 8
+	},
 /area/station/medical/medbay/central)
 "svb" = (
 /obj/structure/chair/office/tactical{
@@ -50061,6 +50210,16 @@
 /obj/structure/reflector/box/anchored,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
+"tZj" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/pine_green/line,
+/turf/open/floor/iron/kitchen/small,
+/area/station/medical/break_room)
 "tZU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/closed/wall/r_wall,
@@ -50533,14 +50692,11 @@
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "umh" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/layer_manifold/visible{
 	dir = 4
 	},
-/turf/open/floor/iron/white/smooth_corner{
-	dir = 1
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 8
 	},
 /area/station/medical/medbay/central)
 "umo" = (
@@ -50560,9 +50716,7 @@
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 4
 	},
-/turf/open/floor/iron/white/smooth_corner{
-	dir = 8
-	},
+/turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "und" = (
 /obj/machinery/door/window/left/directional/east{
@@ -50630,6 +50784,9 @@
 "uqs" = (
 /obj/machinery/portable_atmospherics/canister/anesthetic_mix,
 /obj/structure/window/spawner/directional/south,
+/obj/effect/turf_decal/box/white{
+	color = "#9FED58"
+	},
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/medical/coldroom)
 "urG" = (
@@ -50840,7 +50997,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron/white/smooth_large,
+/obj/effect/turf_decal/trimline/pine_green/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 8
+	},
 /area/station/medical/break_room)
 "uyY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -51213,6 +51375,7 @@
 /area/station/medical/surgery)
 "uOA" = (
 /obj/machinery/suit_storage_unit/medical,
+/obj/effect/turf_decal/tile/pine_green/anticorner/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/medical/coldroom)
 "uPz" = (
@@ -51530,6 +51693,9 @@
 /area/station/hallway/primary/central/aft)
 "uYF" = (
 /obj/machinery/smartfridge/chemistry/preloaded,
+/obj/effect/turf_decal/tile/pine_green/anticorner/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/coldroom)
 "uYV" = (
@@ -51870,6 +52036,9 @@
 "vmo" = (
 /obj/structure/closet/l3closet,
 /obj/machinery/light/no_nightlight/directional/west,
+/obj/effect/turf_decal/tile/pine_green/half/contrasted{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/coldroom)
 "vmA" = (
@@ -51892,6 +52061,15 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/white/small,
 /area/station/medical/virology)
+"vno" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/pine_green/line,
+/turf/open/floor/iron/dark,
+/area/station/medical/coldroom)
 "vnR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -54024,6 +54202,9 @@
 /area/station/maintenance/disposal)
 "wQy" = (
 /obj/structure/closet/secure_closet/medical3,
+/obj/effect/turf_decal/tile/pine_green/half/contrasted{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/coldroom)
 "wQC" = (
@@ -54543,13 +54724,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 8
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 1
 	},
 /obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 4
-	},
+/turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "xgG" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -55457,6 +55636,9 @@
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/siding/corner{
 	dir = 1
+	},
+/obj/effect/turf_decal/tile/pine_green/half/contrasted{
+	dir = 8
 	},
 /turf/open/floor/iron/white/smooth_half,
 /area/station/medical/medbay/central)
@@ -80431,13 +80613,13 @@ bCb
 tqC
 wdl
 bHU
-bHU
+tZj
 bJk
+lTz
 osQ
 osQ
 osQ
-osQ
-osQ
+vno
 pTy
 dES
 bOG
@@ -80694,7 +80876,7 @@ rtk
 vgg
 uhd
 bss
-osQ
+vno
 lor
 sea
 sea
@@ -80932,13 +81114,13 @@ fxE
 bkY
 wjK
 whr
-bqY
+oXU
 ciy
 mEo
 qRO
 xLa
 koW
-ciy
+jBp
 fhj
 iIw
 iIw
@@ -80951,7 +81133,7 @@ pcH
 vgg
 vEL
 bss
-bpz
+fQB
 mKz
 gsP
 sea
@@ -81208,7 +81390,7 @@ bKp
 bpz
 uFo
 bpz
-bpz
+fQB
 pTy
 kYt
 lor
@@ -81449,19 +81631,19 @@ whr
 bqX
 npl
 umh
-lRD
+cqd
 suU
-lRD
-lRD
+cqd
+cqd
 duu
-lRD
+cqd
 lOK
 flq
 uyg
-clM
+lRD
 bHY
 erA
-wQy
+qvo
 wQy
 aJY
 bNO
@@ -82731,7 +82913,7 @@ nUo
 sPf
 woD
 bpJ
-xUU
+tZX
 bsB
 buc
 tix
@@ -83503,7 +83685,7 @@ aFM
 uQu
 oWN
 ktU
-bsB
+llL
 bAg
 mWJ
 mWJ
@@ -83759,7 +83941,7 @@ idj
 tCi
 xQO
 bpF
-tZX
+xUU
 bsB
 htK
 bOI
@@ -84535,7 +84717,7 @@ bIy
 tWt
 bvm
 tWt
-oXU
+tWt
 gKB
 tli
 peY
@@ -84788,7 +84970,7 @@ bnD
 ouX
 brg
 sgD
-cqd
+mss
 cqd
 bvn
 cqd
@@ -87107,7 +87289,7 @@ xHJ
 bwT
 eBd
 bsK
-vTg
+jfs
 vTg
 fri
 bCp
@@ -87621,7 +87803,7 @@ pxw
 dRj
 hEC
 awW
-vTg
+hMw
 igj
 lRN
 lRN


### PR DESCRIPTION
Improves the round-start cytology experience from really ass > actually doable.

Also makes the Sec EVA airlock smaller so it cycles faster, fixes a disconnected disposal pipe outside the morgue, ensures the "Goes to Space" disposals in Virology actually does that, puts a bluespace gas sender board in the CE's locker, replaces a tiny fan with the new atmospheric shield generator, and makes Ordnance's burn chamber one row larger. (3X2 > 3x3)
<img width="865" height="645" alt="Screenshot 2025-09-03 145620" src="https://github.com/user-attachments/assets/25fa2cbe-45f7-4053-a1cd-7c4e52d72d8e" />
<img width="754" height="722" alt="Screenshot 2025-09-03 145627" src="https://github.com/user-attachments/assets/dcbb54ac-2a1e-4f4e-9553-0ae336ef497e" />
<img width="494" height="241" alt="Screenshot 2025-09-03 145641" src="https://github.com/user-attachments/assets/2e053146-020a-495d-af72-35c0c97eafa9" />
<img width="430" height="359" alt="Screenshot 2025-09-03 145916" src="https://github.com/user-attachments/assets/efe1f54c-c3fd-44f6-b3d0-5e20d813a573" />

## Changelog
:cl:
add: Moves the Cytology workspace out of xenobiology and into the shared experimentation space of Science.
add: Cytology gains a grow-tank chamber with which to actually grow anything. Grow chamber shares space with the EXPERIMENTOR.
add: Reinforced chamber for the EXPERIMENTOR expanded to accommodate the cytology grow-tank chamber.
add: Cytology has a dedicated workspace with extra petri dishes, gloves, dropper, microscope, tables and chair, as well as a monkey cube box in the cytology equipment locker.
del: Removes Warrant Scanner gates located in main halls. These do not work as intended.
del: Removes Intel Folder (Epic_Loot path item not to be confused with the antagonist theft object item), emergency spare safe code(intended to only spawn from comms console request) and Station Charter(regularly spawned in with round-start captain loadout to allow them to name the station, otherwise fluff item) from Vault Safe. Current Vault Safe Contents include a  "Keep that Disk" NAD disk verifier skillchip and a copy of the Station Blueprints.
add: Expands Ordnance Lab Burn chamber from 3X2 to 3X3.
add: Replaces tiny fan below ordnance bomb launcher blast door with a paired atmospheric field generator
fix: Disconnects the disposal pipe path originating from a "goes to space" disposal unit inside virology to ensure trash actually goes to space instead of disposals.
add: Places 1 Bluespace Gas Sender machine board into the CE's locker
add: Adds decals to medbay where the pattern was broken.
add: Connects Morgue APC to the grid, as well as fills in a single turf gap in the disposals route to prevent all of medbay's trash emptying out into the main hall.
add: Shrinks Security EVA airlock from a 3X3 to a 1X3 to improve airlock cycle time. Also moves the two emergency oxygen lockers out of the airlock and into Sec EVA proper.
add: Changes Science's Departmental Circuit Printer -> General Circuit printer such as the one found in engineering. Science has had the ability to print and change out their round-start printer for years now and this formalizes their machine board access.
add: Adds a spawning location for Command Bodyguard inside security, an area they have regular access to. (Map did not previously have a landmark/start for the Command Bodyguard.
add: Moves the observer_start spawn landmark from outside the bridge to outside the bar. Previous location did not have the 'Space Station 13' floor decals, and the bar location is closer to the center of the map.
/:cl: