### PR TITLE
Electro-shock therapy has never been easier (baton fix)

### DIFF
--- a/modular_doppler/modular_weapons/code/sec_swords/baton.dm
+++ b/modular_doppler/modular_weapons/code/sec_swords/baton.dm
@@ -28,7 +28,7 @@
 	armor_type = /datum/armor/baton_security
 	throwforce = 7
 	force_say_chance = 50
-	stamina_damage = 35 // DOPPLER EDIT - 4 baton crit now (Original: 60)
+	stamina_damage = 35 // DOPPLER EDIT - 5 baton crit now (Original: 60)
 	knockdown_time = 5 SECONDS
 	clumsy_knockdown_time = 15 SECONDS
 	cooldown = 2.5 SECONDS
@@ -77,7 +77,9 @@
 
 /obj/item/melee/baton/doppler_security/clumsy_check(mob/living/carbon/human/user)
 	. = ..()
-	deductcharge(cell_hit_cost)
+	if(.)
+		SEND_SIGNAL(user, COMSIG_LIVING_MINOR_SHOCK)
+		deductcharge(cell_hit_cost)
 
 /obj/item/melee/baton/doppler_security/baton_effect(mob/living/target, mob/living/user, modifiers, stun_override)
 	if(iscyborg(loc))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The electro-baton was incorrectly deducting charge twice every time it fired, as well as during harmbaton strikes do to the clumsy check deducting charge every time it's called regardless of the parent return value.

I have also changed the comment to accurately reflect how many hits it takes to stun, it seems it was written pre-doppler health buff. Whether 4 hits is the intent or not, I have left it alone. The balance of the time to stun / damage of the baton is beyond the scope of this PR. The status-quo was 5 hits to stamcrit and someone else can pose balance concerns about that later if they like.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Unintended behavior fixed. I think the baton draining charge while on cooldown was very unintuitive if not unintended - that combined with the double dipping of power cost made this baton literally incapable of stamina critting under certain circumstances even with a full cell.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Electro-baton charge deduction being called in error
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
