### PR TITLE
SMES Replacements

### DIFF
--- a/_maps/shuttles/~doppler_shuttles/ferry_hafila.dmm
+++ b/_maps/shuttles/~doppler_shuttles/ferry_hafila.dmm
@@ -113,7 +113,7 @@
 /obj/structure/cable,
 /obj/effect/turf_decal/bot_white,
 /obj/structure/extinguisher_cabinet/directional/east,
-/obj/machinery/power/smes/battery_pack/large/precharged,
+/obj/machinery/power/smes/ship,
 /turf/open/floor/iron/dark/smooth_large,
 /area/shuttle/personally_bought/people_mover)
 "oI" = (

--- a/_maps/shuttles/~doppler_shuttles/ferry_manzil.dmm
+++ b/_maps/shuttles/~doppler_shuttles/ferry_manzil.dmm
@@ -201,7 +201,7 @@
 /obj/structure/cable,
 /obj/effect/turf_decal/bot_white,
 /obj/structure/extinguisher_cabinet/directional/east,
-/obj/machinery/power/smes/battery_pack/large/precharged,
+/obj/machinery/power/smes/ship,
 /turf/open/floor/iron/dark/smooth_large,
 /area/shuttle/personally_bought/house_boat)
 "BW" = (

--- a/_maps/shuttles/~doppler_shuttles/outbound_expedition.dmm
+++ b/_maps/shuttles/~doppler_shuttles/outbound_expedition.dmm
@@ -988,7 +988,7 @@
 /area/shuttle/personally_bought/mothership)
 "yv" = (
 /obj/structure/cable,
-/obj/machinery/power/smes/battery_pack/precharged,
+/obj/machinery/power/smes/ship,
 /obj/effect/turf_decal/bot_white,
 /obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/dark/smooth_large,
@@ -1294,7 +1294,7 @@
 /area/shuttle/personally_bought/mothership)
 "GR" = (
 /obj/structure/cable,
-/obj/machinery/power/smes/battery_pack/precharged,
+/obj/machinery/power/smes/ship,
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/iron/dark/smooth_large,
 /area/shuttle/personally_bought/mothership)


### PR DESCRIPTION
Replaces the battery_pack SMES units on the Hafila, Manzil, and Debug 'outbound_expedition' shuttles

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
If you have recently been using the Hafila or Manzil pattern personal shuttles you may have noticed the incorrect init behavior on the frontier fab battery_pack SMES units - they currently init from being map objects without internal cells, making them worthless.

This PR replaces them with standard SMES units, specifically `/obj/machinery/power/smes/ship` 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
No more mandatory shuttle maintenance to get your APC powered.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
-Replaced `/obj/machinery/power/smes/battery_pack/large` with `/obj/machinery/power/smes/ship` on the Hafila, Manzil, and 'outbound_expedition' shuttle maps
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
