### PR TITLE
Fixes Akhter SMES stationary batteries not having any internal charge

### DIFF
--- a/modular_doppler/colony_fabricator/code/machines/power_storage_unit.dm
+++ b/modular_doppler/colony_fabricator/code/machines/power_storage_unit.dm
@@ -9,9 +9,22 @@
 	output_level_max = 200 KILO WATTS
 	circuit = null
 
+	/// Typepath for the batteries we use to hold our charge, spawned on init.
+	var/spawned_battery_type = /obj/item/stock_parts/power_store/battery/empty
+	/// The amount of batteries we spawn inside of us on init.
+	var/spawned_battery_amount = 5
+
 /obj/machinery/power/smes/battery_pack/Initialize(mapload)
+	initialize_batteries() // Must be done before parent init, so parent can charge the cells.
 	. = ..()
 	AddElement(/datum/element/manufacturer_examine, COMPANY_FRONTIER)
+
+/// Initialize our internal batteries.
+/obj/machinery/power/smes/battery_pack/proc/initialize_batteries()
+	for(var/_ in 1 to spawned_battery_amount)
+		var/obj/item/stock_parts/power_store/spawned_cell = new spawned_battery_type(src)
+		LAZYADD(component_parts, spawned_cell)
+		total_capacity += spawned_cell.max_charge()
 
 /obj/machinery/power/smes/battery_pack/default_deconstruction_screwdriver(mob/user, icon_state_open, icon_state_closed, obj/item/screwdriver)
 	if(screwdriver.tool_behaviour != TOOL_SCREWDRIVER)
@@ -37,10 +50,10 @@
 
 // Automatically set themselves to be completely charged on init
 /obj/machinery/power/smes/battery_pack/precharged
-	charge = 50 * STANDARD_BATTERY_CHARGE
+	charge = 5 * STANDARD_BATTERY_CHARGE
+
 
 // Item for creating the small battery and carrying it around
-
 /obj/item/flatpacked_machine/station_battery
 	name = "flat-packed stationary battery"
 	desc = /obj/machinery/power/smes/battery_pack::desc
@@ -52,8 +65,8 @@
 		/datum/material/silver = HALF_SHEET_MATERIAL_AMOUNT,
 	)
 
-// Larger station batteries, hold more but have less in/output
 
+// Larger station batteries, hold more but have less in/output
 /obj/machinery/power/smes/battery_pack/large
 	name = "large stationary battery"
 	desc = "A massive block of power storage, commonly seen in high storage low output power applications. \
@@ -63,11 +76,11 @@
 	icon = 'modular_doppler/colony_fabricator/icons/power_storage_unit/large_battery.dmi'
 	input_level_max = 50 KILO WATTS
 	output_level_max = 50 KILO WATTS
+	spawned_battery_type = /obj/item/stock_parts/power_store/battery/super
 
 // Automatically set themselves to be completely charged on init
-
 /obj/machinery/power/smes/battery_pack/large/precharged
-	charge = 50 * STANDARD_BATTERY_CHARGE
+	charge = 100 * STANDARD_BATTERY_CHARGE
 
 
 /obj/item/flatpacked_machine/large_station_battery


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

So a recent upstream refactor changed SMES to actually use their component cells, causing these subtypes that don't have a circuit and thus don't automatically generate their cells to be non-functional.
This pr just makes it so these subtypes initialize their own batteries manually, before the parent init charges them, fixing the issue.

Additionally, it seems a recent parity pr got the charges mixed up on these, making both the standard and large battery packs have the same charge set (though nonfunctional). This also reverts them to the previous values each.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes #655.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Akhter stationary batteries SMES types actually have an ability to store charge again, and have their intended charge levels.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
