### PR TITLE
Woe, guns upon us all (Cantina Weapons implant fix)

### DIFF
--- a/modular_doppler/modular_antagonists/cantina/cantina_roles.dm
+++ b/modular_doppler/modular_antagonists/cantina/cantina_roles.dm
@@ -29,7 +29,7 @@
 	id = /obj/item/card/id/advanced/chameleon
 	belt = /obj/item/storage/belt/utility/frontier_colonist
 	box = /obj/item/storage/box/survival/syndie
-	implants = /obj/item/implant/weapons_auth
+	implants = list(/obj/item/implant/weapons_auth)
 	backpack_contents = list(
 		/obj/item/stack/spacecash/c1000 = 2,
 		/obj/item/encryptionkey/syndicate/cantina_headset,
@@ -47,7 +47,7 @@
 	id = /obj/item/card/id/advanced/chameleon
 	belt = /obj/item/storage/belt/utility/frontier_colonist
 	box = /obj/item/storage/box/survival/syndie
-	implants = /obj/item/implant/weapons_auth
+	implants = list(/obj/item/implant/weapons_auth)
 	backpack_contents = list(
 		/obj/item/stack/spacecash/c1000 = 10,
 		)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The outfit settings for the Antag Cantina spawners are now formatted correctly and function (Thanks Ephe). No more getting to the station and finding out your gun doesn't work.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
the thing does what it should now
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix:Cantina weapons implant is correctly implanted in antag cantina spawning cantina characters 😁 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
