### PR TITLE
miniports planetary samples to cargo

### DIFF
--- a/code/modules/cargo/packs/organic.dm
+++ b/code/modules/cargo/packs/organic.dm
@@ -77,24 +77,6 @@
 	crate_name = "exotic seeds crate"
 	crate_type = /obj/structure/closet/crate/hydroponics
 
-/datum/supply_pack/organic/lavalandsamples //DOPPLER EDIT, miniature port from Bubber
-	name = "Planetary Flora Samples"
-	desc = "A box of samples usually native to the distant moon of Indecipheres, \
-		recently found and harvested from a peculiar location on Truth's surface."
-	cost = CARGO_CRATE_VALUE * 10 //edited from 6 to 10, these shits were dangerous to harvest and a pain to cultivate
-	access_view = ACCESS_HYDROPONICS
-	contains = list(
-		/obj/item/seeds/lavaland/polypore,
-		/obj/item/seeds/lavaland/porcini,
-		/obj/item/seeds/lavaland/inocybe,
-		/obj/item/seeds/lavaland/ember,
-		/obj/item/seeds/lavaland/seraka,
-		/obj/item/seeds/lavaland/fireblossom,
-		/obj/item/seeds/lavaland/cactus,
-	)
-	crate_name = "planetary seeds crate"
-	crate_type = /obj/structure/closet/crate/hydroponics
-
 /datum/supply_pack/organic/food
 	name = "Food Crate"
 	desc = "Get things cooking with this crate full of useful ingredients! \

--- a/code/modules/cargo/packs/organic.dm
+++ b/code/modules/cargo/packs/organic.dm
@@ -77,6 +77,24 @@
 	crate_name = "exotic seeds crate"
 	crate_type = /obj/structure/closet/crate/hydroponics
 
+/datum/supply_pack/organic/lavalandsamples //DOPPLER EDIT, miniature port from Bubber
+	name = "Planetary Flora Samples"
+	desc = "A box of samples usually native to the distant moon of Indecipheres, \
+		recently found and harvested from a peculiar location on Truth's surface."
+	cost = CARGO_CRATE_VALUE * 10 //edited from 6 to 10, these shits were dangerous to harvest and a pain to cultivate
+	access_view = ACCESS_HYDROPONICS
+	contains = list(
+		/obj/item/seeds/lavaland/polypore,
+		/obj/item/seeds/lavaland/porcini,
+		/obj/item/seeds/lavaland/inocybe,
+		/obj/item/seeds/lavaland/ember,
+		/obj/item/seeds/lavaland/seraka,
+		/obj/item/seeds/lavaland/fireblossom,
+		/obj/item/seeds/lavaland/cactus,
+	)
+	crate_name = "planetary seeds crate"
+	crate_type = /obj/structure/closet/crate/hydroponics
+
 /datum/supply_pack/organic/food
 	name = "Food Crate"
 	desc = "Get things cooking with this crate full of useful ingredients! \

--- a/modular_doppler/modular_cargo/doppler_cargo_packs.dm
+++ b/modular_doppler/modular_cargo/doppler_cargo_packs.dm
@@ -7,6 +7,7 @@
 	crate_name = "shortsword crate"
 
 /datum/supply_pack/organic/lavalandsamples
+	name = "Thermophytic Seeds Crate"
 	desc = "A box of plant and mushroom samples that thrive in extreme heat and volcanic soil. Great for \
 	harvesting cytology-related chemicals and making a mushroom stirfry, not-so-great for planting in an icy tundra."
 	cost = CARGO_CRATE_VALUE * 9 //the price of failing to snoop around the mining base hard enough

--- a/modular_doppler/modular_cargo/doppler_cargo_packs.dm
+++ b/modular_doppler/modular_cargo/doppler_cargo_packs.dm
@@ -5,3 +5,20 @@
 	access_view = ACCESS_SECURITY
 	contains = list(/obj/item/storage/belt/secsword/deathmatch = 2) //4 swords total
 	crate_name = "shortsword crate"
+
+/datum/supply_pack/organic/lavalandsamples
+	desc = "A box of plant and mushroom samples that thrive in extreme heat and volcanic soil. Great for \
+	harvesting cytology-related chemicals and making a mushroom stirfry, not-so-great for planting in an icy tundra."
+	cost = CARGO_CRATE_VALUE * 9 //the price of failing to snoop around the mining base hard enough
+	access_view = ACCESS_HYDROPONICS
+	contains = list(
+		/obj/item/seeds/lavaland/polypore,
+		/obj/item/seeds/lavaland/porcini,
+		/obj/item/seeds/lavaland/inocybe,
+		/obj/item/seeds/lavaland/ember,
+		/obj/item/seeds/lavaland/seraka,
+		/obj/item/seeds/lavaland/fireblossom,
+		/obj/item/seeds/lavaland/cactus,
+	)
+	crate_name = "thermophytic seeds crate"
+	crate_type = /obj/structure/closet/crate/hydroponics


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Using some appropriated code from one of Bubber's cargo expansions, hydroponics can now order plant samples normally exclusive to Indecipheres at a notable premium. Harvesting this shit from Truth wasn't easy!  

## Why It's Good For The Game

You getting these samples is complete rng otherwise, the only other source is the lavaland ruin on the surface of Truth

## Testing Evidence

I ran it earlier, the crate costed like 2000 cr

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: After some (very painful) harvesting and cultivation of flora from a certain ruin on Truth, PA has approved some otherwise Indecipheres-exclusive plant samples for order by hydroponics. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
