### PR TITLE
Reorganize the loadout, part 1: Glasses

### DIFF
--- a/code/modules/loadout/categories/glasses.dm
+++ b/code/modules/loadout/categories/glasses.dm
@@ -24,6 +24,7 @@
 		outfit.glasses = item_path
 // DOPPLER EDIT END
 
+/* // DOPPLER EDIT REMOVAL START - Custom Loadout Organization
 /datum/loadout_item/glasses/regular
 	name = "Glasses"
 	item_path = /obj/item/clothing/glasses/regular
@@ -75,3 +76,4 @@
 /datum/loadout_item/glasses/monocle
 	name = "Monocle"
 	item_path = /obj/item/clothing/glasses/monocle
+*/ // DOPPLER EDIT REMOVAL END

--- a/modular_doppler/loadout_categories/categories/glasses.dm
+++ b/modular_doppler/loadout_categories/categories/glasses.dm
@@ -84,7 +84,7 @@
 	name = "Retinal Projector (Diagnostics)"
 	item_path = /obj/item/clothing/glasses/hud/ar/projector/diagnostic
 
-/datum/loadout_item/glasses/hud/retinal_projector_diagnostic
+/datum/loadout_item/glasses/hud/retinal_projector_science
 	name = "Retinal Projector (Science)"
 	item_path = /obj/item/clothing/glasses/hud/ar/projector/science
 
@@ -144,7 +144,7 @@
 
 /datum/loadout_item/glasses/hud/stealing/get_item_information()
 	. = ..()
-	.[FA_ICON_LINK] = "Takes in other glasses!"
+	.[FA_ICON_LINK] = "Takes in properties of other glasses!"
 
 /datum/loadout_item/glasses/hud/stealing/techno_visor
 	name = "Techno-Visor"

--- a/modular_doppler/loadout_categories/categories/glasses.dm
+++ b/modular_doppler/loadout_categories/categories/glasses.dm
@@ -22,98 +22,200 @@
 		manager.deselect_item(other_loadout_items[1])
 	return TRUE
 
-/datum/loadout_item/glasses/mining_goggles
-	name = "Explorer Goggles"
+/**
+ * PRESCRIPTION GLASSES
+ */
+/datum/loadout_item/glasses/prescription
+	group = "Prescription Glasses"
+	abstract_type = /datum/loadout_item/glasses/prescription
+
+/datum/loadout_item/glasses/prescription/regular
+	name = "Prescription Glasses"
+	item_path = /obj/item/clothing/glasses/regular
+
+/datum/loadout_item/glasses/prescription/circle_glasses
+	name = "Prescription Glasses (Circle)"
+	item_path = /obj/item/clothing/glasses/regular/circle
+
+/datum/loadout_item/glasses/prescription/hipster_glasses
+	name = "Prescription Glasses (Hipster)"
+	item_path = /obj/item/clothing/glasses/regular/hipster
+
+/datum/loadout_item/glasses/prescription/jamjar
+	name = "Prescription Glasses (Jamjar)"
+	item_path = /obj/item/clothing/glasses/regular/jamjar
+
+/datum/loadout_item/glasses/prescription/thin
+	name = "Prescription Glasses (Thin)"
+	item_path = /obj/item/clothing/glasses/regular/thin
+
+/datum/loadout_item/glasses/prescription/kim
+	name = "Prescription Glasses (Binoclard)"
+	item_path = /obj/item/clothing/glasses/regular/kim
+
+/datum/loadout_item/glasses/prescription/monocle
+	name = "Prescription Monocle"
+	item_path = /obj/item/clothing/glasses/monocle
+
+/**
+ * HUD GLASSES
+ */
+/datum/loadout_item/glasses/hud
+	group = "HUDs"
+	abstract_type = /datum/loadout_item/glasses/hud
+
+/datum/loadout_item/glasses/hud/retinal_projector
+	name = "Retinal Projector (None)"
+	item_path = /obj/item/clothing/glasses/hud/ar/projector
+
+/datum/loadout_item/glasses/hud/retinal_projector_meson
+	name = "Retinal Projector (Meson)"
+	item_path = /obj/item/clothing/glasses/hud/ar/projector/meson
+
+/datum/loadout_item/glasses/hud/retinal_projector_health
+	name = "Retinal Projector (Medical)"
+	item_path = /obj/item/clothing/glasses/hud/ar/projector/health
+
+/datum/loadout_item/glasses/hud/retinal_projector_security
+	name = "Retinal Projector (Security)"
+	item_path = /obj/item/clothing/glasses/hud/ar/projector/security
+
+/datum/loadout_item/glasses/hud/retinal_projector_diagnostic
+	name = "Retinal Projector (Diagnostics)"
+	item_path = /obj/item/clothing/glasses/hud/ar/projector/diagnostic
+
+/datum/loadout_item/glasses/hud/retinal_projector_diagnostic
+	name = "Retinal Projector (Science)"
+	item_path = /obj/item/clothing/glasses/hud/ar/projector/science
+
+/datum/loadout_item/glasses/hud/aviator
+	name = "Aviators (None)"
+	item_path = /obj/item/clothing/glasses/hud/ar/aviator
+
+/datum/loadout_item/glasses/hud/aviator_meson
+	name = "Aviators (Meson)"
+	item_path = /obj/item/clothing/glasses/hud/ar/aviator/meson
+
+/datum/loadout_item/glasses/hud/aviator_health
+	name = "Aviators (Medical)"
+	item_path = /obj/item/clothing/glasses/hud/ar/aviator/health
+
+/datum/loadout_item/glasses/hud/aviator_security
+	name = "Aviators (Security)"
+	item_path = /obj/item/clothing/glasses/hud/ar/aviator/security
+
+/datum/loadout_item/glasses/hud/aviator_diagnostic
+	name = "Aviators (Diagnostics)"
+	item_path = /obj/item/clothing/glasses/hud/ar/aviator/diagnostic
+
+/datum/loadout_item/glasses/hud/aviator_science
+	name = "Aviators (Science)"
+	item_path = /obj/item/clothing/glasses/hud/ar/aviator/science
+
+/datum/loadout_item/glasses/hud/hud_eyepatch_meson
+	name = "HUD Eyepatch (Meson)"
+	item_path = /obj/item/clothing/glasses/hud/eyepatch/meson
+
+/datum/loadout_item/glasses/hud/hud_eyepatch_med
+	name = "HUD Eyepatch (Medical)"
+	item_path = /obj/item/clothing/glasses/hud/eyepatch/med
+
+/datum/loadout_item/glasses/hud/hud_eyepatch_sec
+	name = "HUD Eyepatch (Security)"
+	item_path = /obj/item/clothing/glasses/hud/eyepatch/sec
+
+/datum/loadout_item/glasses/hud/hud_eyepatch_diagnostic
+	name = "HUD Eyepatch (Diagnostics)"
+	item_path = /obj/item/clothing/glasses/hud/eyepatch/diagnostic
+
+/datum/loadout_item/glasses/hud/hud_eyepatch_sci
+	name = "HUD Eyepatch (Science)"
+	item_path = /obj/item/clothing/glasses/hud/eyepatch/sci
+
+/datum/loadout_item/glasses/hud/mining_goggles
+	name = "Explorer Goggles (Meson)"
 	item_path = /obj/item/clothing/glasses/mining_meson
 
-/datum/loadout_item/glasses/holo_infohud
-	name = "Holographic Infohud"
-	item_path = /obj/item/clothing/glasses/tajaran_hud
+/**
+ * HUD GLASSES (Take in other huds)
+ */
+/datum/loadout_item/glasses/hud/stealing
+	abstract_type = /datum/loadout_item/glasses/hud/stealing
 
-/datum/loadout_item/glasses/solid_infohud
-	name = "Solid Infohud"
-	item_path = /obj/item/clothing/glasses/lizard_hud
+/datum/loadout_item/glasses/hud/stealing/get_item_information()
+	. = ..()
+	.[FA_ICON_LINK] = "Takes in other glasses!"
 
-/datum/loadout_item/glasses/welding
-	name = "Welding Goggles"
-	item_path = /obj/item/clothing/glasses/welding
-
-/datum/loadout_item/glasses/white_eyepatch
-	name = "White Eyepatch"
-	item_path = /obj/item/clothing/glasses/eyepatch/white
-
-/datum/loadout_item/glasses/eyewrap
-	name = "Eyepatch Wrap"
-	item_path = /obj/item/clothing/glasses/eyepatch/wrap
-
-/datum/loadout_item/glasses/fake_blindfold
-	name = "Fake Blindfold"
-	item_path = /obj/item/clothing/glasses/trickblindfold
-
-/datum/loadout_item/glasses/techno_visor
+/datum/loadout_item/glasses/hud/stealing/techno_visor
 	name = "Techno-Visor"
 	item_path = /obj/item/clothing/glasses/techno_visor
 
-/datum/loadout_item/glasses/retinal_projector
-	name = "Retinal Projector"
-	item_path = /obj/item/clothing/glasses/hud/ar/projector
+/datum/loadout_item/glasses/hud/stealing/holo_infohud
+	name = "Holographic Infohud"
+	item_path = /obj/item/clothing/glasses/tajaran_hud
 
-/datum/loadout_item/glasses/retinal_projector_meson
-	name = "Meson Retinal Projector"
-	item_path = /obj/item/clothing/glasses/hud/ar/projector/meson
+/datum/loadout_item/glasses/hud/stealing/solid_infohud
+	name = "Solid Infohud"
+	item_path = /obj/item/clothing/glasses/lizard_hud
 
-/datum/loadout_item/glasses/retinal_projector_health
-	name = "Health Retinal Projector"
-	item_path = /obj/item/clothing/glasses/hud/ar/projector/health
+/**
+ * BLINDFOLDS/EYEPATCHES
+ */
+/datum/loadout_item/glasses/blinding
+	group = "Blinding Covers"
+	abstract_type = /datum/loadout_item/glasses/blinding
 
-/datum/loadout_item/glasses/retinal_projector_security
-	name = "Security Retinal Projector"
-	item_path = /obj/item/clothing/glasses/hud/ar/projector/security
+/datum/loadout_item/glasses/blinding/black_blindfold
+	name = "Blindfold (Black)"
+	item_path = /obj/item/clothing/glasses/blindfold
 
-/datum/loadout_item/glasses/retinal_projector_diagnostic
-	name = "Diagnostic Retinal Projector"
-	item_path = /obj/item/clothing/glasses/hud/ar/projector/diagnostic
+/datum/loadout_item/glasses/blinding/fake_blindfold
+	name = "Blindfold (Black, Fake)"
+	item_path = /obj/item/clothing/glasses/trickblindfold
 
-/datum/loadout_item/glasses/aviator
-	name = "Aviators"
-	item_path = /obj/item/clothing/glasses/hud/ar/aviator
+/datum/loadout_item/glasses/blinding/eyepatch
+	name = "Eyepatch (Black)"
+	item_path = /obj/item/clothing/glasses/eyepatch
 
-/datum/loadout_item/glasses/aviator_security
-	name = "Security Aviators"
-	item_path = /obj/item/clothing/glasses/hud/ar/aviator/security
+/datum/loadout_item/glasses/blinding/white_eyepatch
+	name = "Eyepatch (White)"
+	item_path = /obj/item/clothing/glasses/eyepatch/white
 
-/datum/loadout_item/glasses/aviator_health
-	name = "Health Aviators"
-	item_path = /obj/item/clothing/glasses/hud/ar/aviator/health
+/datum/loadout_item/glasses/blinding/medical_eyepatch
+	name = "Eyepatch (Medical)"
+	item_path = /obj/item/clothing/glasses/eyepatch/medical
 
-/datum/loadout_item/glasses/aviator_meson
-	name = "Meson Aviators"
-	item_path = /obj/item/clothing/glasses/hud/ar/aviator/meson
+/datum/loadout_item/glasses/blinding/eyewrap
+	name = "Eyepatch (Wrap)"
+	item_path = /obj/item/clothing/glasses/eyepatch/wrap
 
-/datum/loadout_item/glasses/aviator_diagnostic
-	name = "Diagnostic Aviators"
-	item_path = /obj/item/clothing/glasses/hud/ar/aviator/diagnostic
+/**
+ * OTHER
+ */
+/datum/loadout_item/glasses/other
+	group = "Uncategorized"
+	abstract_type = /datum/loadout_item/glasses/other
 
-/datum/loadout_item/glasses/aviator_science
-	name = "Science Aviators"
-	item_path = /obj/item/clothing/glasses/hud/ar/aviator/science
+/datum/loadout_item/glasses/other/cold_glasses
+	name = "Cold Glasses"
+	item_path = /obj/item/clothing/glasses/cold
 
-/datum/loadout_item/glasses/hud_eyepatch_sec
-	name = "Security HUD Eyepatch"
-	item_path = /obj/item/clothing/glasses/hud/eyepatch/sec
+/datum/loadout_item/glasses/other/heat_glasses
+	name = "Heat Glasses"
+	item_path = /obj/item/clothing/glasses/heat
 
-/datum/loadout_item/glasses/hud_eyepatch_med
-	name = "Medical HUD Eyepatch"
-	item_path = /obj/item/clothing/glasses/hud/eyepatch/med
+/datum/loadout_item/glasses/other/orange_glasses
+	name = "Orange Glasses"
+	item_path = /obj/item/clothing/glasses/orange
 
-/datum/loadout_item/glasses/hud_eyepatch_meson
-	name = "Meson HUD Eyepatch"
-	item_path = /obj/item/clothing/glasses/hud/eyepatch/meson
+/datum/loadout_item/glasses/other/red_glasses
+	name = "Red Glasses"
+	item_path = /obj/item/clothing/glasses/red
 
-/datum/loadout_item/glasses/hud_eyepatch_diagnostic
-	name = "Diagnostic HUD Eyepatch"
-	item_path = /obj/item/clothing/glasses/hud/eyepatch/diagnostic
+/datum/loadout_item/glasses/other/welding
+	name = "Welding Goggles"
+	item_path = /obj/item/clothing/glasses/welding
 
-/datum/loadout_item/glasses/hud_eyepatch_sci
-	name = "Science HUD Eyepatch"
-	item_path = /obj/item/clothing/glasses/hud/eyepatch/sci
+/datum/loadout_item/glasses/other/osisunglasses
+	name = "O.S.I. Sunglasses"
+	item_path = /obj/item/clothing/glasses/osi


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

We've reached a quite unwieldy level of items in our loadout, and this is a step forward in seeking to resolve that, applying it to the glasses loadout category first.

The two methods I use for this are:
1. Sorting the loadout into subgroups, for any coherent group larger than 5 items. This makes browsing our loadouts significantly more manageable.
2. Renaming items into a "type (modifiers)" format wherever applicable. This makes it easier to find specific things when searching for them, and also sorts all similar options nicely together.

To do this sanely we however comment out the full list of the base tg glasses category options, and move these to our modular file.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Categorizing makes it easier to browse, the consistent "type (modifiers)" naming makes it easier to search for things.
Odd that only thin prescription glasses were missing out of all prescription glasses.
O.S.I. sunglasses are a not-particularly-odd one from the clothes vendors that were missing.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Testing Evidence

<img width="660" height="583" alt="image" src="https://github.com/user-attachments/assets/ffc6371c-85d1-4e81-aefd-fdc628e02b0e" />
<img width="662" height="568" alt="image" src="https://github.com/user-attachments/assets/9b54ae3a-2728-4a59-82a4-dcef8f2fe20d" />
<img width="596" height="265" alt="image" src="https://github.com/user-attachments/assets/e99736f1-f4b5-4975-9b9c-d5d009cbb388" />

<!-- Provide proof that the content added, edited, or removed by this pull request is working as intended in-game. Compiling alone doesn't guarantee functionality, so be sure to test thoroughly! -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added the thin prescription glasses and OSI sunglasses to the loadout. Binoclard glasses are no longer thin glasses in the loadout.
qol: Split the glasses loadout category into subgroups. These being HUDs, Prescription Glasses, Blinding Covers, and Uncategorized.
qol: A large portion of the options in the glasses loadout category have been renamed for ease of searching. This only affects their names in the loadout.
qol: Loadout glasses that can take in the properties of other glasses have a little tooltip denoting such.
fix: Added the missing science retinal projector to the loadout.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
