### PR TITLE
Adds the Civilian Modsuit to the Backpack Loadout Category

### DIFF
--- a/modular_doppler/loadout_categories/categories/backpacks.dm
+++ b/modular_doppler/loadout_categories/categories/backpacks.dm
@@ -22,6 +22,10 @@
 	name = "Custom Backpack"
 	item_path = /obj/item/storage/backpack/custom
 
+/datum/loadout_item/backpack/modsuit/civilian
+	name = "Civilian Modsuit"
+	item_path = /obj/item/mod/control/pre_equipped/civilian
+
 /datum/loadout_item/backpack/industrial
 	name = "Custom Industrial Backpack"
 	item_path = /obj/item/storage/backpack/industrial/custom


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
As title.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The civilian variant of the modsuits does not come with EVA pressurization or temperature control like a full space suit. However, it does come with 12 complexity, a storage module, flashlight, and welding protection (on a battery).

Modsuit technology is a known variable in-setting, and more access to the suits would promote interaction with robotics/science as a whole. Being available in the loadout, characters can reflect some of the traits that would come with a personally-owned modsuit, such as being tech savvy, being emotionally/psychologically dependent on wearing a modsuit without being entombed, or enjoying the ability to plug-and-play with the maint modules. (mobile tanning bed, anyone?)

Primary balance concern would be the increased availability of modsuit cores on station, as each civilian modsuit comes with one standard. Additionally, using Maint Robotics to print sec/med/meson/diag HUD modules would make all other those more available to a modsuit'ed crew member regardless of lathe access. A further concern could be the unobstructive flash-protection that the welding protection module provides, but the cost of wearing an EMP-sensitive battery-dependent peice of equipment on your back provides an additional consideration that our 'Approved Cybernetics' quirk Flash-Shield eyes do not.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Testing Evidence
Compiles and is delivered to the loadout suitcase as expected.
<img width="573" height="573" alt="Screenshot 2025-09-23 152611" src="https://github.com/user-attachments/assets/5257f6de-fcf2-41f6-bfd5-7369a74b1240" />
<img width="131" height="153" alt="Screenshot 2025-09-23 153950" src="https://github.com/user-attachments/assets/786a5947-a53a-441e-8521-436ffc9a31d6" />
<img width="600" height="517" alt="Screenshot 2025-09-23 153956" src="https://github.com/user-attachments/assets/cd53aa9e-037c-4d8b-af37-69c38a749b41" />
<img width="689" height="214" alt="Screenshot 2025-09-23 154101" src="https://github.com/user-attachments/assets/020608f4-a6cb-4fc5-aab9-2a7ddf07ff33" />
<img width="1236" height="960" alt="Screenshot 2025-09-23 154109" src="https://github.com/user-attachments/assets/cb50ae74-1ba7-40d5-bc0d-d671b117baa2" />

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Civilian Modsuit to Backpack Loadout Category

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
