### PR TITLE
Slimegirl's Requiem Part 1: refactors slime washing

### DIFF
--- a/modular_doppler/modular_species/species_types/slimes/code/roundstartslimes.dm
+++ b/modular_doppler/modular_species/species_types/slimes/code/roundstartslimes.dm
@@ -21,9 +21,7 @@
 	/// Ability to allow them to shapeshift their body around.
 	var/datum/action/innate/alter_form/alter_form
 	/// Ability to allow them to clean themselves and their stuff.
-	var/datum/action/cooldown/spell/slime_washing/slime_washing
-	/// Ability to allow them to resist the effects of water.
-	var/datum/action/cooldown/spell/slime_hydrophobia/slime_hydrophobia
+	var/datum/action/cooldown/slime_washing/slime_washing
 	/// Ability to allow them to turn their core's GPS on or off.
 	var/datum/action/innate/core_signal/core_signal
 
@@ -43,10 +41,8 @@
 
 /datum/species/jelly/on_species_loss(mob/living/carbon/former_jellyperson, datum/species/new_species, pref_load)
 	. = ..()
-	if(slime_washing)
-		slime_washing.Remove(former_jellyperson)
-	if(core_signal)
-		core_signal.Remove(former_jellyperson)
+	QDEL_NULL(slime_washing)
+	QDEL_NULL(core_signal)
 
 /obj/item/organ/eyes/jelly
 	name = "photosensitive eyespots"
@@ -288,64 +284,6 @@
 			return
 		slime.heal_overall_damage(brute = 1.5 * seconds_per_tick, burn = 1.5 * seconds_per_tick, required_bodytype = BODYTYPE_ORGANIC)
 		slime.adjustOxyLoss(-1 * seconds_per_tick)
-
-
-/**
-* SLIME CLEANING ABILITY -
-* When toggled, slimes clean themselves and their equipment.
-*/
-/datum/action/cooldown/spell/slime_washing
-	name = "Toggle Slime Cleaning"
-	desc = "Filter grime through your outer membrane, cleaning yourself and your equipment for sustenance. Also cleans the floor. For sustenance."
-	button_icon = 'icons/mob/actions/actions_silicon.dmi'
-	button_icon_state = "activate_wash"
-
-	cooldown_time = 1 SECONDS
-	spell_requirements = NONE
-
-/datum/action/cooldown/spell/slime_washing/cast(mob/living/carbon/human/user = usr)
-	. = ..()
-
-	if(user.has_status_effect(/datum/status_effect/slime_washing))
-		slime_washing_deactivate(user)
-		return
-
-	user.apply_status_effect(/datum/status_effect/slime_washing)
-	user.visible_message(span_purple("[user]'s outer membrane starts to develop a cloudy film on the outside, absorbing grime into [user.p_their()] inner layer!"), span_purple("Your outer membrane develops a cloudy film on the outside, absorbing grime off yourself and your clothes; as well as the floor beneath you."))
-
-/**
-* Called when you activate it again after casting the ability-- turning it off, so to say.
-*/
-/datum/action/cooldown/spell/slime_washing/proc/slime_washing_deactivate(mob/living/carbon/human/user)
-	if(!user.has_status_effect(/datum/status_effect/slime_washing))
-		return
-
-	user.remove_status_effect(/datum/status_effect/slime_washing)
-	user.visible_message(span_notice("[user]'s outer membrane returns to normal, no longer cleaning [user.p_their()] surroundings."), span_notice("Your outer membrane returns to normal, filth no longer being cleansed."))
-
-/datum/status_effect/slime_washing
-	id = "slime_washing"
-	alert_type = null
-	status_type = STATUS_EFFECT_UNIQUE
-
-/datum/status_effect/slime_washing/tick(seconds_between_ticks, seconds_per_tick)
-	if(ishuman(owner))
-		var/mob/living/carbon/human/slime = owner
-		for(var/obj/item/slime_items in slime.get_equipped_items(INCLUDE_ACCESSORIES | INCLUDE_HELD))
-			slime_items.wash(CLEAN_WASH)
-			slime.wash(CLEAN_WASH)
-		if((slime.wear_suit?.body_parts_covered | slime.w_uniform?.body_parts_covered | slime.shoes?.body_parts_covered) & FEET)
-			return
-		else
-			var/turf/open/open_turf = get_turf(slime)
-			if(istype(open_turf))
-				open_turf.wash(CLEAN_WASH)
-				return TRUE
-			if(SPT_PROB(5, seconds_per_tick))
-				slime.adjust_nutrition((rand(5,25)))
-
-/datum/status_effect/slime_washing/get_examine_text()
-	return span_notice("[owner.p_Their()] outer layer is pulling in grime, filth sinking inside of [owner.p_their()] body and vanishing.")
 
 /datum/species/jelly/roundstartslime
 	name = "Xenobiological Slime Hybrid"

--- a/modular_doppler/modular_species/species_types/slimes/code/slime_washing.dm
+++ b/modular_doppler/modular_species/species_types/slimes/code/slime_washing.dm
@@ -1,0 +1,70 @@
+/**
+* SLIME CLEANING ABILITY -
+* When toggled, slimes clean themselves and their equipment.
+*/
+/datum/action/cooldown/slime_washing
+	name = "Toggle Slime Cleaning"
+	desc = "Filter grime through your outer membrane, cleaning yourself and your equipment for sustenance. Also cleans the floor. For sustenance."
+	button_icon = 'icons/mob/actions/actions_silicon.dmi'
+	button_icon_state = "activate_wash"
+	cooldown_time = 1 SECONDS
+
+/datum/action/cooldown/slime_washing/Remove(mob/living/remove_from)
+	. = ..()
+	remove_from.remove_status_effect(/datum/status_effect/slime_washing)
+
+/datum/action/cooldown/slime_washing/Activate()
+	. = ..()
+	var/mob/living/carbon/human/user = owner
+	if(!ishuman(user))
+		CRASH("Non-human somehow had [name] action")
+
+	if(user.has_status_effect(/datum/status_effect/slime_washing))
+		user.remove_status_effect(/datum/status_effect/slime_washing)
+	else
+		user.apply_status_effect(/datum/status_effect/slime_washing)
+
+/datum/status_effect/slime_washing
+	id = "slime_washing"
+	alert_type = null
+	status_type = STATUS_EFFECT_UNIQUE
+
+/datum/status_effect/slime_washing/on_apply()
+	if(!ishuman(owner))
+		return FALSE
+	RegisterSignal(owner, COMSIG_MOVABLE_MOVED, PROC_REF(clean_floor))
+	owner.visible_message(
+		span_purple("[owner]'s outer membrane starts to develop a roiling film on the outside, absorbing grime into [owner.p_their()] inner layer!"),
+		span_purple("Your outer membrane develops a roiling film on the outside, absorbing grime off yourself and your clothes; as well as the floor beneath you.")
+	)
+	return TRUE
+
+/datum/status_effect/slime_washing/on_remove()
+	UnregisterSignal(owner, COMSIG_MOVABLE_MOVED)
+	owner.visible_message(
+		span_notice("[owner]'s outer membrane returns to normal, no longer cleaning [owner.p_their()] surroundings."),
+		span_notice("Your outer membrane returns to normal, filth no longer being cleansed.")
+	)
+
+/datum/status_effect/slime_washing/tick(seconds_between_ticks)
+	if(owner.stat == DEAD)
+		qdel(src)
+		return
+	if(owner.wash(CLEAN_WASH) && owner.nutrition <= NUTRITION_LEVEL_FED)
+		owner.adjust_nutrition(rand(5, 25)) // mmm, sustenance.
+	clean_floor()
+
+/datum/status_effect/slime_washing/proc/clean_floor()
+	SIGNAL_HANDLER
+	var/mob/living/carbon/human/slime = owner
+	if(slime.body_position != LYING_DOWN && ((slime.wear_suit?.body_parts_covered | slime.w_uniform?.body_parts_covered | slime.shoes?.body_parts_covered) & FEET))
+		return
+	var/turf/open/open_turf = get_turf(slime)
+	if(!istype(open_turf))
+		return
+	if(open_turf.wash(CLEAN_WASH) && slime.nutrition <= NUTRITION_LEVEL_FED)
+		slime.adjust_nutrition(rand(5, 25))
+	return TRUE
+
+/datum/status_effect/slime_washing/get_examine_text()
+	return span_notice("[owner.p_Their()] outer layer is pulling in grime, filth sinking inside of [owner.p_their()] body and vanishing.")

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7494,6 +7494,7 @@
 #include "modular_doppler\modular_species\species_types\ramatae\ramatan_organs.dm"
 #include "modular_doppler\modular_species\species_types\slimes\slime_bodyparts.dm"
 #include "modular_doppler\modular_species\species_types\slimes\code\roundstartslimes.dm"
+#include "modular_doppler\modular_species\species_types\slimes\code\slime_washing.dm"
 #include "modular_doppler\modular_species\species_types\snails\modular_snail.dm"
 #include "modular_doppler\modular_species\species_types\snails\snail_bodyparts.dm"
 #include "modular_doppler\modular_species\species_types\snails\organs\snail_heart.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ports the following PRs:
- https://github.com/Monkestation/Monkestation2.0/pull/6809
  -  just the slime washing refactor, tho
- https://github.com/Monkestation/Monkestation2.0/pull/7678
- https://github.com/Monkestation/Monkestation2.0/pull/7709

This refactors the slime washing ability, so most of the code lies in the status effect itself, rather than being weirdly split between the ability and the status effect.

I also made it a normal cooldown ability, rather than a spell. Not really any reason for it to be a spell instead of a normal cooldown ability.

I've also improved the code of slime washing itself - it now just calls wash() on the user once, instead of repeatedly calling wash() on the user _for each equipped item they have._ It now also washes the floor whenever the slime moves, instead of just washing the floor each second when it ticks.

also you can crawl around on the floor and lick up grime without needing to take your shoes off.

## Why It's Good For The Game

cleans up code quite a bit, and makes slime washing a bit nicer to use overall.

## Testing Evidence

https://github.com/user-attachments/assets/e7e8590a-e3df-46ce-9763-a2901cf6a8ad

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: Improved the code for the Slime Cleaning ability quite a bit.
qol: You can now lie on the floor while Slime Cleaning is active to clean the floors, without taking your shoes off.
qol: Slime washing now eats grime off the floor when moving, not just every second.
fix: Slime Cleaning now properly provides sustenance when cleaning up grime.
fix: The Slime Cleaning ability is no longer overly laggy.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
