### PR TITLE
Adjustment to Message and Item Description Length

### DIFF
--- a/code/__DEFINES/say.dm
+++ b/code/__DEFINES/say.dm
@@ -117,7 +117,7 @@
 #define MAX_CHARTER_LEN 80
 #define MAX_PLAQUE_LEN 144
 #define MAX_LABEL_LEN 64
-#define MAX_DESC_LEN 560 //DOPPLER SHIFT EDIT TO 560, INIT 280
+#define MAX_DESC_LEN 560 // DOPPLER EDIT CHANGE - orig: #define MAX_DESC_LEN 560
 
 // Audio/Visual Flags. Used to determine what sense are required to notice a message.
 #define MSG_VISUAL (1<<0)


### PR DESCRIPTION
## About The Pull Request

This adjusts the maximum message length from 1024 to 2048, and the item description length from 280 to 560.
This is a direct copy of  #661 but able to actually be merged properly because I did not know how to uncommit certain things and kind of messed up the branch a bit too hard.

## Why It's Good For The Game

People HATE when their messages get cut off. (I am one of these people.)

I have also seen multiple requests for longer item descriptions - intended mainly for loadout items with more flavor.

## Changelog

:cl:
add: Increases maximum message character count from 1024 to 2048.
add: Increases maximum item description character count from 280 to 560.
/:cl: