### PR TITLE
Makes undersized people no longer be squashed by non-dense objects, no more tram slidealong hell

### DIFF
--- a/modular_doppler/modular_quirks/undersized/squashable.dm
+++ b/modular_doppler/modular_quirks/undersized/squashable.dm
@@ -4,8 +4,6 @@
 	var/squash_chance = 50
 	///this is the base value we reset to after squishing, but it's modified by several factors
 	var/squash_damage_base = 20
-	///to this var, which is the actual damage sent through apply_damage
-	var/squash_damage_final
 	///Squash flags, for extra checks etcetera, you can use the same ones as normal squashable
 	var/squash_flags = NONE
 	///Special callback to call on squash instead, for things like hauberoach
@@ -25,7 +23,6 @@
 		src.squash_chance = squash_chance
 	if(squash_damage)
 		src.squash_damage_base = squash_damage
-		src.squash_damage_final = squash_damage_base
 	if(squash_flags)
 		src.squash_flags = squash_flags
 	if(!src.on_squash_callback && squash_callback)
@@ -58,42 +55,55 @@
 			return //Everything worked, we're done!
 
 	if(isliving(crossing_movable))
-		var/mob/living/crossing_mob = crossing_movable
-		if(crossing_mob.mob_size > MOB_SIZE_SMALL && !(crossing_mob.movement_type & MOVETYPES_NOT_TOUCHING_GROUND))
-
-			if(crossing_mob.mob_size >= MOB_SIZE_LARGE) //if something big is stepping on you, it's gonna hurt more.
-				squash_damage_final *= 2
-
-			//normal squashable pacifism check
-			if(HAS_TRAIT(crossing_mob, TRAIT_PACIFISM))
-				crossing_mob.visible_message(span_notice("[crossing_mob] carefully steps over [parent_as_living]."), span_notice("You carefully step over [parent_as_living] to avoid hurting it."))
-				return
-
-			//If you're on Combat intent, you will always squash. If you walk, you will avoid squashing.
-			if(crossing_mob.move_intent == MOVE_INTENT_WALK && crossing_mob.combat_mode == FALSE)
-				crossing_mob.visible_message(span_notice("[crossing_mob] carefully walks around [parent_as_living]."), span_notice("You carefully walk around [parent_as_living] to avoid hurting it."))
-				return
-			//Tiny flying creatures are only squashed if the squasher is explicitly on combat mode
-			if(parent_as_living.movement_type & MOVETYPES_NOT_TOUCHING_GROUND && crossing_mob.combat_mode == FALSE)
-				return
-
-			if(should_squash)
-				if(parent_as_living.movement_type & MOVETYPES_NOT_TOUCHING_GROUND)
-					crossing_mob.visible_message(span_notice("[crossing_mob] slaps [parent_as_living] out of the air!"), span_notice("You slapped [parent_as_living] down."))
-				else
-					crossing_mob.visible_message(span_notice("[crossing_mob] squashed [parent_as_living]."), span_notice("You squashed [parent_as_living]."))
-				Squish(parent_as_living)
-			else
-				parent_as_living.visible_message(span_notice("[parent_as_living] avoids getting crushed."))
-
+		living_entered(crossing_movable, should_squash)
 	else if(isstructure(crossing_movable))
-		if(should_squash)
-			crossing_movable.visible_message(span_notice("[parent_as_living] is crushed under [crossing_movable]."))
-			Squish(parent_as_living)
-		else
-			parent_as_living.visible_message(span_notice("[parent_as_living] avoids getting crushed."))
+		structure_entered(crossing_movable, should_squash)
 
-/datum/component/squashable_carbons/proc/Squish(mob/living/carbon/target)
+/datum/component/squashable_carbons/proc/living_entered(mob/living/crossing_living, should_squash)
+	var/mob/living/parent_as_living = parent
+	// If they're too small, can't squash us.
+	if(crossing_living.mob_size <= MOB_SIZE_SMALL)
+		return
+	// If they're not touching the ground, they're not stepping on us either
+	if(crossing_living.movement_type & MOVETYPES_NOT_TOUCHING_GROUND)
+		return
+
+	// If they're a pacifist, they won't harm us.
+	if(HAS_TRAIT(crossing_living, TRAIT_PACIFISM))
+		crossing_living.visible_message(span_notice("[crossing_living] carefully steps over [parent_as_living]."), span_notice("You carefully step over [parent_as_living] to avoid hurting it."))
+		return
+	// If you're on Combat intent, you will always squash. If you walk, you will avoid squashing.
+	if(crossing_living.move_intent == MOVE_INTENT_WALK && crossing_living.combat_mode == FALSE)
+		crossing_living.visible_message(span_notice("[crossing_living] carefully walks around [parent_as_living]."), span_notice("You carefully walk around [parent_as_living] to avoid hurting it."))
+		return
+	// Tiny flying creatures are only squashed if the squasher is explicitly on combat mode.
+	if(parent_as_living.movement_type & MOVETYPES_NOT_TOUCHING_GROUND && crossing_living.combat_mode == FALSE)
+		return
+
+	if(!should_squash)
+		parent_as_living.visible_message(span_notice("[parent_as_living] avoids getting crushed."))
+		return
+	if(parent_as_living.movement_type & MOVETYPES_NOT_TOUCHING_GROUND)
+		crossing_living.visible_message(span_notice("[crossing_living] slaps [parent_as_living] out of the air!"), span_notice("You slapped [parent_as_living] down."))
+	else
+		crossing_living.visible_message(span_notice("[crossing_living] squashed [parent_as_living]."), span_notice("You squashed [parent_as_living]."))
+	var/damage_modifier = (crossing_living.mob_size >= MOB_SIZE_LARGE) ? 2 : 1 // If something big is stepping on you, it's gonna hurt more.
+	squash_us(parent_as_living, damage_modifier)
+
+/datum/component/squashable_carbons/proc/structure_entered(obj/structure/crossing_structure, should_squash)
+	var/mob/living/parent_as_living = parent
+	// If they're not dense, don't squash us.
+	if(!crossing_structure.density)
+		return
+
+	if(!should_squash)
+		parent_as_living.visible_message(span_notice("[parent_as_living] avoids getting crushed."))
+		return
+	crossing_structure.visible_message(span_notice("[parent_as_living] is crushed under [crossing_structure]."))
+	squash_us(parent_as_living)
+
+/datum/component/squashable_carbons/proc/squash_us(mob/living/carbon/target, damage_modifier = 1)
+	var/squash_damage_final = squash_damage_base * damage_modifier
 
 	if(target.movement_type & MOVETYPES_NOT_TOUCHING_GROUND)
 		//uh oh, we just got smacked out of the air, this is gonna suck
@@ -104,16 +114,16 @@
 
 	if(squash_flags & SQUASHED_SHOULD_BE_GIBBED)
 		target.gib(DROP_ALL_REMAINS)
+		return
+
+	target.apply_damage(squash_damage_final, BRUTE, spread_damage = TRUE)
+	var/obj/item/bodypart/chest/chest_reference = target.get_bodypart(BODY_ZONE_CHEST)
+	if(istype(chest_reference, /obj/item/bodypart/chest/robot))
+		playsound(parent,'sound/effects/wounds/crack2.ogg',90)
+	else if(istype(chest_reference, /obj/item/bodypart/chest/jelly))
+		playsound(parent,'sound/effects/desecration/desecration-01.ogg',90)
 	else
-		target.apply_damage(squash_damage_final, BRUTE, spread_damage = TRUE)
-		squash_damage_final = squash_damage_base //after a squash we reset back to our original value
-		var/obj/item/bodypart/chest/chest_reference = target.get_bodypart(BODY_ZONE_CHEST)
-		if(istype(chest_reference, /obj/item/bodypart/chest/robot))
-			playsound(parent,'sound/effects/wounds/crack2.ogg',90)
-		else if(istype(chest_reference, /obj/item/bodypart/chest/jelly))
-			playsound(parent,'sound/effects/desecration/desecration-01.ogg',90)
-		else
-			playsound(parent,'sound/effects/wounds/crackandbleed.ogg',90)
+		playsound(parent,'sound/effects/wounds/crackandbleed.ogg',90)
 
 /datum/component/squashable_carbons/UnregisterFromParent()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Undersized people would get horrifically squashed just by standing next to the tram, because the underfloor is technically a structure that technically moves past you and technically fits all the requirements for squishing you.
To fix this I decided, well, we really just shouldn't be squashing them for any non-dense structure in the first place.
So this pr makes non-dense structures simply not squash undersized people! This fixes our issue, and also means you can drag open lockers onto undersized people and capture them without instantly crushing them.

As an aside, we mildly refactor our carbon squashing for organization's sake, and forward a damage modifier instead of tracking a `squash_damage_final` var.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It feels kinda awkward when undersized people get squished by things they can otherwise just walk into.

Good when undersized people don't die instantly for even daring to be next to the tram.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Testing Evidence

They're Alive.
<img width="509" height="287" alt="image" src="https://github.com/user-attachments/assets/f6226a88-aca5-4b3f-b67d-92155c9b46e3" />

<!-- Provide proof that the content added, edited, or removed by this pull request is working as intended in-game. Compiling alone doesn't guarantee functionality, so be sure to test thoroughly! -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Undersized people no longer get squashed by structures you can walk into, like opened lockers or tram floors (but not closed lockers).
fix: Standing next to a tram as it passes by as an undersized person no longer squashes you for every single tile straight into hardcrit.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
