### PR TITLE
Adjust partial language formulas for how much our players love to yap incomprehensibly

### DIFF
--- a/code/modules/language/_language.dm
+++ b/code/modules/language/_language.dm
@@ -263,8 +263,8 @@
 		if(translate_prob > 0)
 			// the probability of managing to understand a word is based on how common it is (+10%, -15%)
 			// 1000 words in the list, so words outside the list are just treated as "the 1250th most common word"
-			var/commonness = GLOB.most_common_words[LOWER_TEXT(base_word)] || 1250
-			translate_prob += max((10 * (1 - (min(commonness, 1250) / 500))), 0) // DOPPLER EDIT ADDITION - wrapped in max()
+			var/commonness = GLOB.most_common_words[LOWER_TEXT(base_word)] || 2000 // DOPPLER EDIT CHANGE - More intuitive partial language - original: var/commonness = GLOB.most_common_words[LOWER_TEXT(base_word)] || 1250 
+			translate_prob += (100 * (1 - (min(commonness, 2000) / 2000))) // DOPPLER EDIT CHANGE - More intuitive partial language - original: translate_prob += (10 * (1 - (min(commonness, 1250) / 500)))
 			if(prob(translate_prob))
 				scrambled_words += word
 				translated_index += FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Partial language understanding sets a percentage chance for understanding any given word, which is then weighted up or down based on how common it is in the top 1000 most common. Anything outside of that is weighted as if the 1250th most common word.
Taking into account how people here talk, this means lower percentages are basically unusable, and higher percentages are unintuitively bad.

A previous pr sought to resolve this by capping the formula's minimum translation chance, but it still meant the more common words were often scrambled at lower points.

So in this pr we instead replace the formula entirely, making the chosen percentage the minimum cap and _dramatically_ buffing the chance you understand the top 1000 common words. The latter is supposed to make lower percentages feel like having started flash card studying, by giving you guaranteed translation for the X most common words.
Past 50% you essentially 'know' the top 1000 most common words, and only really roll for uncommon words.

Here's the proposed formula results for a spread of percentages:
### 10% Understanding:
- 100% understood: top 200 most common
- 100-60% understood: 201-1000 most common
- 10% understood: all other
### 25% Understanding:
- 100% understood: top 500 most common
- 100-75% understood: 501-1000 most common
- 25% understood: all other
### 50% Understanding:
- 100% understood: top 1000 most common
- 50% understood: all other
### 75% Understanding:
- 100% understood: top 1000 most common
- 75% understood: all other
### 90% Understanding:
- 100% understood: top 1000 most common
- 90% understood: all other

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

See above.
Allows lower partial understandings to still be vaguely usable, and higher to be more consistent. This is better for how much we yap, and I think feels more intuitive than the current formula still making you roll for common words at higher levels.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Testing Evidence

**Impossible to test fully due to upstream bug.**

<!-- Provide proof that the content added, edited, or removed by this pull request is working as intended in-game. Compiling alone doesn't guarantee functionality, so be sure to test thoroughly! -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Adjusted the partial language formula. The chosen percentage is now the minimum chance you'll understand any given word, while the top 1000 most common words have a dramatically buffed chance. 10% knows the top 200 words guaranteed, 25% the top 500 words, and 50% and above know the full top 1000 most common words.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
