### PR TITLE
Fix sec/captain equipment beacons duplicating whatever options the first beacon used had

### DIFF
--- a/code/_globalvars/~doppler_globalvars/lists/signature_beacon.dm
+++ b/code/_globalvars/~doppler_globalvars/lists/signature_beacon.dm
@@ -1,0 +1,6 @@
+/// Cache of equipment options for signature equipment beacons, generated as needed.
+/// Associative list of the base /datum/signature_equipment type, to a list of all its equipment options.
+GLOBAL_LIST_EMPTY(signature_equipment_options_cache)
+/// Cache of radial menu options for signature equipment beacons, generated as needed.
+/// Associative list of the base /datum/signature_equipment type, to a list of all its radial menu options.
+GLOBAL_LIST_EMPTY(signature_equipment_radials_cache)

--- a/modular_doppler/modular_items/code/signature_beacon.dm
+++ b/modular_doppler/modular_items/code/signature_beacon.dm
@@ -16,8 +16,9 @@
 	. = ..()
 	attempt_selection(user)
 
-/obj/item/signature_beacon/proc/generate_equipment_options()
-	var/static/list/equipment_option_list
+/obj/item/signature_beacon/proc/get_equipment_options()
+	PRIVATE_PROC(TRUE)
+	var/list/equipment_option_list = GLOB.signature_equipment_options_cache[selection_base_type]
 	if(equipment_option_list)
 		return equipment_option_list
 
@@ -25,14 +26,17 @@
 	for(var/datum/signature_equipment/signature_equipment as anything in subtypesof(selection_base_type))
 		equipment_option_list[signature_equipment::name] = signature_equipment
 	sort_list(equipment_option_list)
+
+	GLOB.signature_equipment_options_cache[selection_base_type] = equipment_option_list
 	return equipment_option_list
 
-/obj/item/signature_beacon/proc/generate_radial_options()
-	var/static/list/radial_option_list
+/obj/item/signature_beacon/proc/get_radial_options()
+	PRIVATE_PROC(TRUE)
+	var/list/radial_option_list = GLOB.signature_equipment_radials_cache[selection_base_type]
 	if(radial_option_list)
 		return radial_option_list
 
-	var/list/equipment_option_list = generate_equipment_options()
+	var/list/equipment_option_list = get_equipment_options()
 	radial_option_list = list()
 	for(var/equipment_option as anything in equipment_option_list)
 		var/datum/signature_equipment/signature_equipment = equipment_option_list[equipment_option]
@@ -49,6 +53,7 @@
 		radial_option_list[equipment_option] = radial_option
 	sort_list(radial_option_list)
 
+	GLOB.signature_equipment_radials_cache[selection_base_type] = radial_option_list
 	return radial_option_list
 
 /obj/item/signature_beacon/proc/check_option_menu(mob/user)
@@ -65,7 +70,7 @@
 		playsound(src, 'sound/machines/buzz/buzz-sigh.ogg', 40, TRUE)
 		return
 
-	var/list/radial_option_list = generate_radial_options()
+	var/list/radial_option_list = get_radial_options()
 	var/chosen_option = show_radial_menu(
 		user,
 		src,
@@ -77,7 +82,7 @@
 
 	if(isnull(chosen_option))
 		return
-	var/list/equipment_option_list = generate_equipment_options()
+	var/list/equipment_option_list = get_equipment_options()
 	var/datum/signature_equipment/chosen_signature_type = equipment_option_list[chosen_option]
 	if(isnull(chosen_signature_type))
 		return

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -656,6 +656,7 @@
 #include "code\_globalvars\~doppler_globalvars\religion.dm"
 #include "code\_globalvars\~doppler_globalvars\text.dm"
 #include "code\_globalvars\~doppler_globalvars\lists\quirks.dm"
+#include "code\_globalvars\~doppler_globalvars\lists\signature_beacon.dm"
 #include "code\_js\byjax.dm"
 #include "code\_js\menus.dm"
 #include "code\_onclick\adjacent.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

So when first implementing this I made these use static lists to cache their options, so as to avoid needing to call `subtypesof(...)` and generate a pile of radial options every time the menu is opened!
Minor miscalculation! Forgot static, in fact, does not care about subtypes.

We instead cache this as part of a global list, associative by the base type we base our selections on.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

less jank :+1:

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Testing Evidence

<img width="211" height="184" alt="image" src="https://github.com/user-attachments/assets/2df18d3b-2e08-4792-b970-51e0ca99d5b5" />
<img width="214" height="198" alt="image" src="https://github.com/user-attachments/assets/68096316-2617-4b42-8ac0-21803367cf22" />
<img width="142" height="169" alt="image" src="https://github.com/user-attachments/assets/ceeecac4-91c6-4c06-955c-67d4d687eae3" />



<!-- Provide proof that the content added, edited, or removed by this pull request is working as intended in-game. Compiling alone doesn't guarantee functionality, so be sure to test thoroughly! -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Security and captain loadout beacons are consistent again, rather than giving each other's options.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
