### PR TITLE
Disables Async Blinking + Adds Unblinking Quirk

### DIFF
--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -35,6 +35,7 @@ GLOBAL_LIST_INIT_TYPED(quirk_blacklist, /list/datum/quirk, list(
 	list(/datum/quirk/undersized, /datum/quirk/oversized),
 	list(/datum/quirk/genemodded, /datum/quirk/oversized),
 	list(/datum/quirk/visitor, /datum/quirk/item_quirk/underworld_connections),
+	list(/datum/quirk/unblinking, /datum/quirk/item_quirk/fluoride_stare),
 	// DOPPLER EDIT ADDITION END
 ))
 

--- a/code/modules/surgery/organs/internal/eyes/_eyes.dm
+++ b/code/modules/surgery/organs/internal/eyes/_eyes.dm
@@ -518,7 +518,7 @@
 		addtimer(CALLBACK(src, PROC_REF(animate_eyelids), owner), blink_delay + duration)
 
 /obj/item/organ/eyes/proc/animate_eyelids(mob/living/carbon/human/parent)
-	var/sync_blinking = synchronized_blinking && (parent.get_organ_loss(ORGAN_SLOT_BRAIN) < BRAIN_DAMAGE_ASYNC_BLINKING)
+	var/sync_blinking = TRUE // synchronized_blinking && (parent.get_organ_loss(ORGAN_SLOT_BRAIN) < BRAIN_DAMAGE_ASYNC_BLINKING) //doppler edit - disables async blinking
 	// Randomize order for unsynched animations
 	if (sync_blinking || prob(50))
 		var/list/anim_times = animate_eyelid(eyelid_left, parent, sync_blinking)
@@ -1139,7 +1139,7 @@
 	name = "reptile eyes"
 	desc = "A pair of reptile eyes with thin vertical slits for pupils."
 	icon_state = "lizard_eyes"
-	synchronized_blinking = FALSE
+	// synchronized_blinking = FALSE // doppler edit - disables async blinking
 	pupils_name = "slit pupils"
 	penlight_message = "have vertically slit pupils and tinted whites"
 

--- a/modular_doppler/modular_quirks/unblinking/unblinking.dm
+++ b/modular_doppler/modular_quirks/unblinking/unblinking.dm
@@ -1,0 +1,32 @@
+/datum/quirk/unblinking
+	name = "Unblinking"
+	desc = "For whatever reason, you do not need to blink to keep your eyes (or equivalent visual apparatus) functional."
+	icon = FA_ICON_FACE_FLUSHED
+	value = 0
+	gain_text = span_danger("You no longer feel the need to blink.")
+	lose_text = span_notice("You feel the need to blink again.")
+	medical_record_text = "Patient is incapable of blinking."
+	mob_trait = TRAIT_NO_EYELIDS //Also prevents eye shutting in knockout state and death.
+
+/datum/quirk/unblinking/add(client/client_source)
+	. = ..()
+	var/obj/item/organ/eyes/eyes = quirk_holder.get_organ_slot(ORGAN_SLOT_EYES)
+	if(!eyes)
+		return
+
+	eyes.blink_animation = FALSE
+
+	// interrupt the animations
+	if(eyes.eyelid_left)
+		animate(eyes.eyelid_left, alpha = 0, time = 0)
+	if(eyes.eyelid_right)
+		animate(eyes.eyelid_right, alpha = 0, time = 0)
+
+/datum/quirk/unblinking/remove()
+	. = ..()
+	var/obj/item/organ/eyes/eyes = quirk_holder.get_organ_slot(ORGAN_SLOT_EYES)
+	if(!eyes)
+		return
+
+	eyes.blink_animation = TRUE
+	quirk_holder.update_body()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7451,6 +7451,7 @@
 #include "modular_doppler\modular_quirks\system_shock\system_shock.dm"
 #include "modular_doppler\modular_quirks\tranquility\code\tranquility.dm"
 #include "modular_doppler\modular_quirks\traumatized\traumatized.dm"
+#include "modular_doppler\modular_quirks\unblinking\unblinking.dm"
 #include "modular_doppler\modular_quirks\undersized\gun.dm"
 #include "modular_doppler\modular_quirks\undersized\held_undersized_examine.dm"
 #include "modular_doppler\modular_quirks\undersized\held_undersized_id.dm"


### PR DESCRIPTION
## About The Pull Request

Turns off async blinking. Lizards are no longer given a rather bigoted stereotype by TG coders..
Also adds the unblinking quirk from bubberstation
[#bubberstation/3735](https://github.com/Bubberstation/Bubberstation/pull/3735)

## Why It's Good For The Game

Async blinking is annoying, kind of weird, and broken. (does weird shit with eyes, sometimes making one close??)
Unblinking quirk for those who dislike blinking and want it turned off altogether.

## Testing Evidence

it works i tested at 3 am

## Changelog

:cl:
qol: turns off async blinking
add: bubberstation unblinking quirk
/:cl: