### PR TITLE
Small fixes to both salvage shuttles

### DIFF
--- a/_maps/shuttles/~doppler_shuttles/personal_pod_salvage_endurance.dmm
+++ b/_maps/shuttles/~doppler_shuttles/personal_pod_salvage_endurance.dmm
@@ -155,8 +155,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/docking_port/mobile/personally_bought{
-	},
+/obj/docking_port/mobile/personally_bought,
 /turf/open/floor/iron/dark/smooth_large,
 /area/shuttle/personally_bought/endurance_salvage)
 "H" = (

--- a/_maps/shuttles/~doppler_shuttles/personal_pod_salvage_small.dmm
+++ b/_maps/shuttles/~doppler_shuttles/personal_pod_salvage_small.dmm
@@ -93,8 +93,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/docking_port/mobile/personally_bought{
-	},
+/obj/docking_port/mobile/personally_bought,
 /turf/open/floor/iron/dark/smooth_large,
 /area/shuttle/personally_bought/cramped_salvage)
 "C" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. Adds the window shutter button to the Endurance Shuttle
2. Makes sure both Endurance and Salvage Small are flying the correct direction (before hand, they would fly sideways, drifting style)
3. Replaces one of the two navigation terminals on the Endurance shuttle with the transport terminal so the vessel is functional

## Why It's Good For The Game

1. allows for privacy, defence against asteroids and lets it follow the standard of all other personal shuttles.
2. bug that affects both immersion and the expected way shuttles function
3. Allows the vessel to be moved and function at all. 

## Testing Evidence

Endurance:
[endurance.webm](https://github.com/user-attachments/assets/b2179408-9b27-42a5-8386-6294d87dc2b2)

Salvage Small:
[salvage_small.webm](https://github.com/user-attachments/assets/283cb78c-f6ba-49f9-94c5-6ba097117485)


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Privacy button to the Endurance Shuttle
fix: Flight direction of the Endurance and Salvage Small Shuttle
fix: Endurance Shuttle has the terminal needed for flight
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
