### PR TITLE
Disables Cursed Hotspring Ruin

### DIFF
--- a/code/datums/ruins/icemoon.dm
+++ b/code/datums/ruins/icemoon.dm
@@ -209,7 +209,7 @@
 	description = "Rumors have developed over the many years of Freyja plasma mining. These rumors suggest that the ghosts of dead mistreated excavation staff have returned to \
 	exact revenge on their (now former) employers. Coorperate reminds all staff that rumors are just that: Old Housewife tales meant to scare misbehaving kids to bed."
 	suffix = "icemoon_underground_abandoned_plasma_facility.dmm"
-/* DOPPLER EDIT DISABLES CURSED SPRING
+/* DOPPLER EDIT
 /datum/map_template/ruin/icemoon/underground/hotsprings
 	name = "Ice-Ruin Hot Springs"
 	id = "hotsprings"


### PR DESCRIPTION
## About The Pull Request

Disables the cursed hotspring ruin.

## Why It's Good For The Game

The cursed hotspring is an instant get-fucked event. if you accidentally step into it for more than just one tile, there is the high chance that your character is either:
turned into a random animal type
turned into a random species
and then warps to a random safe tile on station

this is not a good feature and tends to ruin the rounds of players who encounter it (if admin intervention is not given)

:cl:
qol: disables cursed hotspring ruin
/:cl:

