### PR TITLE
The Cantina 2: Feat. Botany

### DIFF
--- a/_maps/doppler/cantina/badguyzone.dmm
+++ b/_maps/doppler/cantina/badguyzone.dmm
@@ -1039,10 +1039,10 @@
 /area/ruin/space/has_grav/powered)
 "tt" = (
 /obj/structure/shelf,
-/obj/item/storage/medkit{
+/obj/item/storage/medkit/regular{
 	pixel_y = -4
 	},
-/obj/item/storage/medkit{
+/obj/item/storage/medkit/regular{
 	pixel_y = 2;
 	pixel_x = 1
 	},


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR adds botany, ration printers, a surgical area, medical equipment + assorted augments, and a single MODsuit/cyborg recharger to the cantina.

## Why It's Good For The Game

More stuff to do for the Bartender, more potential interactions, less lacking when it comes to healing and medical attention and keeps the focus on more than just combative stuff. Botany and the ration printers were a request for bartenders to have more to actively partake in and prepare, and the charger helps people with fused MODsuits or borgs stay there to roleplay.

## Testing Evidence

<img width="1558" height="1492" alt="image" src="https://github.com/user-attachments/assets/280799ae-ce10-47c9-8146-e7e2e3980333" />


<img width="992" height="992" alt="image" src="https://github.com/user-attachments/assets/b33631e7-e473-49fe-85e9-3a07632df312" />

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: medical zone, botany, ration printers, and recharger all added to the cantina
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
