### PR TITLE
The Mad Dog's Balancejak

### DIFF
--- a/modular_doppler/martial_arts/mad_dog.dm
+++ b/modular_doppler/martial_arts/mad_dog.dm
@@ -281,5 +281,5 @@
 	to_chat(usr, "<b><i>Furthermore, you will only fall when entering hardcrit, will occasionally heal when extremely close to death, and can absorb stuns up to a limit, after which you must wait 20 seconds before absorbing more.</i></b>")
 
 #undef KICK_COMBO
-#undef FLYING_KICK_COMBO
+#undef BRACED_THROW_COMBO
 #undef CONSECUTIVE_COMBO


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR does a fair bit, including:
- Ripping out or tweaking basically every example of paralysis or stun in the martial art
- Removing some CQC staples like instant aggro-grab or instant neck snaps (the neck snap now has a lengthy do_after)
- Removing the on-examine message; stun absorption is instead shown by a trailing effect behind a player when their CI & combat mode are on
- Making certain instances of stuns by proxy impossible (harm + harm combo throw is gentle and cannot stun a target)
- Making the block no longer stun a target that hits you; instead you simply have a passive 20% melee block chance, upped to 60% with throwmode on and 100% while holding down spacebar (which prevents you from doing any other action with your hands, like attacking)
- Adding a grab state modifier (such that all grabs have the resistance difficulty of a grab one level higher; passive grabs must be resisted out of like an aggressive grab, and so on) and a grab damage modifier (5 extra stamina damage on resist fail) to better emphasize grappling struggles versus instant grab-slams

## Why It's Good For The Game

Stun combat is generally okay (we have security, after all) but spammable loop stuns blow ass, as do quick 5-second instakills that come from grabbing someone thrice and then neck snapping them.

I didn't like how Mad Dog was under stealthy weapons but gave you a bold loud examine text when you had stun resistance up, so changing it to be a visual effect only active when you're in combat seems far more intuitive.

## Testing Evidence

<img width="1125" height="991" alt="image" src="https://github.com/user-attachments/assets/042634c3-8ef1-4c0d-95ea-44abc752493d" />

https://github.com/user-attachments/assets/e94d13bd-d1df-4eac-9b1d-8eb9388788c2

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: The Mag Dog's Style has had effectively all loopable stun opportunities taken out in lieu of more grappling-centered buffs to grabbing and blocking
add: Mad Dog has le cool movement trail effect when you're in combat and your stun resistance is active
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
