### PR TITLE
Fixes the duplicate fedora issue.

### DIFF
--- a/modular_doppler/modular_vending/code/tg_vendors/clothesmate.dm
+++ b/modular_doppler/modular_vending/code/tg_vendors/clothesmate.dm
@@ -7,9 +7,6 @@
 			"name" = "Head",
 			"icon" = "hat-cowboy",
 			"products" = list(
-				/obj/item/clothing/head/fedora= 5,
-				/obj/item/clothing/head/fedora/beige = 5,
-				/obj/item/clothing/head/fedora/white = 5,
 				/obj/item/clothing/head/standalone_hood = 5,
 				/obj/item/clothing/head/bow = 5,
 				/obj/item/clothing/head/bow/small = 5,


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/DopplerShift13/DopplerShift/issues/811

Yeah so duplicates in product categories makes everything go haywire. I did think about adding a check but the double for loops required is too much performance overhead in my opinion for something that's fixable by just not doing it.

## Why It's Good For The Game

You can buy fedoras instead of them trying to take over the menu.

## Testing Evidence

<img width="431" height="635" alt="image" src="https://github.com/user-attachments/assets/336093ee-6891-4a8a-b041-f45082287d3a" />

## Changelog

:cl:
fix: Fedoras no longer appear in clothesmate categories they're not meant to. And are also now actually buyable.
/:cl: