### PR TITLE
Returns a PACMAN to the Iceland mining base. - Fixes centcom ferry docking and incorrectly placed mapping objects on Pubby

### DIFF
--- a/_maps/map_files/Mining/Iceland.dmm
+++ b/_maps/map_files/Mining/Iceland.dmm
@@ -2045,7 +2045,7 @@
 /area/mine/laborcamp/production)
 "ni" = (
 /obj/structure/rack,
-/obj/item/stack/sheet/mineral/plasma/five,
+/obj/item/stack/sheet/mineral/uranium/fifty,
 /turf/open/floor/plating,
 /area/mine/maintenance/service)
 "nk" = (
@@ -2731,7 +2731,8 @@
 /area/mine/lounge)
 "rZ" = (
 /obj/structure/cable,
-/obj/item/flatpacked_machine/fuel_generator,
+/obj/machinery/power/port_gen/pacman/super,
+/obj/item/wrench,
 /turf/open/floor/plating,
 /area/mine/maintenance/service)
 "se" = (

--- a/_maps/map_files/Pubbystation/pubbystation.dmm
+++ b/_maps/map_files/Pubbystation/pubbystation.dmm
@@ -4099,9 +4099,6 @@
 "arH" = (
 /obj/machinery/modular_computer/preset/command,
 /obj/effect/turf_decal/tile/dark_green/full,
-/obj/item/wallframe/telescreen/entertainment{
-	pixel_x = -32
-	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/command/bridge)
 "arI" = (
@@ -10952,9 +10949,6 @@
 /area/station/service/theater)
 "aVm" = (
 /obj/machinery/vending/autodrobe,
-/obj/item/wallframe/telescreen/entertainment{
-	pixel_y = 32
-	},
 /turf/open/floor/wood/tile,
 /area/station/service/theater)
 "aVn" = (
@@ -14054,9 +14048,6 @@
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 8
 	},
-/obj/item/wallframe/telescreen/entertainment{
-	pixel_x = -32
-	},
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
 "bic" = (
@@ -14668,9 +14659,6 @@
 "blD" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
-	},
-/obj/item/wallframe/telescreen/entertainment{
-	pixel_x = 32
 	},
 /turf/open/floor/wood/large,
 /area/station/hallway/primary/aft)
@@ -17525,9 +17513,6 @@
 /obj/machinery/light/directional/south,
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood,
-/obj/item/wallframe/telescreen/entertainment{
-	pixel_y = -32
-	},
 /turf/open/floor/wood,
 /area/station/science/lab)
 "byW" = (
@@ -18590,9 +18575,6 @@
 /obj/structure/table,
 /obj/item/folder,
 /obj/machinery/light/directional/east,
-/obj/item/wallframe/telescreen/entertainment{
-	pixel_x = 32
-	},
 /turf/open/floor/iron/white,
 /area/station/hallway/primary/aft)
 "bDL" = (
@@ -19564,9 +19546,6 @@
 /area/station/hallway/primary/aft)
 "bJE" = (
 /obj/structure/railing/corner,
-/obj/item/wallframe/telescreen/entertainment{
-	pixel_y = -32
-	},
 /obj/effect/turf_decal/tile/electric_yellow{
 	dir = 8
 	},
@@ -29237,6 +29216,7 @@
 	pixel_x = 8;
 	pixel_y = 5
 	},
+/obj/item/folder/yellow,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "dWk" = (
@@ -30126,16 +30106,9 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "eIg" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
-	},
-/obj/item/wallframe/telescreen/entertainment{
-	pixel_x = -32
-	},
-/turf/open/floor/iron/white/side{
-	dir = 8
-	},
-/area/station/engineering/atmos/hfr_room)
+/obj/machinery/computer/security/telescreen/entertainment,
+/turf/closed/wall/r_wall,
+/area/station/command/bridge)
 "eIL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
@@ -31896,7 +31869,8 @@
 /obj/structure/cable,
 /obj/machinery/door/window/brigdoor{
 	name = "Communications Access";
-	red_alert_access = 1
+	red_alert_access = 1;
+	req_access = list("command")
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/command/bridge)
@@ -38373,6 +38347,27 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/tcommsat/computer)
+"llW" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 6
+	},
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = -4;
+	pixel_y = 1
+	},
+/obj/effect/spawner/random/bureaucracy/pen,
+/obj/item/stamp/denied{
+	pixel_x = 10;
+	pixel_y = -2
+	},
+/obj/item/stamp/granted{
+	pixel_y = 13;
+	pixel_x = 10
+	},
+/obj/item/folder/yellow,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "lmI" = (
 /obj/machinery/computer/security/telescreen/entertainment,
 /turf/closed/wall/r_wall,
@@ -40743,6 +40738,17 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
+"ngk" = (
+/obj/docking_port/stationary{
+	dir = 2;
+	dwidth = 2;
+	height = 13;
+	name = "port bay 2";
+	shuttle_id = "ferry_home";
+	width = 5
+	},
+/turf/open/space/basic,
+/area/space)
 "ngp" = (
 /obj/item/chair/stool,
 /turf/open/floor/carpet,
@@ -45497,6 +45503,10 @@
 /obj/structure/window/reinforced/plasma/fulltile,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
+"qFD" = (
+/obj/machinery/computer/security/telescreen/entertainment,
+/turf/closed/wall/r_wall,
+/area/station/security/lockers)
 "qFJ" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1;
@@ -46124,9 +46134,6 @@
 "rgs" = (
 /obj/structure/table,
 /obj/item/instrument/eguitar,
-/obj/item/wallframe/telescreen/entertainment{
-	pixel_y = 32
-	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
 "rgF" = (
@@ -50427,6 +50434,7 @@
 "ueu" = (
 /obj/structure/table,
 /obj/item/stack/sheet/cardboard,
+/obj/item/folder/yellow,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "ueJ" = (
@@ -52222,7 +52230,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/electric_yellow/line,
-/obj/machinery/wall_healer/directional/west,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/engineering/atmos)
 "vtT" = (
@@ -70618,7 +70625,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+ngk
 bGF
 bHJ
 pbm
@@ -82612,7 +82619,7 @@ aaa
 aaa
 fon
 aht
-dAa
+qFD
 air
 anf
 tCJ
@@ -85457,7 +85464,7 @@ bje
 apo
 aht
 arA
-arA
+eIg
 arA
 atQ
 ooa
@@ -94796,7 +94803,7 @@ pfp
 ksg
 bZh
 rAm
-eIg
+rAm
 odp
 jWA
 bOZ
@@ -99366,7 +99373,7 @@ rUE
 myc
 ltf
 rAP
-nNk
+llW
 eJf
 aTy
 aaa
@@ -100408,7 +100415,7 @@ jHZ
 iSi
 iSi
 iSi
-iSi
+dIU
 iSi
 iSi
 iSi


### PR DESCRIPTION
Returns a functional generator to the iceland mining base power room. 
Removes in-hand versions of entertainment telescreens.
Removes floating medstation in atmospherics.
Fixes windoor to bridge comms console not requiring command access. 
Adds a proper cent com ferry port dock mapping object

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Returns a functional generator to the iceland mining base power room. 
Removes in-hand versions of entertainment telescreens.
Removes floating medstation in atmospherics.
Fixes windoor to bridge comms console not requiring command access. 
Adds a proper cent com ferry port dock mapping object
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Various small fixes that have been on my radar for a while concerning Pubby and Iceland that I've found time/motivation to get around to fixing.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Testing Evidence

<!-- Provide proof that the content added, edited, or removed by this pull request is working as intended in-game. Compiling alone doesn't guarantee functionality, so be sure to test thoroughly! -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
Adds: superpacman generator using uranium to Iceland.
Removes: wrong typepath entertainment telescreens from Pubby
Removes: 1 incorrectly places medstation in Atmospherics
Edits: The secure windoor to bridge comms console has Command access now.
Adds: Correct mapping object for the centcom ferry.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
