### PR TITLE
Pubby Ordnance Polish - Replaces research telescreen with bombsite telescreen, links air alarms to chamber sensors

### DIFF
--- a/_maps/map_files/Pubbystation/pubbystation.dmm
+++ b/_maps/map_files/Pubbystation/pubbystation.dmm
@@ -28683,7 +28683,9 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
 "dxo" = (
-/obj/machinery/igniter/incinerator_ordmix,
+/obj/machinery/igniter/incinerator_ordmix{
+	use_power = 0
+	},
 /turf/open/floor/engine/vacuum,
 /area/station/science/ordnance/burnchamber)
 "dxF" = (
@@ -33042,7 +33044,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/computer/security/telescreen/research/directional/south,
+/obj/machinery/computer/security/telescreen/ordnance/directional/south,
 /obj/effect/turf_decal/siding/dark_blue{
 	dir = 4
 	},
@@ -36690,9 +36692,7 @@
 /turf/open/floor/iron/white/smooth_edge,
 /area/station/science/lab)
 "jWr" = (
-/obj/machinery/atmospherics/components/tank/oxygen{
-	dir = 4
-	},
+/obj/machinery/atmospherics/components/tank/oxygen,
 /obj/structure/sign/poster/official/plasma_effects/directional/east,
 /turf/open/floor/iron/dark/small,
 /area/station/science/ordnance)
@@ -37180,8 +37180,12 @@
 	pixel_y = -36
 	},
 /obj/effect/mapping_helpers/airalarm/mixingchamber_access,
+/obj/effect/mapping_helpers/airalarm/link{
+	chamber_id = "ordnanceburn"
+	},
+/obj/effect/mapping_helpers/airalarm/tlv_no_checks,
 /turf/open/floor/iron/white,
-/area/station/science/ordnance/burnchamber)
+/area/station/science/ordnance)
 "kqc" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/camera/directional/west{
@@ -42081,8 +42085,12 @@
 	},
 /obj/machinery/airalarm/directional/west,
 /obj/effect/mapping_helpers/airalarm/mixingchamber_access,
+/obj/effect/mapping_helpers/airalarm/link{
+	chamber_id = "ordnancefreezer"
+	},
+/obj/effect/mapping_helpers/airalarm/tlv_no_checks,
 /turf/open/floor/engine,
-/area/station/science/ordnance/freezerchamber)
+/area/station/science/ordnance)
 "okX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -43653,6 +43661,10 @@
 	},
 /turf/open/floor/iron/white/smooth_edge,
 /area/station/science/xenobiology)
+"pnj" = (
+/obj/machinery/atmospherics/components/tank/oxygen,
+/turf/open/floor/iron/dark/small,
+/area/station/science/ordnance)
 "pnn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -98626,7 +98638,7 @@ oaI
 efu
 bzh
 bHy
-dfU
+pnj
 dfU
 vDo
 psV
@@ -98883,8 +98895,8 @@ oaI
 bxK
 bzi
 bHy
-dfU
-dfU
+pnj
+pnj
 tOY
 khM
 eZE
@@ -99141,7 +99153,7 @@ pJT
 bxL
 bHy
 jWr
-dfU
+pnj
 bEd
 kmn
 bGv


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
As tin - The bomb site telescreen was the incorrect one, giving access to every camera in science instead of just the two bombsite ones.

Also, despite having mapped in floor air sensors into the burn and freezer chamber, the air alarms for both were not linked to them. This fixes that.

Additionally adds the 'no checks' mapping object so the newly linked air sensors won't yell on the Canary app about the freezer and burn chambers having extreme temperatures.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Damn maybe those air alarms should work the same way they do on all the other TG maps. The telescreen for viewing the bombsite should also make that easy, instead of giving you a list of irrelevant cameras.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Testing Evidence

<!-- Provide proof that the content added, edited, or removed by this pull request is working as intended in-game. Compiling alone doesn't guarantee functionality, so be sure to test thoroughly! -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: The Air Alarms in Pubby ordnance should be much easier to use, and provide useful information on the contents of their respective chambers.
map: Non-structural edits to Ordnance, Replaced the general research department telescreen in ordnance with a specific bombsite telescreen.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
