### PR TITLE
lets the construction autofab asexually reproduce

### DIFF
--- a/modular_doppler/colony_fabricator/code/colony_fabricator/designs/unique.dm
+++ b/modular_doppler/colony_fabricator/code/colony_fabricator/designs/unique.dm
@@ -9,6 +9,7 @@
 	show_on_wiki = FALSE
 	starting_node = TRUE
 	design_ids = list(
+		"colony_autofab",
 		"colony_water_synth",
 		"colony_hydro_synth",
 		"gps_transmitter",
@@ -40,6 +41,16 @@
 		"colony_wirecutters",
 		"colony_wrench",
 		"colony_biogenerator",
+	)
+
+/datum/design/board/construction_autofab
+	name = "Construction Autofab Board"
+	desc = /obj/machinery/rnd/production/colony_lathe::desc
+	id = "colony_autofab"
+	build_path = /obj/item/circuitboard/machine/colony_lathe
+	build_type = COLONY_FABRICATOR
+	category = list(
+		RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_ENGINEERING
 	)
 
 /datum/design/board/organic_synthesizer


### PR DESCRIPTION
## About The Pull Request

Lets the construction autofab make its own machine boards

## Why It's Good For The Game

I never included a way to make more of them, which I feel should be a capability, as the previous iteration had the power to.

## Changelog

:cl:
add: construction autofabs are now capable of asexual reproduction
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
