### PR TITLE
Demobilizes wartime production of exosuits

### DIFF
--- a/modular_doppler/research/techweb/roundstart_techweb_nodes.dm
+++ b/modular_doppler/research/techweb/roundstart_techweb_nodes.dm
@@ -114,9 +114,6 @@
 /datum/techweb_node/mech_mining
 	starting_node = TRUE
 
-/datum/techweb_node/mech_heavy_arms
-	starting_node = TRUE
-
 /datum/techweb_node/chem_synthesis
 	starting_node = TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Yes, we "have the technology" and factually know how to develop cool exosuits. You can still unlock the ability to print these cool exosuits in-round through the relevant experiments. However, their immediate availability is now gone.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Exosuits are really cool and I love them. But they're a bit over-exposed in our play-space with how quickly a player can go from "I want to build this" to "There is now a Durand chasing the antagonist". Removing the ability to make them entirely would suck, so this relatively small move is aimed at tweaking their prevalence. Determined players can still do the relevant experiments and queue the relevant nodes to unlock the ability to print them.

Notably, the Clarke Mining Exosuit and the Odysseus Medical Exosuit are still unlocked and printable round-start.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Testing Evidence

<!-- Provide proof that the content added, edited, or removed by this pull request is working as intended in-game. Compiling alone doesn't guarantee functionality, so be sure to test thoroughly! -->

## Changelog
Removes the following nodes from the round-start availability.
/datum/techweb_node/mech_combat
/datum/techweb_node/mech_light
/datum/techweb_node/mech_heavy
/datum/techweb_node/mech_infiltrator 
/datum/techweb_node/mech_energy_guns
/datum/techweb_node/mech_firearms 
/datum/techweb_node/mech_heavy_arms
/datum/techweb_node/mech_equip_bluespace
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Removed roundstart ability to print combat exosuit parts
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
