### PR TITLE
Fixes the tajaran and tiziran sword in the loadout sharing the same typepath.

### DIFF
--- a/modular_doppler/loadout_categories/categories/belts.dm
+++ b/modular_doppler/loadout_categories/categories/belts.dm
@@ -129,7 +129,7 @@
 	name = "Tizirian Chopping Sword Sheath"
 	item_path = /obj/item/storage/belt/lizard_sabre
 
-/datum/loadout_item/belts/sheath/lizard_sword
+/datum/loadout_item/belts/sheath/tajaran_sword
 	name = "Tajaran Duelist's Blade Sheath"
 	item_path = /obj/item/storage/belt/tajaran_sheath
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

tin

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

's broken right now

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Testing Evidence

<img width="378" height="152" alt="image" src="https://github.com/user-attachments/assets/3a63c568-b88b-4851-8b36-942016456120" />

<!-- Provide proof that the content added, edited, or removed by this pull request is working as intended in-game. Compiling alone doesn't guarantee functionality, so be sure to test thoroughly! -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Tajaran sword no longer breaks the tiziran sword appearing in the loadout.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
