### PR TITLE
fixes ghost spawns not receiving language prefs

### DIFF
--- a/modular_doppler/languages/code/language menu/language_holder.dm
+++ b/modular_doppler/languages/code/language menu/language_holder.dm
@@ -25,7 +25,7 @@ GLOBAL_DATUM_INIT(language_holder_adjustor, /datum/language_holder_adjustor, new
 
 /datum/language_holder_adjustor/Destroy()
 	..()
-	UnregisterSignal(SSdcs, COMSIG_GLOB_CREWMEMBER_JOINED)
+	UnregisterSignal(SSdcs, COMSIG_GLOB_CREWMEMBER_JOINED, COMSIG_GLOB_MOB_LOGGED_IN)
 
 /datum/language_holder/proc/adjust_languages_to_prefs(datum/preferences/preferences)
 	// no prefs? then don't remove any languages


### PR DESCRIPTION
## About The Pull Request

tin, cantags and other spawners menu roles will now receive their language prefs. in fact, anything that uses `COMSIG_GLOB_MOB_LOGGED_IN` will do so.

this closes https://github.com/DopplerShift13/DopplerShift/issues/801

## Why It's Good For The Game

bugfix

## Testing Evidence

<img width="711" height="190" alt="image" src="https://github.com/user-attachments/assets/f7a59509-c727-4669-a52b-e2a5858a8166" />

## Changelog

:cl:
fix: ghost spawner roles will now receive their language prefs
/:cl: