### PR TITLE
allows the escabajaronomicon shield to fit on security armor and suit slots using the security strap

### DIFF
--- a/code/datums/storage/subtypes/belts.dm
+++ b/code/datums/storage/subtypes/belts.dm
@@ -107,8 +107,8 @@
 		/obj/item/reagent_containers/spray/pepper,
 		/obj/item/restraints/handcuffs,
 		/obj/item/restraints/legcuffs/bola,
-		/obj/item/melee/sec_jitte,//DOPPLER EDIT ADDITION
-		/obj/item/shield/escarabajo,//DOPPLER EDIT ADDITION
+		/obj/item/melee/sec_jitte, //DOPPLER EDIT ADDITION
+		/obj/item/shield/escarabajo, //DOPPLER EDIT ADDITION
 	))
 
 ///Webbing security belt

--- a/code/datums/storage/subtypes/belts.dm
+++ b/code/datums/storage/subtypes/belts.dm
@@ -108,6 +108,7 @@
 		/obj/item/restraints/handcuffs,
 		/obj/item/restraints/legcuffs/bola,
 		/obj/item/melee/sec_jitte,//DOPPLER EDIT ADDITION
+		/obj/item/shield/escarabajo,//DOPPLER EDIT ADDITION
 	))
 
 ///Webbing security belt

--- a/modular_doppler/job_straps/code/straps.dm
+++ b/modular_doppler/job_straps/code/straps.dm
@@ -232,4 +232,5 @@
 		/obj/item/gun/ballistic/shotgun/automatic/combat/compact,
 		/obj/item/pen/red/security,
 		/obj/item/storage/belt/secsword,
+		/obj/item/shield/escarabajo,
 	)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

does what it says on the tin, oversight from development

## Why It's Good For The Game

<img width="768" height="557" alt="image" src="https://github.com/user-attachments/assets/6c1d2771-a506-4583-96ef-660780bec7b3" />

unintended behavior/bugfix - escabajaro shield is already intended to do this 
<img width="1171" height="333" alt="image" src="https://github.com/user-attachments/assets/29f78304-93ed-49bc-ac5d-d123453dd1cc" />


## Testing Evidence

works on my machine / compiles

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: the escarabajo shield appropriately fits on suit slots
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
