### PR TITLE
[NONMODULAR] Makes Tourette’s Perhaps A Little Less Offensive

### DIFF
--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -217,10 +217,10 @@
 /datum/mutation/tourettes/on_life(seconds_per_tick, times_fired)
 	if(SPT_PROB(5 * GET_MUTATION_SYNCHRONIZER(src), seconds_per_tick) && owner.stat == CONSCIOUS && !owner.IsStun())
 		switch(rand(1, 3))
-			if(1 to 2) //DOPPLER EDIT: 1 > 1 to 2
-				owner.emote("twitch")
-			if(3) //DOPPLER EDIT: 2 to 3 > 3
-				owner.say("[prob(50) ? "#" : ""][pick("SHIT", "PISS", "FUCK", "CUNT", "COCKSUCKER", "MOTHERFUCKER", "TITS")]", forced=name) //DOPPLER EDIT: ; > #
+			if(1 to 2) //DOPPLER EDIT - ORIGINAL: if(1)
+				owner.emote("[prob(50) ? "twitch" : "twitch_s"]") //DOPPLER EDIT - ORIGINAL: owner.emote("twitch")
+			if(3) //DOPPLER EDIT - ORIGINAL: if(2 to 3)
+				owner.say("[prob(50) ? "#" : ""][pick("SHIT", "PISS", "FUCK", "CUNT", "COCKSUCKER", "MOTHERFUCKER", "TITS")]", forced=name) //DOPPLER EDIT - ORIGINAL: owner.say("[prob(50) ? ";" : ""][pick("SHIT", "PISS", "FUCK", "CUNT", "COCKSUCKER", "MOTHERFUCKER", "TITS")]", forced=name)
 		var/w_offset =  rand(-2, 2)
 		var/z_offset = rand(-1, 1)
 		animate(owner, pixel_w = w_offset, pixel_z = z_offset, time = 0.1 SECONDS, flags = ANIMATION_RELATIVE|ANIMATION_PARALLEL)

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -220,7 +220,7 @@
 			if(1 to 2) //DOPPLER EDIT: 1 > 1 to 2
 				owner.emote("twitch")
 			if(3) //DOPPLER EDIT: 2 to 3 > 3
-				owner.say("[pick("SHIT", "PISS", "FUCK", "CUNT", "COCKSUCKER", "MOTHERFUCKER", "TITS")]", forced=name) //DOPPLER EDIT ORIGINAL: owner.say("[prob(50) ? ";" : ""][pick("SHIT", "PISS", "FUCK", "CUNT", "COCKSUCKER", "MOTHERFUCKER", "TITS")]", forced=name)
+				owner.say("[prob(50) ? "#" : ""][pick("SHIT", "PISS", "FUCK", "CUNT", "COCKSUCKER", "MOTHERFUCKER", "TITS")]", forced=name) //DOPPLER EDIT: ; > #
 		var/w_offset =  rand(-2, 2)
 		var/z_offset = rand(-1, 1)
 		animate(owner, pixel_w = w_offset, pixel_z = z_offset, time = 0.1 SECONDS, flags = ANIMATION_RELATIVE|ANIMATION_PARALLEL)

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -217,7 +217,13 @@
 /datum/mutation/tourettes/on_life(seconds_per_tick, times_fired)
 	if(SPT_PROB(5 * GET_MUTATION_SYNCHRONIZER(src), seconds_per_tick) && owner.stat == CONSCIOUS && !owner.IsStun())
 		switch(rand(1, 3))
-			if(1 to 2) //DOPPLER EDIT - ORIGINAL: if(1)
+			/* DOPPLER EDIT BEGIN - ORIGINAL:
+			if(1)
+				owner.emote("twitch")
+			if(2 to 3)
+				owner.say("[prob(50) ? ";" : ""][pick("SHIT", "PISS", "FUCK", "CUNT", "COCKSUCKER", "MOTHERFUCKER", "TITS")]", forced=name)
+			*/ // DOPPLER EDIT CHANGE - Make tourettes less offensive 
+			if(1 to 2)
 				owner.emote("[prob(50) ? "twitch" : "twitch_s"]") //DOPPLER EDIT - ORIGINAL: owner.emote("twitch")
 			if(3) //DOPPLER EDIT - ORIGINAL: if(2 to 3)
 				owner.say("[prob(50) ? "#" : ""][pick("SHIT", "PISS", "FUCK", "CUNT", "COCKSUCKER", "MOTHERFUCKER", "TITS")]", forced=name) //DOPPLER EDIT - ORIGINAL: owner.say("[prob(50) ? ";" : ""][pick("SHIT", "PISS", "FUCK", "CUNT", "COCKSUCKER", "MOTHERFUCKER", "TITS")]", forced=name)

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -227,7 +227,7 @@
 				owner.emote("[prob(50) ? "twitch" : "twitch_s"]")
 			if(3)
 				owner.say("[prob(50) ? "#" : ""][pick("SHIT", "PISS", "FUCK", "CUNT", "COCKSUCKER", "MOTHERFUCKER", "TITS")]", forced=name) 
-				// DOPPLER EDIT END
+			// DOPPLER EDIT END
 		var/w_offset =  rand(-2, 2)
 		var/z_offset = rand(-1, 1)
 		animate(owner, pixel_w = w_offset, pixel_z = z_offset, time = 0.1 SECONDS, flags = ANIMATION_RELATIVE|ANIMATION_PARALLEL)

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -224,7 +224,7 @@
 				owner.say("[prob(50) ? ";" : ""][pick("SHIT", "PISS", "FUCK", "CUNT", "COCKSUCKER", "MOTHERFUCKER", "TITS")]", forced=name)
 			*/ // DOPPLER EDIT CHANGE - Make tourettes less offensive 
 			if(1 to 2)
-				owner.emote("[prob(50) ? "twitch" : "twitch_s"]") //DOPPLER EDIT - ORIGINAL: owner.emote("twitch")
+				owner.emote("[prob(50) ? "twitch" : "twitch_s"]")
 			if(3) //DOPPLER EDIT - ORIGINAL: if(2 to 3)
 				owner.say("[prob(50) ? "#" : ""][pick("SHIT", "PISS", "FUCK", "CUNT", "COCKSUCKER", "MOTHERFUCKER", "TITS")]", forced=name) //DOPPLER EDIT - ORIGINAL: owner.say("[prob(50) ? ";" : ""][pick("SHIT", "PISS", "FUCK", "CUNT", "COCKSUCKER", "MOTHERFUCKER", "TITS")]", forced=name)
 		var/w_offset =  rand(-2, 2)

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -217,10 +217,10 @@
 /datum/mutation/tourettes/on_life(seconds_per_tick, times_fired)
 	if(SPT_PROB(5 * GET_MUTATION_SYNCHRONIZER(src), seconds_per_tick) && owner.stat == CONSCIOUS && !owner.IsStun())
 		switch(rand(1, 3))
-			if(1)
+			if(1 to 2) //DOPPLER EDIT: 1 > 1 to 2
 				owner.emote("twitch")
-			if(2 to 3)
-				owner.say("[prob(50) ? ";" : ""][pick("SHIT", "PISS", "FUCK", "CUNT", "COCKSUCKER", "MOTHERFUCKER", "TITS")]", forced=name)
+			if(3) //DOPPLER EDIT: 2 to 3 > 3
+				owner.say("[pick("SHIT", "PISS", "FUCK", "CUNT", "COCKSUCKER", "MOTHERFUCKER", "TITS")]", forced=name) //DOPPLER EDIT ORIGINAL: owner.say("[prob(50) ? ";" : ""][pick("SHIT", "PISS", "FUCK", "CUNT", "COCKSUCKER", "MOTHERFUCKER", "TITS")]", forced=name)
 		var/w_offset =  rand(-2, 2)
 		var/z_offset = rand(-1, 1)
 		animate(owner, pixel_w = w_offset, pixel_z = z_offset, time = 0.1 SECONDS, flags = ANIMATION_RELATIVE|ANIMATION_PARALLEL)

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -225,7 +225,7 @@
 			*/ // DOPPLER EDIT CHANGE - Make tourettes less offensive 
 			if(1 to 2)
 				owner.emote("[prob(50) ? "twitch" : "twitch_s"]")
-			if(3) //DOPPLER EDIT - ORIGINAL: if(2 to 3)
+			if(3)
 				owner.say("[prob(50) ? "#" : ""][pick("SHIT", "PISS", "FUCK", "CUNT", "COCKSUCKER", "MOTHERFUCKER", "TITS")]", forced=name) //DOPPLER EDIT - ORIGINAL: owner.say("[prob(50) ? ";" : ""][pick("SHIT", "PISS", "FUCK", "CUNT", "COCKSUCKER", "MOTHERFUCKER", "TITS")]", forced=name)
 		var/w_offset =  rand(-2, 2)
 		var/z_offset = rand(-1, 1)

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -226,7 +226,8 @@
 			if(1 to 2)
 				owner.emote("[prob(50) ? "twitch" : "twitch_s"]")
 			if(3)
-				owner.say("[prob(50) ? "#" : ""][pick("SHIT", "PISS", "FUCK", "CUNT", "COCKSUCKER", "MOTHERFUCKER", "TITS")]", forced=name) //DOPPLER EDIT - ORIGINAL: owner.say("[prob(50) ? ";" : ""][pick("SHIT", "PISS", "FUCK", "CUNT", "COCKSUCKER", "MOTHERFUCKER", "TITS")]", forced=name)
+				owner.say("[prob(50) ? "#" : ""][pick("SHIT", "PISS", "FUCK", "CUNT", "COCKSUCKER", "MOTHERFUCKER", "TITS")]", forced=name) 
+				// DOPPLER EDIT END
 		var/w_offset =  rand(-2, 2)
 		var/z_offset = rand(-1, 1)
 		animate(owner, pixel_w = w_offset, pixel_z = z_offset, time = 0.1 SECONDS, flags = ANIMATION_RELATIVE|ANIMATION_PARALLEL)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Flips the probability of the Tourette’s Syndrome gene causing twitching and swearing such that twitching is now 66.7% of tics and swearing is now 33.3% of tics. Furthermore, replaces the radio message variant of the verbal tic with just a whispered version, and gives the twitch a 50% chance of being more subtle.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

I don’t think negative genes have to be /tg/-sufficient levels of bad to work here, particularly given that we are a roleplay server, anyways. As someone that deals with tics myself, I’ve always found the display of Tourette’s ingame just outright inaccurate. While not _offended_ myself per se, I do think it’s right to call the portrayal _offensive_. My tics do not randomly make me click my walkie on at work and scream swears at my co-workers. The probabilities were altered mostly because — even if I, personally, suffer from coprolalia — it is actually not that common in sufferers of Tourette’s, just one of the more noticeable symptoms. In an ideal world, we’d have more non-swear verbal tics, and in an ideal world, we’d have more expressive physical tics than just *twitch, but as it stands, there’s too many species that such tics might be inaccurate for, and any specifics can be roleplayed out or put in flavor text of characters that have this gene.

## Testing Evidence

<!-- Provide proof that the content added, edited, or removed by this pull request is working as intended in-game. Compiling alone doesn't guarantee functionality, in be sure to test thoroughly! -->

<img width="531" height="228" alt="image" src="https://github.com/user-attachments/assets/75fa41a0-ab5a-4d6d-b955-2bdcd000aada" />

Over time, twitches happened more often than sudden cursing, though not too much more often.


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Farce
qol: Made Tourette’s a little less offensive.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->