### PR TITLE
You have to be on combat mode to squish undersized people now

### DIFF
--- a/modular_doppler/modular_quirks/undersized/squashable.dm
+++ b/modular_doppler/modular_quirks/undersized/squashable.dm
@@ -68,16 +68,11 @@
 	if(crossing_living.movement_type & MOVETYPES_NOT_TOUCHING_GROUND)
 		return
 
-	// If they're a pacifist, they won't harm us.
+	// If they're a pacifist, they can't harm us.
 	if(HAS_TRAIT(crossing_living, TRAIT_PACIFISM))
-		crossing_living.visible_message(span_notice("[crossing_living] carefully steps over [parent_as_living]."), span_notice("You carefully step over [parent_as_living] to avoid hurting it."))
 		return
-	// If you're on Combat intent, you will always squash. If you walk, you will avoid squashing.
-	if(crossing_living.move_intent == MOVE_INTENT_WALK && crossing_living.combat_mode == FALSE)
-		crossing_living.visible_message(span_notice("[crossing_living] carefully walks around [parent_as_living]."), span_notice("You carefully walk around [parent_as_living] to avoid hurting it."))
-		return
-	// Tiny flying creatures are only squashed if the squasher is explicitly on combat mode.
-	if(parent_as_living.movement_type & MOVETYPES_NOT_TOUCHING_GROUND && crossing_living.combat_mode == FALSE)
+	// If you're not on Combat intent, don't squash
+	if(crossing_living.combat_mode == FALSE)
 		return
 
 	if(!should_squash)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Sort of mangled the logic chain in undersized squishing so that combat mode's required in order for them to be squished. I don't fully comprehend code and this was mostly guesswork (not vibecoding, just guesswork), but it does work as intended according to everything I could think of testing.

Also removed the chat text for walking around people because avoiding harming them is no longer a particularly notable event, and also because I didn't feel like figuring out how to fix the part where it always uses it/its for the mob being walked around for some reason???
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The original intent of undersized-squishing was twofold: to prevent undersized characters from wreaking havoc due to their diminutive clickbox, and because it was kind of funny for a bit. It's been long enough that it's mostly annoying how frequent it is now. Accidentally/"accidentally" leaving combat intent on is still a thing that people do, anyways. Station bots and dense structures and stuff will still squish freely.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Testing Evidence
this would require recording video so just dude trust me (i'll spin up sharex if its REALLY necessary)
<!-- Provide proof that the content added, edited, or removed by this pull request is working as intended in-game. Compiling alone doesn't guarantee functionality, so be sure to test thoroughly! -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: you must be on combat intent to squish undersized people now, so that it happens accidentally less often
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
