### PR TITLE
(DNM) Experimental ethereal buff

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -347,7 +347,7 @@
 #define NUTRITION_LEVEL_ALMOST_FULL 535
 
 // The standard charge all other Ethereal charge defines are scaled against.
-#define STANDARD_ETHEREAL_CHARGE (1 * STANDARD_CELL_CHARGE)
+#define STANDARD_ETHEREAL_CHARGE (2.5 * STANDARD_CELL_CHARGE) //DOPPLER EDIT - Original: (1 * STANDARD_CELL_CHARGE)
 // Charge levels for Ethereals, in joules.
 #define ETHEREAL_CHARGE_NONE 0
 #define ETHEREAL_CHARGE_LOWPOWER (0.4 * STANDARD_ETHEREAL_CHARGE)
@@ -507,7 +507,7 @@
 #define DOOR_CRUSH_DAMAGE 20 //the amount of damage that airlocks deal when they crush you
 
 #define HUNGER_FACTOR 0.05 //factor at which mob nutrition decreases
-#define ETHEREAL_DISCHARGE_RATE (1e-3 * STANDARD_ETHEREAL_CHARGE * 0.75) // Rate at which ethereal stomach charge decreases. DOPPLER EDIT ORIGINAL: ETHEREAL_DISCHARGE_RATE (1e-3 * STANDARD_ETHEREAL_CHARGE)
+#define ETHEREAL_DISCHARGE_RATE (1e-3 * STANDARD_ETHEREAL_CHARGE * 0.50) // Rate at which ethereal stomach charge decreases. DOPPLER EDIT ORIGINAL: ETHEREAL_DISCHARGE_RATE (1e-3 * STANDARD_ETHEREAL_CHARGE)
 /// How much nutrition eating clothes as moth gives and drains
 #define CLOTHING_NUTRITION_GAIN 15
 #define REAGENTS_METABOLISM 0.2 //How many units of reagent are consumed per second, by default.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR changes the ethereal discharge rate from 75% of the TG standard to 50%, and also multiplies their charge level by 2.5: Ethereals sitting at "full" charge have ~50 KJ, with high-capacity cells being 100 KJ for reference. This also means that ethereals will have an effective pool of ~500 KJ to draw from when using ethereal mod cores in modsuits (as said mod cores have an energy multiplier of .1).

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This should hopefully do two things: A, make it so ethereals can focus more on roleplay without having to recharge constantly in long conversations, and B, actually make use of their species-specific gear. I've been warned not to make the discharge rate lower than synths, but as it turns out, it was lower to begin with, so I want to testmerge to see how it feels in a real round.

Most of the ways ethereals charge don't use static static numbers, but use multipliers connected to their (new) standard charge level, so I doubt this will make things more difficult for them. All this PR aims to do is make them a bit less frustrating to play, and let them use MODs better.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Testing Evidence
It compiles
<!-- Provide proof that the content added, edited, or removed by this pull request is working as intended in-game. Compiling alone doesn't guarantee functionality, so be sure to test thoroughly! -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Ethereals discharge slower now, and have a bit more base charge.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
