### PR TITLE
(fixes?) access requirement on nebulastation cargo <--> salvage bay shutters

### DIFF
--- a/_maps/doppler/automapper/templates/nebulastation/nebulastation_shipbreaking.dmm
+++ b/_maps/doppler/automapper/templates/nebulastation/nebulastation_shipbreaking.dmm
@@ -44,7 +44,9 @@
 	name = "Salvage Bay Shutters"
 	},
 /obj/machinery/button/door/directional/north{
-	id = "shipbreaking"
+	id = "shipbreaking";
+	req_access = list("cargo");
+	name = "Salvage Bay Shutter Control"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- nebulastation salvage bay shutters directly connect to cargo's warehouse
- they had no access requirements
- anyone could walk in if you had the warehouse open

- it no longer does this
- also added a unique name for the shutters cus why not
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
- you should be able to have your warehouse open w/o random people able to walk in
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Testing Evidence
- booted it up. works as expected. sorry i cant provide proof nebulastation almost crashes my pc w/o obs running i dont want to try it w/.
<!-- Provide proof that the content added, edited, or removed by this pull request is working as intended in-game. Compiling alone doesn't guarantee functionality, so be sure to test thoroughly! -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
map: NebulaStation salvage bay shutters are clearly defined and now require cargo access to open
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
