### PR TITLE
Fixes security and SRA not showing up under security and service on the manifest

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -173,6 +173,7 @@ SUBSYSTEM_DEF(job)
 		name_occupations[job.title] = job
 		for(var/alt_title in job.alternate_titles)
 			name_occupations[alt_title] = job
+		name_occupations[job.get_default_job_title()] = job // DOPPLER EDIT ADDITION - ALTERNATIVE_JOB_TITLES
 		type_occupations[job_type] = job
 
 		if(job.job_flags & JOB_NEW_PLAYER_JOINABLE)

--- a/modular_doppler/modular_jobs/code/job_overrides/job_flavor.dm
+++ b/modular_doppler/modular_jobs/code/job_overrides/job_flavor.dm
@@ -30,6 +30,16 @@
 		Hold a karaoke night in the office. Break a leg, it doesn't have to be yours. \
 		Follow orders from people that know better than you."
 	supervisors = "the Chief Guard, and the head of your assigned department (if applicable)"
+	alternate_titles = list(
+		JOB_SECURITY_OFFICER_MEDICAL,
+		JOB_SECURITY_OFFICER_ENGINEERING,
+		JOB_SECURITY_OFFICER_SUPPLY,
+		JOB_SECURITY_OFFICER_SCIENCE,
+		JOB_SECURITY_GUARD_MEDICAL,
+		JOB_SECURITY_GUARD_ENGINEERING,
+		JOB_SECURITY_GUARD_SUPPLY,
+		JOB_SECURITY_GUARD_SCIENCE,
+	)
 
 /datum/job/detective
 	description = "Security officers with extra strings attached. \


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I believe I accidentally re-introduced this bug in my original pr after first testing this.

Renaming the trims in #996 forgot to account for the manifest using the trims to find the job datum, which won't find the right job datum, and thus it won't register that job on the manifest.
This is fixed by making the job subsystem make the result of `get_default_job_title()` also link to the job, in addition to the default job name.

Security guard however needs to use the manual `alternate_titles` route, because it has four departmental trims not otherwise linked to the job. We keep the old departmental trim names for posterity's sake.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

fix jank :+1:

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Testing Evidence

<img width="333" height="329" alt="image" src="https://github.com/user-attachments/assets/de861f60-b642-4f9e-b7f2-e38604445b54" />
<img width="410" height="296" alt="image" src="https://github.com/user-attachments/assets/d961d2ec-4fe4-43a9-ab1c-9d2344bd7834" />
<img width="420" height="67" alt="image" src="https://github.com/user-attachments/assets/2841ffb6-7206-4ebd-95b7-5699369e9215" />
<img width="329" height="89" alt="image" src="https://github.com/user-attachments/assets/8f1b859c-8603-4448-aca8-bd829df1c6b4" />


<!-- Provide proof that the content added, edited, or removed by this pull request is working as intended in-game. Compiling alone doesn't guarantee functionality, so be sure to test thoroughly! -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Security and Sophont Resources Agent shows up as security and service on the manifest again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
