### PR TITLE
[TM ONLY] Early pull of tgstation#95032: Honorifics don't mangle runechat color

### DIFF
--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -50,11 +50,11 @@
 		return signal_face // no need to null-check, because force_set will always set a signal_face
 
 	var/face_name = isnull(signal_face) ? get_face_name("") : signal_face
-	var/id_name = isnull(signal_id) ? get_id_name("",  honorifics = add_id_name) : signal_id // DOPPLER EDIT CHANGE - Early pull of TG#95032 - Original: var/id_name = isnull(signal_id) ? get_id_name("",  honorifics = TRUE) : signal_id
+	var/id_name = isnull(signal_id) ? get_id_name("",  honorifics = add_id_name) : signal_id // DOPPLER EDIT CHANGE - Early pull of tgstation##95032 - Original: var/id_name = isnull(signal_id) ? get_id_name("",  honorifics = TRUE) : signal_id
 
 	// We need to account for real name
 	if(force_real_name)
-		var/disguse_name = get_visible_name(add_id_name = add_id_name, force_real_name = FALSE) // DOPPLER EDIT CHANGE - Early pull of TG#95032 - Original: var/disguse_name = get_visible_name(add_id_name = TRUE, force_real_name = FALSE)
+		var/disguse_name = get_visible_name(add_id_name = add_id_name, force_real_name = FALSE) // DOPPLER EDIT CHANGE - Early pull of tgstation##95032 - Original: var/disguse_name = get_visible_name(add_id_name = TRUE, force_real_name = FALSE)
 		return "[real_name][disguse_name == real_name ? "" : " (as [disguse_name])"]"
 
 	// We're just some unknown guy

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -50,11 +50,11 @@
 		return signal_face // no need to null-check, because force_set will always set a signal_face
 
 	var/face_name = isnull(signal_face) ? get_face_name("") : signal_face
-	var/id_name = isnull(signal_id) ? get_id_name("",  honorifics = TRUE) : signal_id
+	var/id_name = isnull(signal_id) ? get_id_name("",  honorifics = add_id_name) : signal_id // DOPPLER EDIT CHANGE - Early pull of TG#95032 - Original: var/id_name = isnull(signal_id) ? get_id_name("",  honorifics = TRUE) : signal_id
 
 	// We need to account for real name
 	if(force_real_name)
-		var/disguse_name = get_visible_name(add_id_name = TRUE, force_real_name = FALSE)
+		var/disguse_name = get_visible_name(add_id_name = add_id_name, force_real_name = FALSE) // DOPPLER EDIT CHANGE - Early pull of TG#95032 - Original: var/disguse_name = get_visible_name(add_id_name = TRUE, force_real_name = FALSE)
 		return "[real_name][disguse_name == real_name ? "" : " (as [disguse_name])"]"
 
 	// We're just some unknown guy


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

https://github.com/tgstation/tgstation/pull/95032

> Vocal runechat uses voice name but emote runechat uses face name with add_id_name = FALSE
Honorifics were being added onto it despite it asking to ignore ID which meant it gave you a different color
Fixes it by not including honorifics when ignoring ID

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It's jank. Begone.
Especially vital now we're getting chat names recolored by the chat color.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Testing Evidence

<img width="163" height="105" alt="image" src="https://github.com/user-attachments/assets/f0b19881-8c73-4d2c-bd87-0b66ea6aab75" />
<img width="259" height="127" alt="image" src="https://github.com/user-attachments/assets/95b19206-b623-488f-95b9-bd6c7e3d7de3" />
<img width="166" height="113" alt="image" src="https://github.com/user-attachments/assets/de28e8e4-ff4f-4ae4-8984-b1c7bc4d6ba0" />


<!-- Provide proof that the content added, edited, or removed by this pull request is working as intended in-game. Compiling alone doesn't guarantee functionality, so be sure to test thoroughly! -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Having an active honorific no longer changes your runechat/chat emote/signing color
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
