### PR TITLE
Makes the chat color preference work for AIs and borgs.

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1243,7 +1243,7 @@
 			GLOB.chat_colors_by_mob_name -= oldname // DOPPLER EDIT ADDITION
 
 	if(client) // DOPPLER EDIT ADDITION - Update the mob chat color list, adding the new name
-		GLOB.chat_colors_by_mob_name[name] = list(chat_color, chat_color_darkened) // DOPPLER EDIT ADDITION
+		cache_chat_color(name, chat_color, chat_color_darkened) // DOPPLER EDIT ADDITION
 	log_mob_tag("TAG: [tag] RENAMED: [key_name(src)]")
 
 	return TRUE

--- a/modular_doppler/modular_customization/preferences/chat_color.dm
+++ b/modular_doppler/modular_customization/preferences/chat_color.dm
@@ -5,7 +5,7 @@
 	savefile_key = "ic_chat_color"
 
 /datum/preference/color/chat_color/apply_to_human(mob/living/carbon/human/target, value)
-	target.apply_preference_chat_color(value)
+	target.apply_chat_color(value)
 	return
 
 /datum/preference/color/chat_color/deserialize(input, datum/preferences/preferences)
@@ -17,21 +17,49 @@
 /datum/preference/color/chat_color/serialize(input)
 	return process_chat_color(sanitize_hexcolor(input))
 
-/mob/living/carbon/human/proc/apply_preference_chat_color(value)
+/// Applies the given chat color, processing it before doing so.
+/mob/living/proc/apply_chat_color(value, add_to_cache = FALSE)
 	if(isnull(value))
 		return FALSE
 
 	chat_color = process_chat_color(value, sat_shift = 1, lum_shift = 1)
 	chat_color_darkened = process_chat_color(value, sat_shift = 0.85, lum_shift = 0.85)
 	chat_color_name = name
+	if(add_to_cache)
+		cache_chat_color(name, chat_color, chat_color_darkened)
 	return TRUE
+
+/// Manually applies the chat color preference.
+/mob/living/proc/apply_chat_color_preference(client/player_client)
+	var/color_to_use = player_client?.prefs?.read_preference(/datum/preference/color/chat_color)
+	if(isnull(color_to_use))
+		return FALSE
+	apply_chat_color(color_to_use, add_to_cache = TRUE)
+	return TRUE
+
+/// Copies the chat color from the given mob to us, caching it if need be.
+/mob/living/proc/copy_chat_color(mob/living/copy_from, add_to_cache = TRUE)
+	chat_color = copy_from.chat_color
+	chat_color_darkened = copy_from.chat_color_darkened
+	chat_color_name = name
+
+	if(add_to_cache)
+		cache_chat_color(chat_color_name, chat_color, chat_color_darkened)
+
+/// Caches the given chat color for the given name, overriding whatever may already be there.
+/proc/cache_chat_color(name, chat_color, chat_color_darkened)
+	GLOB.chat_colors_by_mob_name[name] = list(chat_color, chat_color_darkened)
+
+/// Returns a list of chat colors cached for the given name, if any.
+/proc/get_cached_chat_color(name)
+	return GLOB.chat_colors_by_mob_name[name]
 
 #define CHAT_COLOR_NORMAL 1
 #define CHAT_COLOR_DARKENED 2
 
 /// Get the mob's chat color by looking up their name in the cached list, if no match is found default to colorize_string().
 /datum/chatmessage/proc/get_chat_color_string(name, darkened)
-	var/chat_color_strings = GLOB.chat_colors_by_mob_name[name]
+	var/chat_color_strings = get_cached_chat_color(name)
 	if(chat_color_strings)
 		return darkened ? chat_color_strings[CHAT_COLOR_DARKENED] : chat_color_strings[CHAT_COLOR_NORMAL]
 	if(darkened)

--- a/modular_doppler/modular_customization/preferences/chat_color_silicon.dm
+++ b/modular_doppler/modular_customization/preferences/chat_color_silicon.dm
@@ -1,0 +1,15 @@
+
+/mob/living/silicon/ai/apply_prefs_job(client/player_client, datum/job/job)
+	. = ..()
+	apply_chat_color_preference(player_client)
+
+/mob/living/silicon/robot/apply_prefs_job(client/player_client, datum/job/job)
+	. = ..()
+	var/chat_color_applied = apply_chat_color_preference(player_client)
+	if(chat_color_applied && mmi?.brainmob)
+		mmi.brainmob.copy_chat_color(src)
+
+/mob/living/silicon/robot/deploy_init(mob/living/silicon/ai/AI)
+	. = ..()
+	if(get_cached_chat_color(AI.name))
+		copy_chat_color(AI)

--- a/modular_doppler/modular_customization/preferences/preferences.dm
+++ b/modular_doppler/modular_customization/preferences/preferences.dm
@@ -12,4 +12,6 @@
 // Updates the mob's chat color in the global cache
 /datum/preferences/safe_transfer_prefs_to(mob/living/carbon/human/character, icon_updates = TRUE, is_antag = FALSE)
 	. = ..()
-	GLOB.chat_colors_by_mob_name[character.name] = list(character.chat_color, character.chat_color_darkened) // by now the mob has had its prefs applied to it
+	// by now the mob has had its prefs applied to it
+	if(character.chat_color && character.chat_color_darkened)
+		cache_chat_color(character.name, character.chat_color, character.chat_color_darkened)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7331,6 +7331,7 @@
 #include "modular_doppler\modular_customization\preferences\body_marking_moth.dm"
 #include "modular_doppler\modular_customization\preferences\breasts.dm"
 #include "modular_doppler\modular_customization\preferences\chat_color.dm"
+#include "modular_doppler\modular_customization\preferences\chat_color_silicon.dm"
 #include "modular_doppler\modular_customization\preferences\cyber_limbs.dm"
 #include "modular_doppler\modular_customization\preferences\ears.dm"
 #include "modular_doppler\modular_customization\preferences\fluff.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Previously, the chat color preference only worked for humans, because it'd only apply to humans.
We fix this by making the AI and robot jobs apply these when they would also apply their other prefs, accounting for shells and MMIs

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Kinda wack it doesn't work for silicons.
Especially with #1005, this now matters a lot more.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Testing Evidence

<img width="107" height="140" alt="image" src="https://github.com/user-attachments/assets/e7e24c05-e1ba-4a70-b7c6-e50fc9615812" />
<img width="106" height="122" alt="image" src="https://github.com/user-attachments/assets/2f90f891-0a42-4119-8c0a-e06d95f4072d" />
<img width="109" height="119" alt="image" src="https://github.com/user-attachments/assets/58e4baab-757d-4507-894d-a554c595a118" />
<img width="122" height="134" alt="image" src="https://github.com/user-attachments/assets/7a6d8680-dc30-45fc-8ba1-facbbc046909" />


<!-- Provide proof that the content added, edited, or removed by this pull request is working as intended in-game. Compiling alone doesn't guarantee functionality, so be sure to test thoroughly! -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Chat color preference works for borgs, AIs, and their shells/holograms.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
