### PR TITLE
explodes tg batons

### DIFF
--- a/modular_doppler/modular_weapons/code/sec_swords/baton_overrides.dm
+++ b/modular_doppler/modular_weapons/code/sec_swords/baton_overrides.dm
@@ -1,0 +1,16 @@
+// overrides various easy sources of tg sec batons
+
+/datum/crafting_recipe/secbot
+	reqs = list(
+		/obj/item/assembly/signaler = 1,
+		/obj/item/clothing/head/helmet/sec = 1,
+		/obj/item/melee/baton/doppler_security = 1,
+		/obj/item/assembly/prox_sensor = 1,
+		/obj/item/bodypart/arm/right/robot = 1,
+	)
+
+/mob/living/simple_animal/bot/secbot
+	baton_type = /obj/item/melee/baton/doppler_security
+
+/datum/supply_pack/security/baton
+	contains = list(/obj/item/melee/baton/doppler_security = 3)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7707,6 +7707,7 @@
 #include "modular_doppler\modular_weapons\code\guns\smg.dm"
 #include "modular_doppler\modular_weapons\code\guns\tian.dm"
 #include "modular_doppler\modular_weapons\code\sec_swords\baton.dm"
+#include "modular_doppler\modular_weapons\code\sec_swords\baton_overrides.dm"
 #include "modular_doppler\modular_weapons\code\sec_swords\big_sword.dm"
 #include "modular_doppler\modular_weapons\code\sec_swords\holodeck_trainer.dm"
 #include "modular_doppler\modular_weapons\code\sec_swords\jitte.dm"


### PR DESCRIPTION
## About The Pull Request

replaces beepskys baton with a doppler sec shockprod, replaces the recipe, and replaces the batons that come in the cargo crate

## Why It's Good For The Game

u gotta use the doppler batons brx sorry

## Testing Evidence

yeah it works

## Changelog

:cl:
balance: most sources of tg security batons are exploded forever
/:cl:
