### PR TITLE
reduces the effective power of all jetpacks

### DIFF
--- a/modular_doppler/modular_balancing/jetpacks.dm
+++ b/modular_doppler/modular_balancing/jetpacks.dm
@@ -1,0 +1,25 @@
+// Makes jetpacks lower power
+// MOD jetpacks consume twice the power
+// Gas jetpacks have a lower top speed
+
+/obj/item/tank/jetpack
+	full_speed = FALSE
+	drift_force = 0.25 NEWTONS
+	stabilizer_force = 0.2 NEWTONS
+
+/obj/item/tank/jetpack/improvised
+	drift_force = 0.2 NEWTONS
+	stabilizer_force = 0.1 NEWTONS
+
+/obj/item/tank/jetpack/oxygen/captain
+	drift_force = 0.5 NEWTONS
+	stabilizer_force = 0.5 NEWTONS
+
+/obj/item/mod/module/jetpack
+	active_power_cost = DEFAULT_CHARGE_DRAIN * 0.1
+	drift_force = 0.25 NEWTONS
+	stabilizer_force = 0.2 NEWTONS
+
+/obj/item/mod/module/jetpack/advanced
+	drift_force = 0.5 NEWTONS
+	stabilizer_force = 0.5 NEWTONS

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7155,6 +7155,7 @@
 #include "modular_doppler\modular_antagonists\changeling\changeling.dm"
 #include "modular_doppler\modular_antagonists\datums\antag_recipes.dm"
 #include "modular_doppler\modular_antagonists\pirates\tiziran_raiders.dm"
+#include "modular_doppler\modular_balancing\jetpacks.dm"
 #include "modular_doppler\modular_cargo\doppler_cargo_packs.dm"
 #include "modular_doppler\modular_cosmetics\toggle_clothes.dm"
 #include "modular_doppler\modular_cosmetics\code\chest.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

all jetpacks have had their effective acceleration and deceleration greatly reduced, meaning more time to reach top speed and to slow down/change direction
gas powered jetpacks no longer give a speed bonus in space
modsuit jetpacks consume twice the power

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

something about using jetpacks in annoying chases, good luck with that now

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: all jetpacks are generally less instantaneous to accelerate and stop
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
