### PR TITLE
Changes the categories of the orbit menu

### DIFF
--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -70,6 +70,11 @@ GLOBAL_DATUM_INIT(orbit_menu, /datum/orbit_menu, new)
 	var/list/ghosts = list()
 	var/list/misc = list()
 	var/list/npcs = list()
+	// DOPPLER ADDITIONS START
+	var/list/ninelives = list()
+	var/list/cantina = list()
+	var/list/truth = list()
+	// DOPPLER ADDITIONS END
 
 	for(var/name in new_mob_pois)
 		var/list/serialized = list()
@@ -109,6 +114,17 @@ GLOBAL_DATUM_INIT(orbit_menu, /datum/orbit_menu, new)
 		if(isliving(mob_poi))
 			serialized += get_living_data(mob_poi)
 
+		// DOPPLER ADDITION START - Additional filters for 9LP crew and popular ghost roles, players that aren't caught by them get put under 'misc alive'
+		if(mob_poi.mind?.assigned_role?.faction == FACTION_STATION)
+			ninelives += list(serialized)
+			continue
+		if(istype(mob_poi.mind?.assigned_role, /datum/job/cantinoid))
+			cantina += list(serialized) // we don't need the antag data tbh
+			continue
+		if(istype(mob_poi.mind?.assigned_role, /datum/job/primitive_genemod))
+			truth += list(serialized)
+			continue
+		// DOPPLER ADDITION END
 		var/list/antag_data = get_antag_data(mob_poi.mind, is_admin)
 		if(length(antag_data))
 			serialized += antag_data
@@ -147,6 +163,11 @@ GLOBAL_DATUM_INIT(orbit_menu, /datum/orbit_menu, new)
 		"ghosts" = ghosts,
 		"misc" = misc,
 		"npcs" = npcs,
+		// DOPPLER ADDITIONS START
+		"ninelives" = ninelives,
+		"cantina" = cantina,
+		"truth" = truth,
+		// DOPPLER ADDITIONS END
 		"can_observe" = !HAS_TRAIT(user, TRAIT_NO_OBSERVE),
 	)
 

--- a/modular_doppler/modular_antagonists/cantina/cantina_roles.dm
+++ b/modular_doppler/modular_antagonists/cantina/cantina_roles.dm
@@ -1,8 +1,11 @@
 
-/datum/job/cantina_regular
+/datum/job/cantinoid
+	title = "Undisclosed Location guest"
+
+/datum/job/cantinoid/regular
 	title = "Undisclosed Location regular"
 
-/datum/job/cantina_bartender
+/datum/job/cantinoid/bartender
 	title = "Undisclosed Location bartender"
 
 /datum/antagonist/traitor/cantina

--- a/modular_doppler/modular_antagonists/cantina/spawners.dm
+++ b/modular_doppler/modular_antagonists/cantina/spawners.dm
@@ -11,7 +11,7 @@
 	flavour_text = "Known by The Curfew and Sundown to squares, The Undisclosed Location is a front for criminal activity in the sector. \
 	The breadth of their corporate affiliations is on a need to know basis, but the sheer volume of gear in the back is at least a little \
 	illuminating. You're a regular here, and you know that they can get you the goods."
-	spawner_job_path = /datum/job/cantina_regular
+	spawner_job_path = /datum/job/cantinoid/regular
 	role_ban = ROLE_TRAITOR
 
 /obj/effect/mob_spawn/ghost_role/human/cantina/create(mob/mob_possessor, newname)
@@ -38,7 +38,7 @@
 	flavour_text = "Known by The Curfew and Sundown to squares, The Undisclosed Location is a front for criminal activity in the sector. \
 	The breadth of their corporate affiliations is on a need to know basis, but the sheer volume of gear in the back is at least a little \
 	illuminating. You're an employee here, and you have clientele to please."
-	spawner_job_path = /datum/job/cantina_bartender
+	spawner_job_path = /datum/job/cantinoid/bartender
 	role_ban = ROLE_TRAITOR
 
 /obj/effect/mob_spawn/ghost_role/human/cantina_bartender/create(mob/mob_possessor, newname)

--- a/tgui/packages/tgui/interfaces/Orbit/OrbitContent.tsx
+++ b/tgui/packages/tgui/interfaces/Orbit/OrbitContent.tsx
@@ -34,15 +34,33 @@ export function OrbitContent(props) {
   }
 
   const sections: readonly ContentSection[] = [
+    /** DOPPLER ADDITIONS START -- More categories! */
+    {
+      color: 'black',
+      content: data.cantina,
+      title: 'Cantina Crowd',
+    },
+    {
+      color: 'orange',
+      content: data.ninelives,
+      title: '9LP Crewmembers',
+    },
+    {
+      color: 'teal',
+      content: data.truth,
+      title: 'Truth Dwellers',
+    },
+    /* DOPPLER EDIT - moved down
     {
       color: 'purple',
       content: data.deadchat_controlled,
       title: 'Deadchat Controlled',
     },
+    /** DOPPLER ADDITIONS END */
     {
       color: 'blue',
       content: data.alive,
-      title: 'Alive',
+      title: 'Misc Alive', // DOPPLER EDIT - old: 'Alive'
     },
     {
       content: data.dead,
@@ -52,6 +70,13 @@ export function OrbitContent(props) {
       content: data.ghosts,
       title: 'Ghosts',
     },
+    /** DOPPLER ADDITION START */
+    {
+      color: 'purple',
+      content: data.deadchat_controlled,
+      title: 'Deadchat Controlled',
+    },
+    /** DOPPLER ADDITION END */
     {
       content: data.misc,
       title: 'Misc',

--- a/tgui/packages/tgui/interfaces/Orbit/OrbitSearchBar.tsx
+++ b/tgui/packages/tgui/interfaces/Orbit/OrbitSearchBar.tsx
@@ -32,6 +32,11 @@ export function OrbitSearchBar(props) {
       data.critical,
       data.deadchat_controlled,
       data.dead,
+      /** DOPPLER ADDITIONS START */
+      data.ninelives,
+      data.cantina,
+      data.truth,
+      /** DOPPLER ADDITIONS END */
       data.ghosts,
       data.misc,
       data.npcs,

--- a/tgui/packages/tgui/interfaces/Orbit/types.ts
+++ b/tgui/packages/tgui/interfaces/Orbit/types.ts
@@ -19,6 +19,11 @@ export type OrbitData = {
   ghosts: Observable[];
   misc: Observable[];
   npcs: Observable[];
+  /** DOPPLER ADDITIONS START */
+  ninelives: Observable[];
+  cantina: Observable[];
+  truth: Observable[];
+  /** DOPPLER ADDITIONS END */
   orbiting: Observable | null;
   can_observe: BooleanLike;
 };


### PR DESCRIPTION
## About The Pull Request

Adds some more categories to the orbit menu.
9LP crew, cantinoids and the truth ghostrole get their own categories. players who don't have a category i.e changing room players or less popular ghost roles fall into the 'misc alive' category.

## Why It's Good For The Game

I wanted to organize the orbit menu. Its kinda bad how every player is just tossed into the same few pools.

**noteworthy:** cantinoids being a category means they (obivously) show up on the orbit menu now, previously this was only for admin eyes. i think its fine having observes see who is a cantina antag, so they can get a better grasp on the round and whether or not they pile on.

## Testing Evidence

<img width="400" height="550" alt="1777426095" src="https://github.com/user-attachments/assets/dc0c494f-1e08-4f4b-8bd9-cda66d1f578c" />

## Changelog

:cl:
qol: Adds more categories and filtering to the orbit menu, making it easier to use.
/:cl:
