### PR TITLE
Buffs Revenant to have less early-game busy-work, gives them most languages and adds the ability to manifest (and stay manifested) without hostile ability use.

### DIFF
--- a/code/modules/mob/living/basic/space_fauna/revenant/_revenant.dm
+++ b/code/modules/mob/living/basic/space_fauna/revenant/_revenant.dm
@@ -106,6 +106,10 @@
 
 	GLOB.revenant_relay_mobs |= src
 
+	// DOPPLER EDIT ADDITION START - Calls a proc that gives langauges + manifest powers
+	add_roleplay_powers()
+	// DOPPLER EDIT ADDITION END
+
 /mob/living/basic/revenant/Destroy()
 	GLOB.revenant_relay_mobs -= src
 	return ..()

--- a/modular_doppler/revenant_buffs/_revenant.dm
+++ b/modular_doppler/revenant_buffs/_revenant.dm
@@ -31,7 +31,7 @@
 	background_icon_state = "bg_revenant"
 	overlay_icon_state = "bg_revenant_border"
 	button_icon_state = "r_nightvision"
-	cooldown_time = 1 SECONDS
+	cooldown_time = 1
 	spell_requirements = NONE
 
 /datum/action/cooldown/spell/revenant_manifest/can_cast_spell(feedback = TRUE)

--- a/modular_doppler/revenant_buffs/_revenant.dm
+++ b/modular_doppler/revenant_buffs/_revenant.dm
@@ -26,7 +26,7 @@
 // Makes you appear. For when you want to be visible while monologueing. Or stalk people spooky style.
 /datum/action/cooldown/spell/revenant_manifest
 	name = "Manifest"
-	desc = "Manifests you into the realm of hte living for all to see. Unlike your other powers, this keeps you perpetually visible until you activate this ability again."
+	desc = "Manifests you into the realm of the living for all to see. Unlike your other powers, this keeps you perpetually visible until you activate this ability again."
 	button_icon = 'icons/mob/actions/actions_revenant.dmi'
 	background_icon_state = "bg_revenant"
 	overlay_icon_state = "bg_revenant_border"
@@ -55,7 +55,6 @@
 	// Decativates if active.
 	if(cast_on.has_status_effect(/datum/status_effect/revenant/revealed/manifest))
 		cast_on.remove_status_effect(/datum/status_effect/revenant/revealed/manifest)
-		to_chat(cast_on, span_revennotice("You recede from the corporeal realm."))
 		cast_on.balloon_alert(cast_on, "unmanifested")
 		return
 

--- a/modular_doppler/revenant_buffs/_revenant.dm
+++ b/modular_doppler/revenant_buffs/_revenant.dm
@@ -1,0 +1,64 @@
+// Add a large variety of buffs and extra capabilities to the Revenant meant to make them more roleplay engaging and not just a vehicle for mechanics.
+
+/mob/living/basic/revenant
+	/// Starting essence: Buffed from 75 -> 200
+	essence = 200
+	/// Starting natural regen for Revenants: Buffed from 75 -> 100
+	max_essence = 100
+	/// Some starting essence so you aren't sitting there puppy-eyed during greenshift.
+	essence_excess = 100
+
+/// Adds languages and manifest
+/mob/living/basic/revenant/proc/add_roleplay_powers()
+	// Gives the manifest power
+	var/datum/action/cooldown/spell/revenant_manifest/manifest_action = new(src)
+	manifest_action.Grant(src)
+
+	// Gives all languages except secret ones.
+	for(var/datum/language/language_type as anything in GLOB.all_languages)
+		var/datum/language/language = GLOB.language_datum_instances[language_type]
+		if(isnull(language))
+			continue
+		if(language.secret)
+			continue
+		grant_language(language.type, ALL, source = LANGUAGE_SPAWNER)
+
+// Makes you appear. For when you want to be visible while monologueing. Or stalk people spooky style.
+/datum/action/cooldown/spell/revenant_manifest
+	name = "Manifest"
+	desc = "Manifests you into the realm of hte living for all to see. Unlike your other powers, this keeps you perpetually visible until you activate this ability again."
+	button_icon = 'icons/mob/actions/actions_revenant.dmi'
+	background_icon_state = "bg_revenant"
+	overlay_icon_state = "bg_revenant_border"
+	button_icon_state = "r_nightvision"
+	cooldown_time = 1 SECONDS
+	spell_requirements = NONE
+
+/datum/action/cooldown/spell/revenant_manifest/can_cast_spell(feedback = TRUE)
+	. = ..()
+	if(!.)
+		return FALSE
+	// This shouldn't happen.
+	if(!isrevenant(owner))
+		stack_trace("[type] was owned by a non-revenant mob, please don't.")
+		return FALSE
+
+	// Can't cast while CC'd.
+	var/mob/living/basic/revenant/ghost = owner
+	if(ghost.dormant || HAS_TRAIT(ghost, TRAIT_REVENANT_INHIBITED))
+		return FALSE
+
+	return TRUE
+
+/datum/action/cooldown/spell/revenant_manifest/cast(mob/living/basic/revenant/cast_on)
+	. = ..()
+	// Decativates if active.
+	if(cast_on.has_status_effect(/datum/status_effect/revenant/revealed/manifest))
+		cast_on.remove_status_effect(/datum/status_effect/revenant/revealed/manifest)
+		to_chat(cast_on, span_revennotice("You recede from the corporeal realm."))
+		cast_on.balloon_alert(cast_on, "unmanifested")
+		return
+
+	// If not active: applies an unique status effect responsible for the manifesting.
+	cast_on.apply_status_effect(/datum/status_effect/revenant/revealed/manifest, STATUS_EFFECT_PERMANENT)
+	cast_on.balloon_alert(cast_on, "manifested")

--- a/modular_doppler/revenant_buffs/revenant_effects.dm
+++ b/modular_doppler/revenant_buffs/revenant_effects.dm
@@ -1,0 +1,16 @@
+/// Special version of manifest, plus override to make sure that the two reveals don't conflict.
+/datum/status_effect/revenant/revealed/on_remove()
+	REMOVE_TRAIT(owner, TRAIT_REVENANT_REVEALED, TRAIT_STATUS_EFFECT(id))
+
+	if(HAS_TRAIT(owner, TRAIT_REVENANT_REVEALED)) // checks if we're still visible through manifest so we don't give jaunt movement too early
+		owner.incorporeal_move = FALSE
+	else
+		owner.incorporeal_move = INCORPOREAL_MOVE_JAUNT
+
+	owner.RemoveInvisibility(type)
+	owner.update_appearance(UPDATE_ICON)
+	owner.update_mob_action_buttons()
+	return
+
+/datum/status_effect/revenant/revealed/manifest
+	id = "revenant_revealed_manifest"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7747,6 +7747,8 @@
 #include "modular_doppler\research\designs\limbgrower_designs.dm"
 #include "modular_doppler\research\techweb\all_nodes.dm"
 #include "modular_doppler\research\techweb\roundstart_techweb_nodes.dm"
+#include "modular_doppler\revenant_buffs\_revenant.dm"
+#include "modular_doppler\revenant_buffs\revenant_effects.dm"
 #include "modular_doppler\ruins_but_epic\code\space_junk.dm"
 #include "modular_doppler\scream_b_gone\code\human.dm"
 #include "modular_doppler\sec_armor_normalization\sec_armor_normalization.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Based on a thread in dev-ideas, Revenant currently suffers from the fact that it is very mechanical and doesn't leave the door open to RP. So this addresses some of these concerns.

Revenants now start with 100 spendable essence pool (not enough for shock lights but enough for everything else), a base regen of 100 and a starting pool of essence of 200. This is largely so you can cut out the arbitrary essence-farm mining trip for when we have a greenshift and immediately focus on spooking and interacting with people.

Revenants now understand every non-secret language. Because of their inability to speak normally it only lets them understand it, though Telepathy bypasses language anyway. Now you can roleplay as the ghost of a dream of a memory of a cyborg warrior that understandFrench.

Finally it gives one extra ability to Revenant: Manifest. It simply forces you to be manifested (comes for free), can be toggled on/of to demanifest, and does not conflict with the existing manifest mechanic. Meaning you can /me with it, but also creepily stalk people if you jive with that. Flash yourself before big crowds: GASP!

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Roleplay components are obviously good. I am personally of the opinion that the Revenant grind does not add anything of substance on our server compared to /tg/. You can still kill people on death's door and it still comes with that juicy bonus of increasing your cap, but beyond that its just busy-work hunting for cadavers which are much rarer on our server if you don't hitch a ride on the mining shuttle and just suck up all the corpses there.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Testing Evidence

<img width="1617" height="1097" alt="image" src="https://github.com/user-attachments/assets/87bbd748-ab93-45d7-9f92-08e4b5fc69b0" />

Also tested that using abilities during manifest doesn't override one another.

<!-- Provide proof that the content added, edited, or removed by this pull request is working as intended in-game. Compiling alone doesn't guarantee functionality, so be sure to test thoroughly! -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Revenant can now manifest themselves without using hostile ability, which they can toggle at will.
add: Revenant can now understand almost all languages.
balance: Revenant now has more starting essence and can buy some upgrades upon first appearance
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
