### PR TITLE
Makes synth charging faster

### DIFF
--- a/modular_doppler/modular_species/species_types/android/charging/power_cord.dm
+++ b/modular_doppler/modular_species/species_types/android/charging/power_cord.dm
@@ -1,6 +1,6 @@
 
 /// Rate at which a power cord can charge its stomach cell.
-#define POWER_CORD_CHARGE_RATE (CHARGING_STOMACH_DISCHARGE_RATE * 33)
+#define POWER_CORD_CHARGE_RATE (CHARGING_STOMACH_DISCHARGE_RATE * 66)
 /// Delay between power cord charging attempts.
 #define POWER_CORD_CHARGE_DELAY 0.5 SECONDS
 /// Minimum charge percent an APC must have for a power cord to be able to drain it.

--- a/modular_doppler/modular_species/species_types/android/charging/power_cord.dm
+++ b/modular_doppler/modular_species/species_types/android/charging/power_cord.dm
@@ -2,7 +2,7 @@
 /// Rate at which a power cord can charge its stomach cell.
 #define POWER_CORD_CHARGE_RATE (CHARGING_STOMACH_DISCHARGE_RATE * 33)
 /// Delay between power cord charging attempts.
-#define POWER_CORD_CHARGE_DELAY 0.5 SECONDS
+#define POWER_CORD_CHARGE_DELAY 0.25 SECONDS
 /// Minimum charge percent an APC must have for a power cord to be able to drain it.
 #define POWER_CORD_APC_MINIMUM_PERCENT 5
 

--- a/modular_doppler/modular_species/species_types/android/charging/power_cord.dm
+++ b/modular_doppler/modular_species/species_types/android/charging/power_cord.dm
@@ -2,7 +2,7 @@
 /// Rate at which a power cord can charge its stomach cell.
 #define POWER_CORD_CHARGE_RATE (CHARGING_STOMACH_DISCHARGE_RATE * 33)
 /// Delay between power cord charging attempts.
-#define POWER_CORD_CHARGE_DELAY 0.25 SECONDS
+#define POWER_CORD_CHARGE_DELAY 0.5 SECONDS
 /// Minimum charge percent an APC must have for a power cord to be able to drain it.
 #define POWER_CORD_APC_MINIMUM_PERCENT 5
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

this PR is incredibly simple. it just makes the charge speed take half as long as it does currently

## Why It's Good For The Game

the current charge speed is incredibly slow, and synth players often find themselves in prolonged scenes/scenarios where they cant charge for a long time. when they DO get the opportunity to charge at an APC, it takes incredibly long to do so. hopefully this makes charging a shorter affair while still making it take at least a little bit

## Testing Evidence

OBS was being a bitch and i couldnt record it but it does work and it goes twice as fast

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: made synth charging twice as fast
/:cl:
