### PR TITLE
Sci and Med HUD Half-Vision Description Revision

### DIFF
--- a/modular_doppler/modular_cosmetics/code/face/glasses.dm
+++ b/modular_doppler/modular_cosmetics/code/face/glasses.dm
@@ -165,7 +165,7 @@
 	)
 /obj/item/clothing/glasses/hud/eyepatch/med
 	name = "medical HUD eyepatch"
-	desc = "Do no harm; but, maybe harm has befallen you-- or your poor eyeball. Thankfully there's a way to continue your oath, thankfully it didn't mention strange experimental surgeries."
+	desc = "As the saying goes, 'Do no harm.' But, maybe harm has befallen you— or your poor eyeball. Fortunately there's a way to continue your oath, and it's thankfully not a strange experimental surgery."
 	icon_state = "medpatch"
 	base_icon_state = "medpatch"
 	clothing_traits = list(TRAIT_MEDICAL_HUD)
@@ -225,7 +225,7 @@
 
 /obj/item/clothing/glasses/hud/eyepatch/sci
 	name = "science HUD eyepatch"
-	desc = "Every few years, the aspiring mad scientist says to themselves 'I've got the castle, the evil laugh and equipment, but what I need is a look', thankfully, Dr. Galox has already covered that for you dear friend - while it doesn't do much beyond scan chemicals, what it lacks in use it makes up for in style."
+	desc = "An eyepatch fitted with an R&D scanner HUD. It can scan chemicals, tell you the makeup of certain materials, and even features an internal database that can scan objects for any tech particularly noteworthy."
 	icon_state = "scipatch"
 	base_icon_state = "scipatch"
 	clothing_traits = list(TRAIT_REAGENT_SCANNER, TRAIT_RESEARCH_SCANNER)


### PR DESCRIPTION
## About The Pull Request

revises the science and medical HUD eyepatch descriptions. Previously, they were grammatically incorrect and very annoying to read, on top of being vague on the details of their actual function in the case of the science scanner.

## Why It's Good For The Game

Knowing the functions of equipment is nice, and should be stated in the item's description. On top of that, no one like reading sentences with horrible flow.

## Testing Evidence
proof that the sci-patch description is there and that you can read it
<img width="676" height="134" alt="image" src="https://github.com/user-attachments/assets/d1f93cf3-7091-4e54-ab7d-b7f8c57bc68e" />

proof that the med-patch description is there and that you can read it
<img width="650" height="140" alt="image" src="https://github.com/user-attachments/assets/7b7963dc-9374-409f-93f6-19ece3beb971" />


further proof that the sci eyepatch does actually have these capabilities that weren't mentioned in the old description
<img width="223" height="55" alt="image" src="https://github.com/user-attachments/assets/5eae7728-0fc2-481c-815d-e56a45ecf619" />
<img width="318" height="53" alt="image" src="https://github.com/user-attachments/assets/199fd723-dbfb-4fb3-b4d9-1a538413390c" />
## Changelog

:cl:
spellcheck: revised sci-patch and med-patch hud descriptions
/:cl:
