### PR TITLE
Atypical Tastes can now replace your tongue.

### DIFF
--- a/modular_doppler/modular_quirks/atypical_tastes/atypical_tastes.dm
+++ b/modular_doppler/modular_quirks/atypical_tastes/atypical_tastes.dm
@@ -16,7 +16,7 @@ GLOBAL_LIST_INIT(possible_quirk_atypical_tastes, list(
 
 /datum/quirk_constant_data/atypical_taster
 	associated_typepath = /datum/quirk/atypical_tastes
-	customization_options = list(/datum/preference/choiced/atypical_tastes)
+	customization_options = list(/datum/preference/choiced/atypical_tastes, /datum/preference/toggle/tongue_replacement)
 
 /datum/quirk/atypical_tastes/add_unique(client/client_source)
 	var/obj/item/organ/tongue/desired_taste_copier = GLOB.possible_quirk_atypical_tastes[client_source?.prefs?.read_preference(/datum/preference/choiced/atypical_tastes)]
@@ -33,8 +33,16 @@ GLOBAL_LIST_INIT(possible_quirk_atypical_tastes, list(
 		to_chat(human_holder, span_warning("As you seem to lack a tongue and thus ability to taste food, the [name] quirk has been disabled."))
 		return
 
-	holder_tongue.liked_foodtypes = desired_taste_copier.liked_foodtypes
-	holder_tongue.disliked_foodtypes = desired_taste_copier.disliked_foodtypes
-	holder_tongue.toxic_foodtypes = desired_taste_copier.toxic_foodtypes
-	holder_tongue.sense_of_taste = desired_taste_copier.sense_of_taste
+	if(client_source?.prefs?.read_preference(/datum/preference/toggle/tongue_replacement))
+		var/obj/item/organ/tongue/new_tongue = new desired_taste_copier()
+		new_tongue.Insert(human_holder, special = TRUE)
+		holder_tongue.moveToNullspace()
+		if(ishemophage(human_holder))
+			new_tongue.AddComponent(/datum/component/organ_corruption/tongue, time_to_corrupt = 0)
+		STOP_PROCESSING(SSobj, holder_tongue)
+	else
+		holder_tongue.liked_foodtypes = desired_taste_copier.liked_foodtypes
+		holder_tongue.disliked_foodtypes = desired_taste_copier.disliked_foodtypes
+		holder_tongue.toxic_foodtypes = desired_taste_copier.toxic_foodtypes
+		holder_tongue.sense_of_taste = desired_taste_copier.sense_of_taste
 	medical_record_text = "Patient exhibits atypical mutation in taste receptors."

--- a/modular_doppler/modular_quirks/atypical_tastes/code/preferences.dm
+++ b/modular_doppler/modular_quirks/atypical_tastes/code/preferences.dm
@@ -18,3 +18,18 @@
 
 /datum/preference/choiced/atypical_tastes/apply_to_human(mob/living/carbon/human/target, value)
 	return
+
+/datum/preference/toggle/tongue_replacement
+	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
+	savefile_key = "tongue_replacement"
+	savefile_identifier = PREFERENCE_CHARACTER
+	default_value = FALSE
+
+/datum/preference/toggle/tongue_replacement/apply_to_human(mob/living/carbon/human/target, value)
+	return
+
+/datum/preference/toggle/tongue_replacement/is_accessible(datum/preferences/preferences)
+	if (!..(preferences))
+		return FALSE
+
+	return "Atypical Tastes" in preferences.all_quirks

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/atypical_taster.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/atypical_taster.tsx
@@ -1,7 +1,17 @@
-import { FeatureChoiced } from '../base';
+import {
+  CheckboxInput,
+  type FeatureChoiced,
+  type FeatureToggle,
+} from '../base';
 import { FeatureDropdownInput } from '../dropdowns';
 
 export const atypical_tastes: FeatureChoiced = {
   name: 'Atypical Tastes',
   component: FeatureDropdownInput,
+};
+
+export const tongue_replacement: FeatureToggle = {
+  name: 'Replace Tongue',
+  description: 'Replaces your tongue with the selected tongue.',
+  component: CheckboxInput,
 };


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a toggle box component to Atypical tastes that lets it fully replace your tongue rather than just give you different tastes. It has a function to instantly corrupt for hemophages as well!
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Hemophage Tiziransssss can now ssssspeak ssssibilantly.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Testing Evidence
Tested it, it works on my local.
<!-- Provide proof that the content added, edited, or removed by this pull request is working as intended in-game. Compiling alone doesn't guarantee functionality, so be sure to test thoroughly! -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added an option for Atypical Tastes to replace your tongue entirely.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
