### PR TITLE
partial suture replacement

### DIFF
--- a/modular_doppler/deforest_medical_items/code/storage_items.dm
+++ b/modular_doppler/deforest_medical_items/code/storage_items.dm
@@ -155,7 +155,7 @@
 		/obj/item/reagent_containers/hypospray/medipen/deforest/meridine = 1,
 		/obj/item/reagent_containers/hypospray/medipen/deforest/morpital = 1,
 		/obj/item/stack/medical/ointment = 1,
-		/obj/item/stack/medical/suture = 1,
+		/obj/item/stack/medical/bruise_pack = 1,
 		/obj/item/stack/medical/suture/coagulant = 1,
 		/obj/item/stack/medical/gauze/sterilized = 1,
 		/obj/item/storage/pill_bottle/painkiller = 1,

--- a/modular_doppler/modular_medical/code/medkit.dm
+++ b/modular_doppler/modular_medical/code/medkit.dm
@@ -1,3 +1,30 @@
+/obj/item/storage/medkit/regular/PopulateContents()
+	if(empty)
+		return
+	var/static/items_inside = list(
+		/obj/item/stack/medical/gauze = 1,
+		/obj/item/stack/medical/bruise_pack = 1,
+		/obj/item/storage/box/bandages = 1,
+		/obj/item/stack/medical/mesh = 1,
+		/obj/item/stack/medical/ointment = 1,
+		/obj/item/reagent_containers/hypospray/medipen = 1,
+		/obj/item/healthanalyzer/simple = 1,
+	)
+	generate_items_inside(items_inside,src)
+
+/obj/item/storage/medkit/emergency/PopulateContents()
+	if(empty)
+		return
+	var/static/items_inside = list(
+		/obj/item/healthanalyzer/simple = 1,
+		/obj/item/stack/medical/gauze = 1,
+		/obj/item/storage/box/bandages = 1,
+		/obj/item/stack/medical/ointment = 1,
+		/obj/item/reagent_containers/hypospray/medipen/ekit = 2,
+		/obj/item/storage/pill_bottle/iron = 1,
+	)
+	generate_items_inside(items_inside,src)
+
 /obj/item/storage/backpack/duffelbag/science/synth_treatment_kit
 	name = "synthetic treatment kit"
 	desc = "A \"surgical\" duffel bag containing everything you need to treat the worst and <i>best</i> of inorganic wounds."


### PR DESCRIPTION
## About The Pull Request

replaces sutures in "basic" medkits with bruise packs and band-aids

## Why It's Good For The Game

sutures are a somewhat advanced medical item, and it doesn't really make much sense for random greyshirts to suture their own wounds - people complained about it on discord and i agree, so i have decided to do it myself

## Testing Evidence

<img width="584" height="180" alt="image" src="https://github.com/user-attachments/assets/50a64638-cfc8-44b7-90c3-a70b2f9b463e" />


## Changelog

:cl:
add: Added bruise packs, bandages and ointment to basic, emergency and frontier medkits.
del: Removed sutures from basic, emergency and frontier medkits. Removed one mesh from basic medkit.
balance: Emergency medkit gets a full box of bandages instead of a singular bandage.
/:cl: