### PR TITLE
future support for our coming planetary stations: loosens shipbreaking dock requirements

### DIFF
--- a/modular_doppler/shipbreaking/code/docking_clamp.dm
+++ b/modular_doppler/shipbreaking/code/docking_clamp.dm
@@ -131,7 +131,7 @@
 			temp_docking_port.Destroy(TRUE)
 			return
 		var/area/turf_area = get_area(checked_turf)
-		if(!is_space_or_openspace(checked_turf) || checked_turf.is_blocked_turf(TRUE) || !is_area_nearby_station(turf_area))
+		if(checked_turf.is_blocked_turf(TRUE) || !(turf_area.outdoors))
 			balloon_alert(user, "dock not clear!")
 			new /obj/effect/temp_visual/telegraphing/long_duration(checked_turf)
 			temp_docking_port.Destroy(TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

see title
loosens requirements for a shipbreaking dock, only needing tiles to be open and outdoors, which includes space.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
right now, planetary stations cant have shipbreaking at all, even if they wanted

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: shipbreaking docks have looser requirements and can now be placed anywhere open and "outdoors"
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
