### PR TITLE
Fax machines can announce received faxes over radio, station fax machines do so by default

### DIFF
--- a/code/modules/paperwork/fax.dm
+++ b/code/modules/paperwork/fax.dm
@@ -402,6 +402,7 @@ GLOBAL_VAR_INIT(fax_autoprinting, FALSE)
 /obj/machinery/fax/proc/receive(obj/item/loaded, sender_name)
 	playsound(src, 'sound/machines/printer.ogg', 50, FALSE)
 	INVOKE_ASYNC(src, PROC_REF(animate_object_travel), loaded, "fax_receive", find_overlay_state(loaded, "receive"))
+	announce_fax_arrival(sender_name) // DOPPLER EDIT ADDITION - faxes announce over radio.
 	say("Received correspondence from [sender_name].")
 	history_add("Receive", sender_name)
 	addtimer(CALLBACK(src, PROC_REF(vend_item), loaded), 1.9 SECONDS)

--- a/modular_doppler/fax_improvements/code/fax_radio/areas.dm
+++ b/modular_doppler/fax_improvements/code/fax_radio/areas.dm
@@ -1,0 +1,45 @@
+
+/**
+ * Overrides
+ */
+
+/area
+	/// The type of encryption key faxes start with when loaded into this area, if any.
+	var/obj/item/encryptionkey/fax_encryption_key_type
+
+
+/**
+ * General Station Areas
+ */
+
+/area/station/command
+	fax_encryption_key_type = /obj/item/encryptionkey/headset_com
+
+/area/station/cargo
+	fax_encryption_key_type = /obj/item/encryptionkey/headset_cargo
+
+/area/station/engineering
+	fax_encryption_key_type = /obj/item/encryptionkey/headset_eng
+
+/area/station/medical
+	fax_encryption_key_type = /obj/item/encryptionkey/headset_med
+
+/area/station/science
+	fax_encryption_key_type = /obj/item/encryptionkey/headset_sci
+
+/area/station/security
+	fax_encryption_key_type = /obj/item/encryptionkey/headset_sec
+
+/area/station/service
+	fax_encryption_key_type = /obj/item/encryptionkey/headset_service
+
+
+/**
+ * Special Station Areas
+ */
+
+/area/station/service/lawoffice
+	fax_encryption_key_type = /obj/item/encryptionkey/headset_srvsec
+
+/area/station/medical/psychology
+	fax_encryption_key_type = /obj/item/encryptionkey/headset_srvmed

--- a/modular_doppler/fax_improvements/code/fax_radio/fax.dm
+++ b/modular_doppler/fax_improvements/code/fax_radio/fax.dm
@@ -2,8 +2,8 @@
 /obj/machinery/fax
 	/// Weakref to the encryption key we use for deciding our internal radio channels.
 	var/datum/weakref/encryption_key_ref
-	/// What frequency do we announce over without a key, for subtypes to override.
-	var/default_announcement_frequency = FREQ_COMMON
+	/// What channel do we announce over without a key, for subtypes to override.
+	var/default_announcement_channel = RADIO_CHANNEL_COMMON
 	/// Whether we announce our faxes over radio.
 	var/announce_over_radio = FALSE
 
@@ -58,7 +58,9 @@
 	if(panel_open)
 		var/obj/item/encryptionkey/encryption_key = encryption_key_ref?.resolve()
 		if(encryption_key)
-			. += span_notice("Its key slot is occupied by [encryption_key].")
+			. += span_notice("Its encryption key slot is occupied by [encryption_key].")
+		else
+			. += span_notice("Its encryption key slot is unoccupied.")
 
 	. += span_notice("[EXAMINE_HINT("Right-Click")] with a multitool to turn [announce_over_radio ? "off" : "on"] received faxes being announced over radio.")
 
@@ -67,7 +69,7 @@
 		for(var/channel_name in get_radio_channels())
 			var/channel_span_class = get_radio_span(GLOB.default_radio_channels[channel_name])
 			announcement_channels += "<li><b>[span_class(channel_span_class, channel_name)]</b></li>"
-		. += span_notice("It is currently announcing received faxes to the following frequencies:")
+		. += span_notice("It is currently announcing received faxes on the following frequencies:")
 		. += span_notice("<ul style='display:inline-block; margin: 0; list-style: square;'>[announcement_channels.Join()]</ul>")
 	else
 		. += span_notice("It is not currently announcing received faxes.")

--- a/modular_doppler/fax_improvements/code/fax_radio/fax.dm
+++ b/modular_doppler/fax_improvements/code/fax_radio/fax.dm
@@ -1,0 +1,125 @@
+
+/obj/machinery/fax
+	/// Weakref to the encryption key we use for deciding our internal radio channels.
+	var/datum/weakref/encryption_key_ref
+	/// What frequency do we announce over without a key, for subtypes to override.
+	var/default_announcement_frequency = FREQ_COMMON
+	/// Whether we announce our faxes over radio.
+	var/announce_over_radio = FALSE
+
+/obj/machinery/fax/Initialize(mapload)
+	. = ..()
+	if(mapload)
+		set_mapload_radio()
+
+/obj/machinery/fax/Destroy()
+	QDEL_NULL(encryption_key_ref)
+	return ..()
+
+/obj/machinery/fax/attack_hand_secondary(mob/user, list/modifiers)
+	var/obj/item/encryptionkey/encryption_key = encryption_key_ref?.resolve()
+	if(encryption_key)
+		user.put_in_hands(encryption_key)
+		encryption_key_ref = null
+		playsound(src, 'sound/machines/click.ogg', 50, TRUE)
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+	return ..()
+
+/obj/machinery/fax/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(istype(tool, /obj/item/encryptionkey))
+		return encryption_key_act(user, tool)
+	return ..()
+
+/obj/machinery/fax/multitool_act_secondary(mob/living/user, obj/item/tool)
+	announce_over_radio = !announce_over_radio
+	balloon_alert(user, "radio [announce_over_radio ? "on": "off"]")
+	playsound(src, 'sound/machines/click.ogg', 50, TRUE)
+	return ITEM_INTERACT_SUCCESS
+
+/obj/machinery/fax/add_context(atom/source, list/context, obj/item/held_item, mob/user)
+	. = ..()
+	if(isnull(held_item))
+		var/obj/item/encryptionkey/encryption_key = encryption_key_ref?.resolve()
+		if(encryption_key)
+			context[SCREENTIP_CONTEXT_RMB] = "Remove encryption key"
+			return CONTEXTUAL_SCREENTIP_SET
+		return .
+
+	if(held_item?.tool_behaviour == TOOL_MULTITOOL)
+		context[SCREENTIP_CONTEXT_RMB] = "Turn [announce_over_radio ? "off" : "on"] radio messages"
+		return CONTEXTUAL_SCREENTIP_SET
+	if(istype(held_item, /obj/item/encryptionkey))
+		var/obj/item/encryptionkey/encryption_key = encryption_key_ref?.resolve()
+		context[SCREENTIP_CONTEXT_LMB] = "[encryption_key ? "Swap" : "Add"] encryption key"
+		return CONTEXTUAL_SCREENTIP_SET
+
+/obj/machinery/fax/examine()
+	. = ..()
+	if(panel_open)
+		var/obj/item/encryptionkey/encryption_key = encryption_key_ref?.resolve()
+		if(encryption_key)
+			. += span_notice("Its key slot is occupied by [encryption_key].")
+
+	. += span_notice("[EXAMINE_HINT("Right-Click")] with a multitool to turn [announce_over_radio ? "off" : "on"] received faxes being announced over radio.")
+
+	if(announce_over_radio)
+		var/list/announcement_channels = list()
+		for(var/channel_name in get_radio_channels())
+			var/channel_span_class = get_radio_span(GLOB.default_radio_channels[channel_name])
+			announcement_channels += "<li><b>[span_class(channel_span_class, channel_name)]</b></li>"
+		. += span_notice("It is currently announcing received faxes to the following frequencies:")
+		. += span_notice("<ul style='display:inline-block; margin: 0; list-style: square;'>[announcement_channels.Join()]</ul>")
+	else
+		. += span_notice("It is not currently announcing received faxes.")
+
+
+
+/// Sets the encryption key and radio based on our current area. Use for mapload.
+/obj/machinery/fax/proc/set_mapload_radio()
+	var/area/current_area = get_area(src)
+	if(isnull(current_area.fax_encryption_key_type))
+		return
+	var/obj/item/encryptionkey/new_key = new current_area.fax_encryption_key_type(src)
+	encryption_key_ref = WEAKREF(new_key)
+	announce_over_radio = TRUE
+
+/// Handles interacting with this fax machine using an encryption key.
+/obj/machinery/fax/proc/encryption_key_act(mob/living/user, obj/item/encryptionkey/new_key)
+	if(!panel_open)
+		balloon_alert(user, "open panel first!")
+		return ITEM_INTERACT_BLOCKING
+	if(!user.transferItemToLoc(new_key, src, silent = FALSE))
+		balloon_alert(user, "stuck to hands!")
+		return ITEM_INTERACT_BLOCKING
+
+	var/obj/item/encryptionkey/existing_key = encryption_key_ref?.resolve()
+	if(existing_key)
+		user.put_in_hands(existing_key)
+	encryption_key_ref = WEAKREF(new_key)
+	playsound(src, 'sound/machines/click.ogg', 50, TRUE)
+	return ITEM_INTERACT_SUCCESS
+
+/// Gets the list of radio channels to use when announcing a fax.
+/obj/machinery/fax/proc/get_radio_channels()
+	var/obj/item/encryptionkey/encryption_key = encryption_key_ref?.resolve()
+	if(encryption_key)
+		return encryption_key.channels
+	else
+		return list(default_announcement_frequency)
+
+/// Announces the arrival of a fax over AAS, if need be.
+/obj/machinery/fax/proc/announce_fax_arrival(sender_name)
+	if(!announce_over_radio)
+		return
+	var/list/channels = get_radio_channels()
+	aas_config_announce(/datum/aas_config_entry/fax_received, list("SENDER" = sender_name, "FAX" = fax_name), null, channels)
+
+
+
+/datum/aas_config_entry/fax_received
+	name = "Departmental: Fax Received Announcement"
+	announcement_lines_map = list(
+		"Message" = "Fax received from %SENDER at %FAX!")
+	vars_and_tooltips_map = list(
+		"SENDER" = "will be replaced with the Sender's name.",
+		"FAX" = "will be replaced with the Fax Machine's name.")

--- a/modular_doppler/fax_improvements/code/fax_radio/fax.dm
+++ b/modular_doppler/fax_improvements/code/fax_radio/fax.dm
@@ -107,7 +107,7 @@
 	if(encryption_key)
 		return encryption_key.channels
 	else
-		return list(default_announcement_frequency)
+		return list(default_announcement_channel)
 
 /// Announces the arrival of a fax over AAS, if need be.
 /obj/machinery/fax/proc/announce_fax_arrival(sender_name)

--- a/modular_doppler/modular_antagonists/cantina/cantina_items.dm
+++ b/modular_doppler/modular_antagonists/cantina/cantina_items.dm
@@ -106,6 +106,21 @@
 	This one has been customized to block its network-visibility as needed."
 	obj_flags = parent_type::obj_flags | EMAGGED
 	visible_to_network = FALSE
+	default_announcement_channel = RADIO_CHANNEL_SYNDICATE
+	announce_over_radio = TRUE
+
+	/// The radio that we use for broadcasting.
+	var/obj/item/radio/radio
+	/// The type of the radio we use for broadcasting.
+	var/radio_type = /obj/item/radio/headset/syndicate
+
+/obj/machinery/fax/cantina/Initialize(mapload)
+	. = ..()
+	radio = new radio_type(src)
+
+/obj/machinery/fax/cantina/Destroy()
+	QDEL_NULL(radio)
+	return ..()
 
 /obj/machinery/fax/cantina/add_context(atom/source, list/context, obj/item/held_item, mob/user)
 	. = ..()
@@ -116,6 +131,13 @@
 	visible_to_network = !visible_to_network
 	balloon_alert(user, (visible_to_network ? "fax unhidden" : "fax hidden"))
 	return CLICK_ACTION_SUCCESS
+
+/obj/machinery/fax/cantina/announce_fax_arrival(sender_name)
+	if(!announce_over_radio)
+		return
+	var/announcement_message = "Fax received from [sender_name] at #!@%ERR-34%2 CANNOT LOCAT@#!"
+	for(var/channel in get_radio_channels())
+		radio.talk_into(src, announcement_message, channel, null)
 
 
 /*

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6999,6 +6999,8 @@
 #include "modular_doppler\epic_loot\code\loot_structures\wall_jackets.dm"
 #include "modular_doppler\epic_loot\code\storage_containers\containers.dm"
 #include "modular_doppler\examinemore\code\examine_more.dm"
+#include "modular_doppler\fax_improvements\code\fax_radio\areas.dm"
+#include "modular_doppler\fax_improvements\code\fax_radio\fax.dm"
 #include "modular_doppler\flavortext_and_records\code\defines.dm"
 #include "modular_doppler\flavortext_and_records\code\examine.dm"
 #include "modular_doppler\flavortext_and_records\code\flavor_text.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Inspired by an Iris station feature, but coded entirely from scratch.
This implementation uses encryption keys to determine the radio channels used, defaulting to common if none, and It can be toggled on/off with a multitool.
Station fax machines pick an encryption key based on the area, and toggle themselves on automatically. SR agents and psychologists get theirs broadcasted to both departments they're under, while command only gets it on command radio.

It may be worth announcing head of staff faxes to their departments as well depending on how this pans out, but this seems better right now.

The cantina fax machine gets its own special announcement radio so it can announce over the undisclosed radio and doesn't need to go through the crew announcements system.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It's incredibly super very easy to miss a fax.
This avoids that! AND lets you turn it off, or change it, or steal the key from the fax.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Testing Evidence

<img width="638" height="319" alt="image" src="https://github.com/user-attachments/assets/5d3bd486-cb57-44d1-927d-d55c88c5fec6" />
<img width="580" height="46" alt="image" src="https://github.com/user-attachments/assets/f57322e0-6b81-4c04-a169-8651b052d73a" />


<!-- Provide proof that the content added, edited, or removed by this pull request is working as intended in-game. Compiling alone doesn't guarantee functionality, so be sure to test thoroughly! -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Fax machines can now be made to announce received faxes over radio using a multitool, and an encryption key can change the channels.
add: Station fax machines announce received faxes over departmental radio by default.
add: The cantina fax announces its faxes over undisclosed radio.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
