### PR TITLE
adds hemophage food recipes to the food crafting list

### DIFF
--- a/code/_globalvars/lists/crafting.dm
+++ b/code/_globalvars/lists/crafting.dm
@@ -20,6 +20,7 @@ GLOBAL_LIST_INIT(crafting_category_food, list(
 	CAT_SPAGHETTI,
 	CAT_ICE,
 	CAT_DRINK,
+	CAT_HEMOPHAGE, // DOPPLER ADDITION - Hemophage food
 ))
 
 GLOBAL_LIST_INIT(crafting_category, list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

see title

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

currently hemophage food is listed among regular crafting recipes rather than food recipes

:cl:
fix: hemophage food is now listed with other food recipes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
