### PR TITLE
Of Stars and Luminescence | Slime Subspecies Quirks

### DIFF
--- a/modular_doppler/modular_quirks/luminescent/luminescent_quirk.dm
+++ b/modular_doppler/modular_quirks/luminescent/luminescent_quirk.dm
@@ -1,0 +1,73 @@
+GLOBAL_LIST_INIT(possible_quirk_extracts, list(
+	"Grey" = /obj/item/slime_extract/grey,
+	"Green" = /obj/item/slime_extract/green,
+	"Cerulean" = /obj/item/slime_extract/cerulean,
+	"Blue" = /obj/item/slime_extract/blue,
+	"Dark Blue" = /obj/item/slime_extract/darkblue,
+	"Purple" = /obj/item/slime_extract/purple,
+	"Dark Purple" = /obj/item/slime_extract/darkpurple,
+	"Orange" = /obj/item/slime_extract/orange,
+	"Yellow" = /obj/item/slime_extract/yellow,
+	"Red" = /obj/item/slime_extract/red,
+	"Pink" = /obj/item/slime_extract/pink,
+	"Light Pink" = /obj/item/slime_extract/pink,
+	"Black" = /obj/item/slime_extract/black,
+	"Oil" = /obj/item/slime_extract/oil,
+	"Sepia" = /obj/item/slime_extract/sepia,
+	"Bluespace" = /obj/item/slime_extract/bluespace,
+	"Rainbow" = /obj/item/slime_extract/rainbow,
+	"Metal" = /obj/item/slime_extract/metal,
+	"Silver" = /obj/item/slime_extract/silver,
+	"Gold" = /obj/item/slime_extract/gold,
+	"Adamantine" = /obj/item/slime_extract/adamantine,
+	"Pyrite" = /obj/item/slime_extract/pyrite,
+))
+
+/datum/quirk/item_quirk/luminescent
+	name = "Luminescent"
+	desc = "You are more resonant-inclined than the rest of your slimy peers, and gain one slime extract of your choosing. Exclusive to Slimepeople."
+	value = 2
+	icon = FA_ICON_MAGIC
+	gain_text = span_notice("You feel a power welling up within your core.")
+	lose_text = span_warning("The power in your core fades...")
+	medical_record_text = "Patient possesses a unique core."
+	quirk_flags = QUIRK_HUMAN_ONLY
+
+/datum/quirk/item_quirk/luminescent/add_unique(client/client_source)
+	var/mob/living/carbon/human/human_holder = quirk_holder
+	desired_extract = GLOB.possible_quirk_extracts[client_source?.prefs?.read_preference(/datum/preference/choiced/luminescent_extract)]
+		give_item_to_holder(GLOB.possible_quirk_extracts, list(LOCATION_RPOCKET, LOCATION_LPOCKET, LOCATION_BACKPACK, LOCATION_HANDS))
+
+/datum/quirk/item_quirk/luminescent/remove()
+
+var/obj/item/slime_extract/desired_extract
+
+/datum/quirk/luminescent/is_species_appropriate(datum/species/mob_species)
+	if(mob_species != /datum/species/jelly)
+		return FALSE
+	return ..()
+
+/datum/quirk_constant_data/luminescent
+		associated_typepath = /datum/quirk/item_quirk/luminescent
+		customization_options = list(/datum/preference/choiced/luminescent_extract)
+
+/datum/preference/choiced/luminescent_extract
+	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
+	savefile_key = "luminescent_extract"
+	savefile_identifier = PREFERENCE_CHARACTER
+	can_randomize = FALSE
+
+/datum/preference/choiced/luminescent_extract/init_possible_values()
+	return list("Random") + assoc_to_keys(GLOB.possible_quirk_extracts)
+
+/datum/preference/choiced/luminescent_extract/create_default_value()
+	return "Random"
+
+/datum/preference/choiced/luminescent_extract/is_accessible(datum/preferences/preferences)
+	if (!..())
+		return FALSE
+
+	return "Luminescent" in preferences.all_quirks
+
+/datum/preference/choiced/luminescent/apply_to_human(mob/living/carbon/human/target, value)
+	return

--- a/modular_doppler/modular_quirks/luminescent/luminescent_quirk.dm
+++ b/modular_doppler/modular_quirks/luminescent/luminescent_quirk.dm
@@ -33,8 +33,7 @@ GLOBAL_LIST_INIT(possible_quirk_extracts, list(
 	medical_record_text = "Patient possesses a unique core."
 	quirk_flags = QUIRK_HUMAN_ONLY
 	// a variable holding the extract spawned so we can keep track of it
-	var/object/item/slime_extract/spawned_extract
-
+	var/obj/item/slime_extract/spawned_extract
 /datum/quirk/item_quirk/luminescent/add_unique(client/client_source)
 	var/mob/living/carbon/human/human_holder = quirk_holder
 	// fetch the quirk

--- a/modular_doppler/modular_quirks/luminescent/luminescent_quirk.dm
+++ b/modular_doppler/modular_quirks/luminescent/luminescent_quirk.dm
@@ -26,23 +26,27 @@ GLOBAL_LIST_INIT(possible_quirk_extracts, list(
 /datum/quirk/item_quirk/luminescent
 	name = "Luminescent"
 	desc = "You are more resonant-inclined than the rest of your slimy peers, and gain one slime extract of your choosing. Exclusive to Slimepeople."
-	value = 2
+	value = 1
 	icon = FA_ICON_MAGIC
 	gain_text = span_notice("You feel a power welling up within your core.")
 	lose_text = span_warning("The power in your core fades...")
 	medical_record_text = "Patient possesses a unique core."
 	quirk_flags = QUIRK_HUMAN_ONLY
+	// a variable holding the extract spawned so we can keep track of it
+	var/object/item/slime_extract/spawned_extract
 
 /datum/quirk/item_quirk/luminescent/add_unique(client/client_source)
 	var/mob/living/carbon/human/human_holder = quirk_holder
-	desired_extract = GLOB.possible_quirk_extracts[client_source?.prefs?.read_preference(/datum/preference/choiced/luminescent_extract)]
-		give_item_to_holder(GLOB.possible_quirk_extracts, list(LOCATION_RPOCKET, LOCATION_LPOCKET, LOCATION_BACKPACK, LOCATION_HANDS))
+	// fetch the quirk
+	var/extract_path = GLOB.possible_quirk_extracts[client_source.prefs?.read_preference(/datum/preference/choiced/luminescent_extract)]
+	// instantiate it in nullspace
+	spawned_extract = new extract_path()
+	// activate it
+	spawned.extract.activate(quirk_human,quirk_human.dna.species, SLIME_ACTIVATE_MAJOR)
+	// or put in hands
+	give_item_to_holder(spawned_extract, list(LOCATION_RPOCKET, LOCATION_LPOCKET, LOCATION_BACKPACK, LOCATION_HANDS))
 
-/datum/quirk/item_quirk/luminescent/remove()
-
-var/obj/item/slime_extract/desired_extract
-
-/datum/quirk/luminescent/is_species_appropriate(datum/species/mob_species)
+/datum/quirk/item_quirk/luminescent/is_species_appropriate(datum/species/mob_species)
 	if(mob_species != /datum/species/jelly)
 		return FALSE
 	return ..()

--- a/modular_doppler/modular_quirks/luminescent/luminescent_quirk.dm
+++ b/modular_doppler/modular_quirks/luminescent/luminescent_quirk.dm
@@ -31,24 +31,16 @@ GLOBAL_LIST_INIT(possible_quirk_extracts, list(
 	gain_text = span_notice("You feel a power welling up within your core.")
 	lose_text = span_warning("The power in your core fades...")
 	medical_record_text = "Patient possesses a unique core."
-	quirk_flags = QUIRK_HUMAN_ONLY
 	// a variable holding the extract spawned so we can keep track of it
 	var/obj/item/slime_extract/spawned_extract
 /datum/quirk/item_quirk/luminescent/add_unique(client/client_source)
-	var/mob/living/carbon/human/human_holder = quirk_holder
+	if(isjelly(quirk_holder))
 	// fetch the quirk
 	var/extract_path = GLOB.possible_quirk_extracts[client_source.prefs?.read_preference(/datum/preference/choiced/luminescent_extract)]
 	// instantiate it in nullspace
 	spawned_extract = new extract_path()
-	// activate it
-	spawned.extract.activate(quirk_human,quirk_human.dna.species, SLIME_ACTIVATE_MAJOR)
-	// or put in hands
+	// put in hands
 	give_item_to_holder(spawned_extract, list(LOCATION_RPOCKET, LOCATION_LPOCKET, LOCATION_BACKPACK, LOCATION_HANDS))
-
-/datum/quirk/item_quirk/luminescent/is_species_appropriate(datum/species/mob_species)
-	if(mob_species != /datum/species/jelly)
-		return FALSE
-	return ..()
 
 /datum/quirk_constant_data/luminescent
 		associated_typepath = /datum/quirk/item_quirk/luminescent

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7535,6 +7535,7 @@
 #include "modular_doppler\modular_quirks\limping\limping.dm"
 #include "modular_doppler\modular_quirks\limping\preferences.dm"
 #include "modular_doppler\modular_quirks\linguist\linguist.dm"
+#include "modular_doppler\modular_quirks\luminescent\luminescent_quirk.dm"
 #include "modular_doppler\modular_quirks\night_vision\night_vision.dm"
 #include "modular_doppler\modular_quirks\oversized\oversized.dm"
 #include "modular_doppler\modular_quirks\overwrites\equipping.dm"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/dopplershift_preferences/luminescent.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/dopplershift_preferences/luminescent.tsx
@@ -1,0 +1,7 @@
+import { FeatureChoiced } from '../base';
+import { FeatureDropdownInput } from '../dropdowns';
+
+export const luminescent_extract: FeatureChoiced = {
+  name: 'Extract',
+  component: FeatureDropdownInput,
+};


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds two new quirks: Luminescent and Stargazer, each letting you turn into a Slimeperson's respective subspecies, with the former additionally granting the ability to absorb an extract of your choice.

## Why It's Good For The Game

With the in-progress powers update, I figured it'd be fun (and fitting) to allow Slimepeople to start the round with their own unique set of powers that were already present, but not available without Xenobiology. Adds a little extra magic to the setting when the time comes.

## Testing Evidence

TBA

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added two new slime-exclusive quirks.
/:cl: