### PR TITLE
removes weird aggressive spawntext

### DIFF
--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -325,11 +325,6 @@
 		info += span_boldnotice("As this station was initially staffed with a \
 			[CONFIG_GET(flag/jobs_have_minimal_access) ? "full crew, only your job's necessities" : "skeleton crew, additional access may"] \
 			have been added to your ID card.")
-	//DOPPLER EDIT ADDITION START - ALTERNATIVE_JOB_TITLES
-	if(alt_title != title)
-		info += span_warning("Remember that alternate titles are purely for flavor and roleplay.")
-		info += span_warning("Do not use your \"[alt_title]\" alt title as an excuse to forego your duties as a [title].")
-	//DOPPLER EDIT END
 
 	return info
 


### PR DESCRIPTION
## About The Pull Request

players are no longer admonished about ignoring their job duties on spawn

## Why It's Good For The Game

i dont like the way this piece of text be talkin to people. we dont need to shove passive aggressive red text into every spawn. plus this removes a nonmodular edit for free.

## Testing Evidence

i think its safe to guess that this one is fine but just in case i checked the original tg file to make sure nothing was missing

## Changelog

:cl:
fix: removed some unnecessary spawn text
/:cl:
