### PR TITLE
Removes prompt which asks if you're sure you wish to observe

### DIFF
--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -74,8 +74,9 @@
 	if(SSlag_switch.measures[DISABLE_DEAD_KEYLOOP])
 		less_input_message = " - Notice: Observer freelook is currently disabled."
 	// Don't convert this to tgui please, it's way too important
-	var/this_is_like_playing_right = alert(usr, "Are you sure you wish to observe? You will not be able to play this round![less_input_message]", "Observe", "Yes", "No")
-	if(QDELETED(src) || !src.client || this_is_like_playing_right != "Yes")
+/*	var/this_is_like_playing_right = alert(usr, "Are you sure you wish to observe? You will not be able to play this round![less_input_message]", "Observe", "Yes", "No")
+	if(QDELETED(src) || !src.client || this_is_like_playing_right != "Yes")	DOPPLER EDIT CHANGE, remove the observe certainty prompt. observing is free. */
+	if(QDELETED(src) || !src.client)
 		ready = PLAYER_NOT_READY
 		return FALSE
 

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -70,13 +70,17 @@
 		ready = PLAYER_NOT_READY
 		return FALSE
 
+/*	DOPPLER EDIT CHANGE START, remove the observe certainty prompt. observing is free
 	var/less_input_message
 	if(SSlag_switch.measures[DISABLE_DEAD_KEYLOOP])
 		less_input_message = " - Notice: Observer freelook is currently disabled."
 	// Don't convert this to tgui please, it's way too important
-/*	var/this_is_like_playing_right = alert(usr, "Are you sure you wish to observe? You will not be able to play this round![less_input_message]", "Observe", "Yes", "No")
-	if(QDELETED(src) || !src.client || this_is_like_playing_right != "Yes")	DOPPLER EDIT CHANGE, remove the observe certainty prompt. observing is free. */
+	var/this_is_like_playing_right = alert(usr, "Are you sure you wish to observe? You will not be able to play this round![less_input_message]", "Observe", "Yes", "No")
+	if(QDELETED(src) || !src.client || this_is_like_playing_right != "Yes") */
 	if(QDELETED(src) || !src.client)
+/*	DOPPLER EDIT CHANGE END, old code:
+	var/this_is_like_playing_right = alert(usr, "Are you sure you wish to observe? You will not be able to play this round![less_input_message]", "Observe", "Yes", "No")
+	if(QDELETED(src) || !src.client || this_is_like_playing_right != "Yes") */
 		ready = PLAYER_NOT_READY
 		return FALSE
 


### PR DESCRIPTION
## About The Pull Request

Removes this:

<img width="464" height="151" alt="image" src="https://github.com/user-attachments/assets/dbd64292-e292-4c48-a495-8c16efe8fe66" />

## Why It's Good For The Game

Observing is free.

## Testing Evidence

No evidence but I did test it. 😇

## Changelog

:cl:
qol: Removes prompt which asks if you're sure you wish to observe
/:cl: