### PR TITLE
Adds extra regen proc to sleepers to fix appearance issue

### DIFF
--- a/modular_doppler/modular_mob_spawn/code/mob_spawn.dm
+++ b/modular_doppler/modular_mob_spawn/code/mob_spawn.dm
@@ -18,5 +18,6 @@
 // regenerate the appearance at the end of create()
 // as safety to make sure the correct appearance is applied
 /obj/effect/mob_spawn/ghost_role/human/create(mob/mob_possessor, newname)
-	var/mob/living/carbon/human/spawned_mob = ..()
+	. = ..()
+	var/mob/living/carbon/human/spawned_mob = .
 	spawned_mob?.dna.species.regenerate_organs(spawned_mob)

--- a/modular_doppler/modular_mob_spawn/code/mob_spawn.dm
+++ b/modular_doppler/modular_mob_spawn/code/mob_spawn.dm
@@ -15,3 +15,8 @@
 		tgui_alert(target, text)
 		return FALSE
 
+// regenerate the appearance at the end of create()
+// as safety to make sure the correct appearance is applied
+/obj/effect/mob_spawn/ghost_role/human/create(mob/mob_possessor, newname)
+	var/mob/living/carbon/human/spawned_mob = ..()
+	spawned_mob?.dna.species.regenerate_organs(spawned_mob)


### PR DESCRIPTION
## About The Pull Request

calls regenerate_organs() after your blorbo is created to make sure their appearance is correct.

## Why It's Good For The Game

yay markings

## Testing Evidence

after at top before at bottom
<img width="129" height="184" alt="1780244070" src="https://github.com/user-attachments/assets/1923dcc2-d9e4-4430-9020-e14593dc6095" />


## Changelog

:cl:
fix: Body-markings issues with ghost role sleepers is less likely to occur
/:cl:
