### PR TITLE
The Curfew & Sundown Tax Audit

### DIFF
--- a/_maps/doppler/cantina/badguyzone.dmm
+++ b/_maps/doppler/cantina/badguyzone.dmm
@@ -284,7 +284,6 @@
 /obj/item/organ/cyberimp/arm/strongarm{
 	pixel_y = -2
 	},
-/obj/item/organ/cyberimp/chest/spine/atlas,
 /obj/item/organ/cyberimp/arm/toolkit/razor_claws{
 	pixel_y = 4
 	},
@@ -437,17 +436,11 @@
 /area/ruin/space/has_grav/powered/undisclosed_location)
 "gi" = (
 /obj/structure/shelf,
-/obj/item/crowbar/power/syndicate{
-	pixel_y = -4
-	},
-/obj/item/crowbar/power/syndicate,
-/obj/item/screwdriver/power{
-	pixel_y = 4
-	},
-/obj/item/screwdriver/power,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/bot,
+/obj/item/crowbar/red,
+/obj/item/screwdriver/power,
 /turf/open/floor/iron/colony/texture,
 /area/ruin/space/has_grav/powered/undisclosed_location)
 "gp" = (
@@ -1655,7 +1648,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/storage/medkit/surgery_syndie{
-	pixel_y = 6
+	pixel_y = 7
 	},
 /obj/item/lazarus_injector,
 /obj/item/defibrillator/compact/combat/loaded,
@@ -2485,13 +2478,10 @@
 	pixel_x = -4;
 	pixel_y = -5
 	},
-/obj/item/organ/cyberimp/arm/toolkit/gun/laser,
-/obj/item/organ/cyberimp/arm/toolkit/gun/laser{
-	pixel_y = -6
-	},
 /obj/item/organ/cyberimp/arm/toolkit/toolset,
 /obj/structure/shelf,
 /obj/effect/turf_decal/bot,
+/obj/item/organ/cyberimp/chest/spine,
 /turf/open/floor/iron/colony/texture,
 /area/ruin/space/has_grav/powered/undisclosed_location)
 "JX" = (
@@ -2563,7 +2553,6 @@
 	pixel_y = -6
 	},
 /obj/structure/closet/crate/secure/syndicate/mi13,
-/obj/item/minigunpack,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/colony/texture,
 /area/ruin/space/has_grav/powered/undisclosed_location)
@@ -2577,15 +2566,14 @@
 	pixel_x = 8;
 	pixel_y = 13
 	},
-/obj/item/storage/medkit/tactical/premium{
-	pixel_x = 1;
-	pixel_y = -6
+/obj/effect/turf_decal/bot,
+/obj/item/storage/medkit/tactical{
+	pixel_y = -7
 	},
 /obj/item/gun/medbeam{
 	pixel_y = 1;
 	pixel_x = -1
 	},
-/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/colony/texture,
 /area/ruin/space/has_grav/powered/undisclosed_location)
 "LS" = (
@@ -2767,10 +2755,9 @@
 /area/ruin/space/has_grav/powered/undisclosed_location)
 "OB" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/item/storage/box/syndie_kit/cowboy{
+/obj/item/storage/box/syndie_kit/cutouts{
 	pixel_x = -4
 	},
-/obj/item/storage/box/syndie_kit/cutouts,
 /obj/item/storage/box/syndie_kit/combat_baking{
 	pixel_x = 4
 	},
@@ -2779,11 +2766,8 @@
 	pixel_x = -4
 	},
 /obj/item/storage/box/syndie_kit/throwing_weapons{
-	pixel_y = 12
-	},
-/obj/item/storage/box/syndie_kit/rebarxbowsyndie{
-	pixel_x = 4;
-	pixel_y = 12
+	pixel_y = 12;
+	pixel_x = 4
 	},
 /obj/structure/shelf,
 /obj/machinery/light/red/directional/south,
@@ -2859,12 +2843,7 @@
 /obj/item/inducer/syndicate{
 	pixel_y = 9
 	},
-/obj/item/chameleon{
-	pixel_y = -7;
-	pixel_x = 4
-	},
 /obj/item/jammer{
-	pixel_x = -5;
 	pixel_y = -3
 	},
 /turf/open/floor/iron/colony/nanocarbon,
@@ -3074,18 +3053,14 @@
 /obj/structure/shelf,
 /obj/item/storage/box/syndie_kit/chameleon{
 	pixel_y = -3;
-	pixel_x = 7
-	},
-/obj/item/storage/backpack/duffelbag/syndie/c4{
-	pixel_y = 10;
-	pixel_x = -5
-	},
-/obj/item/storage/backpack/duffelbag/syndie/surgery{
-	pixel_y = 6
+	pixel_x = 4
 	},
 /obj/item/storage/box/syndie_kit/chameleon{
-	pixel_y = -11;
-	pixel_x = 3
+	pixel_x = -4;
+	pixel_y = -3
+	},
+/obj/item/storage/backpack/duffelbag/syndie/surgery{
+	pixel_y = 7
 	},
 /turf/open/floor/iron/colony/nanocarbon,
 /area/ruin/space/has_grav/powered/undisclosed_location)
@@ -3254,34 +3229,30 @@
 "Tz" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/clothing/suit/armor/vest/alt{
-	pixel_y = -14;
+	pixel_y = -9;
 	pixel_x = 8
 	},
 /obj/item/clothing/head/helmet{
-	pixel_y = -5;
+	pixel_y = 1;
 	pixel_x = 7
 	},
 /obj/structure/shelf,
 /obj/item/suppressor{
-	pixel_y = 10
-	},
-/obj/item/jammer{
-	pixel_x = -5;
-	pixel_y = 1
+	pixel_y = 13
 	},
 /obj/item/clothing/head/helmet{
-	pixel_y = -5;
+	pixel_y = 1;
 	pixel_x = -1
 	},
 /obj/item/clothing/head/helmet{
-	pixel_y = -5;
+	pixel_y = 1;
 	pixel_x = -9
 	},
 /obj/item/clothing/suit/armor/vest/alt{
-	pixel_y = -14
+	pixel_y = -9
 	},
 /obj/item/clothing/suit/armor/vest/alt{
-	pixel_y = -14;
+	pixel_y = -9;
 	pixel_x = -8
 	},
 /obj/effect/turf_decal/bot,

--- a/_maps/doppler/cantina/badguyzone.dmm
+++ b/_maps/doppler/cantina/badguyzone.dmm
@@ -591,8 +591,15 @@
 	pixel_x = 1;
 	pixel_y = -1
 	},
-/obj/item/multitool,
 /obj/effect/decal/cleanable/cobweb,
+/obj/item/storage/toolbox/mechanical{
+	has_latches = 0;
+	latches = "quad_latch";
+	name = "evil fucked up toolbox";
+	desc = "Why in the world does it have four latches?";
+	pixel_y = -8;
+	pixel_x = 4
+	},
 /turf/open/floor/iron/colony/texture,
 /area/ruin/space/has_grav/powered/undisclosed_location)
 "iy" = (
@@ -602,13 +609,20 @@
 /area/ruin/space/has_grav/powered/undisclosed_location)
 "iD" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/toolbox/mechanical{
-	has_latches = 0;
-	latches = "quad_latch";
-	name = "evil fucked up toolbox";
-	desc = "Why in the world does it have four latches?";
+/obj/item/wrench/combat{
 	pixel_y = 17;
-	pixel_x = -2
+	pixel_x = -8
+	},
+/obj/item/wrench/combat{
+	pixel_y = 10;
+	pixel_x = -11
+	},
+/obj/item/multitool{
+	pixel_y = 8;
+	pixel_x = 8
+	},
+/obj/item/multitool{
+	pixel_y = 9
 	},
 /obj/item/storage/belt/utility,
 /obj/item/storage/belt/utility{
@@ -862,6 +876,7 @@
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/blood/oil,
 /obj/structure/frame/machine/secured,
+/obj/item/circuitboard/machine/ore_silo,
 /turf/open/floor/iron/colony/texture,
 /area/ruin/space/has_grav/powered/undisclosed_location)
 "np" = (
@@ -2530,6 +2545,12 @@
 	pixel_x = -3;
 	pixel_y = -10
 	},
+/obj/item/storage/belt/holster{
+	pixel_x = 2
+	},
+/obj/item/storage/belt/holster{
+	pixel_y = -6
+	},
 /turf/open/floor/iron/colony/texture,
 /area/ruin/space/has_grav/powered/undisclosed_location)
 "KO" = (
@@ -2959,13 +2980,6 @@
 /area/ruin/space/has_grav/powered/undisclosed_location)
 "Qs" = (
 /obj/effect/turf_decal/bot,
-/obj/item/stack/sheet/iron/fifty{
-	pixel_y = 10
-	},
-/obj/item/stack/sheet/glass/fifty{
-	pixel_y = 6;
-	pixel_x = 3
-	},
 /turf/open/floor/iron/colony/texture,
 /area/ruin/space/has_grav/powered/undisclosed_location)
 "Qz" = (
@@ -3146,24 +3160,20 @@
 /turf/open/floor/plating/nanocarbon,
 /area/ruin/space/has_grav/powered/undisclosed_location)
 "SE" = (
-/obj/structure/shelf,
-/obj/item/storage/belt/holster{
-	pixel_x = 2
-	},
-/obj/item/storage/belt/holster{
-	pixel_y = -6
-	},
-/obj/item/wrench/combat{
-	pixel_y = 10;
-	pixel_x = -7
-	},
-/obj/item/multitool/ai_detect{
-	pixel_x = 7
-	},
-/obj/item/suppressor{
-	pixel_y = -6
-	},
-/obj/item/wrench/combat,
+/obj/structure/closet/crate/cargo,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/cloth/ten,
+/obj/item/stack/sheet/leather/five,
+/obj/item/stack/sheet/mineral/gold/fifty,
+/obj/item/stack/sheet/mineral/plasma/fifty,
+/obj/item/stack/sheet/mineral/titanium/fifty,
+/obj/item/stack/sheet/mineral/uranium/fifty,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/stack/sheet/mineral/silver/fifty,
+/obj/item/stack/sheet/mineral/diamond/fifty,
+/obj/item/stack/sheet/mineral/bananium/five,
+/obj/item/stack/sheet/bluespace_crystal/fifty,
 /turf/open/floor/iron/colony/nanocarbon,
 /area/ruin/space/has_grav/powered/undisclosed_location)
 "SF" = (
@@ -3257,6 +3267,9 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/light/red/directional/north,
+/obj/item/suppressor{
+	pixel_y = 11
+	},
 /turf/open/floor/iron/colony/texture,
 /area/ruin/space/has_grav/powered/undisclosed_location)
 "TB" = (

--- a/_maps/shuttles/~doppler_shuttles/tiziran_interceptor.dmm
+++ b/_maps/shuttles/~doppler_shuttles/tiziran_interceptor.dmm
@@ -48,7 +48,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/machinery/suit_storage_unit/void_old/jetpack,
+/obj/machinery/suit_storage_unit/industrial/personal_shuttle/heavy,
 /turf/open/floor/plating,
 /area/shuttle/personally_bought/tiziran_interceptor)
 "i" = (
@@ -214,7 +214,7 @@
 	dir = 8
 	},
 /obj/machinery/light/small/red/directional/east,
-/obj/machinery/suit_storage_unit/void_old/jetpack,
+/obj/machinery/suit_storage_unit/industrial/personal_shuttle/heavy,
 /turf/open/floor/plating,
 /area/shuttle/personally_bought/tiziran_interceptor)
 "O" = (

--- a/_maps/shuttles/~doppler_shuttles/tiziran_interceptor.dmm
+++ b/_maps/shuttles/~doppler_shuttles/tiziran_interceptor.dmm
@@ -31,22 +31,24 @@
 /turf/closed/wall/mineral/nanocarbon/nodiagonal/tiziran_bronze,
 /area/shuttle/personally_bought/tiziran_interceptor)
 "g" = (
-/obj/item/ammo_box/magazine/ammo_stack/bolt_slug/full,
-/obj/item/ammo_box/magazine/ammo_stack/bolt_slug/full,
-/obj/item/gun/ballistic/bolt_thrower,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
 /obj/structure/shelf,
-/obj/item/ammo_box/magazine/ammo_stack/bolt_shot/full,
-/obj/item/ammo_box/magazine/ammo_stack/bolt_shot/full,
+/obj/item/storage/box/tiziran_goods,
+/obj/item/storage/box/tiziran_meats{
+	pixel_y = 3
+	},
+/obj/item/storage/box/tiziran_cans{
+	pixel_y = -5
+	},
 /turf/open/floor/plating,
 /area/shuttle/personally_bought/tiziran_interceptor)
 "h" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/machinery/suit_storage_unit/tiziran_raiders,
+/obj/machinery/suit_storage_unit/void_old/jetpack,
 /turf/open/floor/plating,
 /area/shuttle/personally_bought/tiziran_interceptor)
 "i" = (
@@ -211,8 +213,8 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/obj/machinery/suit_storage_unit/tiziran_raiders,
 /obj/machinery/light/small/red/directional/east,
+/obj/machinery/suit_storage_unit/void_old/jetpack,
 /turf/open/floor/plating,
 /area/shuttle/personally_bought/tiziran_interceptor)
 "O" = (

--- a/modular_doppler/modular_uplink/code/dangerous.dm
+++ b/modular_doppler/modular_uplink/code/dangerous.dm
@@ -3,7 +3,7 @@
 	desc = "A sheath carrying a rare Tajaran vibroblade. The oscillation allows the tip to bite through many \
 	substances by the weapon's own weight alone."
 	item = /obj/item/storage/belt/tajaran_sheath/vibro
-	cost = 6
+	cost = 8 // esword but it ignores 75% of armor and has a cool sheath
 	purchasable_from = ~(UPLINK_ALL_SYNDIE_OPS)
 
 /datum/uplink_item/dangerous/bolt_thrower
@@ -29,35 +29,42 @@
 	to achieve such a lengthy blade. Exotic amendments to its constituent alloys allow for keener edge and help alleviate a rare \
 	phenomena where clashed blades in near vacuum can contact weld to one another."
 	item = /obj/item/melee/tizirian_sword/megachoppa
-	cost = 6
+	cost = 5 // weaker than an esword & can't be hidden at all
 	purchasable_from = ~(UPLINK_ALL_SYNDIE_OPS)
 
 /datum/uplink_item/dangerous/saber
 	name = "Saber"
 	desc = "Forged by the artisan clans of the Uz'ka, it's a medium-sized, one-handed weapon that can cut through lightly armored or unarmored foes with utter ease. A staple for every member when going through their rites."
 	item = /obj/item/claymore/cutlass
-	cost = 4
+	cost = 8 // identical to an esword but cool looking
 	purchasable_from = ~(UPLINK_ALL_SYNDIE_OPS)
 
 /datum/uplink_item/dangerous/baseball
 	name = "Ablative Bat"
 	desc = "Specially forged by the highest ranking artisan clans, this bat was given to some of the Zar'Khet to act as vanguards. Used to dispel laser fire more commonly used in hostile lands, it gave a sense of courage and pride to those in the ranks."
 	item = /obj/item/melee/baseball_bat/ablative
-	cost = 6
+	cost = 6 // weaker than an esword but makes you laser immune which is really funny
+	purchasable_from = ~(UPLINK_ALL_SYNDIE_OPS)
+
+/datum/uplink_item/dangerous/minigun
+	name = "Laser Minigun Backpack"
+	desc = "A hefty power-pack that comes with a linked laser minigun capable of outputting a terrifying volley of firepower in full-auto. The power-pack must be worn on your back to be utilized properly, and the minigun may need time to cool after overheating."
+	item = /obj/item/minigunpack
+	cost = 8 // can't exactly hide it and it has some clear downsides
 	purchasable_from = ~(UPLINK_ALL_SYNDIE_OPS)
 
 /datum/uplink_item/dangerous/shrink_ray
 	name = "Shrink Ray"
 	desc = "This is a piece of frightening Grey tech that enhances the magnetic pull of atoms in a localized space to temporarily make an object shrink. Great for break-ins, or cutting a foe down to size. "
 	item = /obj/item/gun/energy/shrink_ray/thinktank
-	cost = 18 // free instant passage through walls & makes an opponent drop literally all of their stuff when hit
+	cost = 16 // free instant passage through walls & makes an opponent drop literally all of their stuff when hit
 	purchasable_from = ~(UPLINK_ALL_SYNDIE_OPS)
 
 /datum/uplink_item/dangerous/spikeroach_nade
 	name = "Spike Synthroach Greande"
 	desc = "Synthroaches are the remnants of old bio-synth weapons. A few survived the end of their war and the clean-up efforts, and evolved into pests that are ubiquitous on most ships. This grenade is full of 'spikeroaches', synth-roaches that were once fearsome self-detonating drones and are now...still self-detonating drones."
 	item = /obj/item/grenade/spawnergrenade/spikeroach
-	cost = 6
+	cost = 5
 	purchasable_from = ~(UPLINK_ALL_SYNDIE_OPS)
 
 /datum/uplink_item/dangerous/n20_rock

--- a/modular_doppler/modular_uplink/code/device_tools.dm
+++ b/modular_doppler/modular_uplink/code/device_tools.dm
@@ -18,3 +18,6 @@
 	item = /obj/item/reagent_containers/hypospray/medipen/survival/luxury
 	cost = 1 // takes ages to use in-pressure because of the release, so it's cheap
 	purchasable_from = ~(UPLINK_ALL_SYNDIE_OPS)
+
+/datum/uplink_item/device_tools/encryptionkey
+	cost = 6 // i'm sorry, little one

--- a/modular_doppler/modular_uplink/code/stealthy.dm
+++ b/modular_doppler/modular_uplink/code/stealthy.dm
@@ -4,7 +4,8 @@
 		but gain untold hand-to-hand combat prowess, immunity to being in critical condition, and generally become rather difficult to kill."
 	item = /obj/item/book/granter/martial/mad_dog
 	progression_minimum = 30 MINUTES
-	cost = 13 // offers decent hand to hand combos and resistance to one stun while in combat but you can still get shot & can't use guns
+	population_minimum = TRAITOR_POPULATION_LOWPOP // same as scarp
+	cost = 12 // offers decent hand to hand combos and resistance to one stun while in combat but you can still get shot & can't use guns
 	surplus = 0
 	purchasable_from = UPLINK_TRAITORS | UPLINK_SPY
 

--- a/modular_doppler/modular_uplink/code/suits.dm
+++ b/modular_doppler/modular_uplink/code/suits.dm
@@ -18,7 +18,7 @@
 	desc = "A relatively affordable suit originally issued to Imperial Tiziran forces. The wide availability \
 	of surplus units has led to their broad adoption by irregular Tiziran forces and even criminal enterprise."
 	item = /obj/item/mod/control/pre_equipped/raider
-	cost = 8
+	cost = 10 // direct upgrade from the syndie MOD in both armor and modules
 	purchasable_from = ~(UPLINK_ALL_SYNDIE_OPS)
 
 /datum/uplink_item/suits/jetpack_harness

--- a/modular_doppler/modular_uplink/code/uplink.dm
+++ b/modular_doppler/modular_uplink/code/uplink.dm
@@ -1,3 +1,0 @@
-/datum/antagonist/traitor/cantinoid/on_gain()
-	. = ..()
-	uplink_handler.add_telecrystals(10)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7667,7 +7667,6 @@
 #include "modular_doppler\modular_uplink\code\kit_tactical.dm"
 #include "modular_doppler\modular_uplink\code\stealthy.dm"
 #include "modular_doppler\modular_uplink\code\suits.dm"
-#include "modular_doppler\modular_uplink\code\uplink.dm"
 #include "modular_doppler\modular_uplink\code\uplink_kits.dm"
 #include "modular_doppler\modular_vending\code\_vending.dm"
 #include "modular_doppler\modular_vending\code\doppler_vendors\de_forest\vendor.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR cuts down on the volume of free "gimmes" that the Curfew & Sundown has available.
To be more specific, it:
- Lowers the Cantina Regular & Bartender TC count to 20
- Moves the minigun backpack from free to 8TC
- Makes the Mad Dog's Style have the same minimum pop requirement as Sleeping Carp
- Replaces the Atlas spinal implant with the standard version
- Replaces the free nukie premium medkit with the standard tactical medkit
- Removes the free chameleon device, one of the two free radio jammers, cowboy kit w/ magnum, rebar crossbow kit, free jaws of life, and both of the free laser gun implants
- Raises & lowers the TC value of some items in the uplink (most importantly, the all-comms encryption key is now 6TC)
- Removes the free raider MODsuits and bolt-thrower from one of the shuttle options (you can still buy these)

Everything else remains, including the laser carbines/disabler SMGs/armor/chameleon kits/smartguns/all of the cybernetics

Also adds a crate full of standard materials + an ore silo board to the cantina, just to ensure they don't need to steal boulders to get mats & to hint at what the machine frame is good for

## Why It's Good For The Game

While nobody can say no to free stuff, the sheer volume of free options made it a little easy for people playing the badguy to load up on a ludicrous volume of gear, from spending a slight sliver of their tc to access every one of the station's comms to having free .357 magnums, raider MODsuits, rebar bows, and more. This retains the feeling of the Curfew & Sundown having a stockpile of gear while still ensuring antags have to pick and choose their equipment a _little_ more carefully.

## Testing Evidence

<img width="1444" height="1121" alt="image" src="https://github.com/user-attachments/assets/aff3c546-f977-4ada-a00f-687086dc43d8" />
<img width="785" height="67" alt="image" src="https://github.com/user-attachments/assets/c15900c2-4778-4230-b664-141f9bc49705" />

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Cantina Regulars & Bartenders have a default 20 telecrystals to spend again
balance: The Curfew & Sundown has received an audit and has less free equipment available
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
