### PR TITLE
makes modsuit gun holster modules unprintable

### DIFF
--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -2470,7 +2470,7 @@
 		RND_CATEGORY_MODSUIT_MODULES + RND_SUBCATEGORY_MODSUIT_MODULES_ENGINEERING
 	)
 
-/datum/design/module/mod_holster
+/* /datum/design/module/mod_holster // DOPPLER REMOVAL - Unprintable holster modules
 	name = "Holster Module"
 	id = "mod_holster"
 	materials = list(
@@ -2480,7 +2480,7 @@
 	build_path = /obj/item/mod/module/holster
 	category = list(
 		RND_CATEGORY_MODSUIT_MODULES + RND_SUBCATEGORY_MODSUIT_MODULES_SECURITY
-	)
+	) */
 
 /datum/design/module/mod_sonar
 	name = "Active Sonar Module"

--- a/code/modules/research/techweb/nodes/modsuit_nodes.dm
+++ b/code/modules/research/techweb/nodes/modsuit_nodes.dm
@@ -93,7 +93,7 @@
 		"mod_stealth",
 		"mod_mag_harness",
 		"mod_pathfinder",
-		"mod_holster",
+		// "mod_holster", // DOPPLER REMOVAL - Unprintable holsters
 		"mod_sonar",
 		"mod_projectile_dampener",
 		"mod_criminalcapture",


### PR DESCRIPTION
## About The Pull Request

see title

## Why It's Good For The Game

For much the same reason as we just denied letting the sword holster module be printable, letting the crew pull an entire rifle out of their ass doesn't fit with the design well.

## Changelog

:cl:
balance: modsuit holster modules are no longer printable in exofabs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
