### PR TITLE
adds the trauma that makes you randomly get hypnotized to the traumatized quirk

### DIFF
--- a/modular_doppler/_HELPERS/preferences.dm
+++ b/modular_doppler/_HELPERS/preferences.dm
@@ -53,4 +53,5 @@ GLOBAL_LIST_INIT(quirk_trauma_choice, list(
 	"Muscle Weakness" = /datum/brain_trauma/mild/muscle_weakness,
 	"Muscle Spasms" = /datum/brain_trauma/mild/muscle_spasms,
 	"Nervous cough" = /datum/brain_trauma/mild/nervous_cough,
+	"Hypnotic Stupor" = /datum/brain_trauma/severe/hypnotic_stupor,
 ))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

see title

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I was going to use this for a character but never realized that it's a curated list of traumas before, the funniest possible thing that happens with this is someone says KILL ~~JOHN LENNON~~ THE CAPTAIN at just the wrong moment with this.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: the traumatized quirk now allows the "hypnotic stupor" trauma, which makes you randomly susceptible to getting hypnotized by anything
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
