### PR TITLE
gives jetpacks back JUST their brake force

### DIFF
--- a/modular_doppler/modular_balancing/jetpacks.dm
+++ b/modular_doppler/modular_balancing/jetpacks.dm
@@ -5,7 +5,7 @@
 /obj/item/tank/jetpack
 	full_speed = FALSE
 	drift_force = 0.25 NEWTONS
-	stabilizer_force = 0.2 NEWTONS
+	stabilizer_force = 1.0 NEWTONS
 
 /obj/item/tank/jetpack/improvised
 	drift_force = 0.2 NEWTONS
@@ -13,13 +13,13 @@
 
 /obj/item/tank/jetpack/oxygen/captain
 	drift_force = 0.5 NEWTONS
-	stabilizer_force = 0.5 NEWTONS
+	stabilizer_force = 1.0 NEWTONS
 
 /obj/item/mod/module/jetpack
 	active_power_cost = DEFAULT_CHARGE_DRAIN * 0.1
 	drift_force = 0.25 NEWTONS
-	stabilizer_force = 0.2 NEWTONS
+	stabilizer_force = 1.0 NEWTONS
 
 /obj/item/mod/module/jetpack/advanced
 	drift_force = 0.5 NEWTONS
-	stabilizer_force = 0.5 NEWTONS
+	stabilizer_force = 1.0 NEWTONS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

see title

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

having really low braking force makes combat awkward in space, which was the idea, but it also makes any kind of precise EVA work at all really annoying too, which is a bigger problem than any theoretical fight in space is

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Testing Evidence

<!-- Provide proof that the content added, edited, or removed by this pull request is working as intended in-game. Compiling alone doesn't guarantee functionality, so be sure to test thoroughly! -->

:cl:
qol: jetpacks have braking force greater than their thruster power again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
