### PR TITLE
Smuggling quirk no longer spams bitrunner's sec records.

### DIFF
--- a/modular_doppler/underworld_connections/underworld_connections_quirk.dm
+++ b/modular_doppler/underworld_connections/underworld_connections_quirk.dm
@@ -59,6 +59,8 @@
 /datum/quirk/item_quirk/underworld_connections/remove()
 	if (ishuman(quirk_holder))
 		var/mob/living/carbon/human/human_holder = quirk_holder
+		if(HAS_TRAIT(human_holder, TRAIT_BITRUNNER_AVATAR))
+			return
 		var/datum/record/crew/our_record = find_record(human_holder.name)
 		if (isnull(our_record))
 			return

--- a/modular_doppler/underworld_connections/underworld_connections_quirk.dm
+++ b/modular_doppler/underworld_connections/underworld_connections_quirk.dm
@@ -49,6 +49,8 @@
 	// Set us as 'suspected' on HUDs at roundstart and leave a note about our dark and mysterious past. No permits for us! If we're human.
 	if (ishuman(quirk_holder))
 		var/mob/living/carbon/human/human_holder = quirk_holder
+		if(HAS_TRAIT(human_holder, TRAIT_BITRUNNER_AVATAR))
+			return
 		var/datum/record/crew/our_record = find_record(human_holder.name)
 		if (our_record)
 			our_record.wanted_status = WANTED_SUSPECT


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #1053. Adds a check to make sure the person taking the smuggler quirk isn't a bitrunner avatar, meaning it won't spam bitrunner's records if they use the personalized avatar to make their avatar themselves.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
N/A
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Testing Evidence
Works.
<!-- Provide proof that the content added, edited, or removed by this pull request is working as intended in-game. Compiling alone doesn't guarantee functionality, so be sure to test thoroughly! -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Bitrunners using a personalized avatar alongside the Black Market Smuggler quirk no longer spam sec records.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
