### PR TITLE
adds a 2-point power to make Phantasmal Tool into a Presti-like cantrip

### DIFF
--- a/modular_doppler/modular_powers/code/powers/sorcerous/thaumaturge/phantasmal_mastery.dm
+++ b/modular_doppler/modular_powers/code/powers/sorcerous/thaumaturge/phantasmal_mastery.dm
@@ -13,6 +13,10 @@
 		tool_action.power_refunds = FALSE
 		tool_action.required_affinity = 3
 		tool_action.enable()
+		var/atom/movable/ui_element = tool_action.get_atom_moveable()
+		if(ui_element && tool_action.charge_overlay)
+    		ui_element.cut_overlay(tool_action.charge_overlay)
+    		tool_action.charge_overlay = null
 
 /datum/power/thaumaturge/phantasmal_mastery/remove()
 	. = ..()

--- a/modular_doppler/modular_powers/code/powers/sorcerous/thaumaturge/phantasmal_mastery.dm
+++ b/modular_doppler/modular_powers/code/powers/sorcerous/thaumaturge/phantasmal_mastery.dm
@@ -4,14 +4,14 @@
 	value = 2
 	required_powers = list(/datum/power/thaumaturge/phantasmal_tool)
 
-/datum/power/psyker_power/telepathy_area/post_add()
+/datum/power/thaumaturge/phantasmal_mastery/post_add()
 	. = ..()
 	var/datum/power/thaumaturge/phantasmal_tool/tool_power = power_holder.get_power(/datum/power/thaumaturge/phantasmal_tool)
 	var/datum/action/cooldown/power/thaumaturge/phantasmal_tool/tool_action = tool_power?.action_path
 	if(tool_action)
 		tool_action.max_charges = 0
 
-/datum/power/psyker_power/telepathy_area/remove()
+/datum/power/thaumaturge/phantasmal_mastery/remove()
 	. = ..()
 	var/datum/power/thaumaturge/phantasmal_tool/tool_power = power_holder.get_power(/datum/power/thaumaturge/phantasmal_tool)
 	var/datum/action/cooldown/power/thaumaturge/phantasmal_tool/tool_action = tool_power?.action_path

--- a/modular_doppler/modular_powers/code/powers/sorcerous/thaumaturge/phantasmal_mastery.dm
+++ b/modular_doppler/modular_powers/code/powers/sorcerous/thaumaturge/phantasmal_mastery.dm
@@ -1,6 +1,6 @@
 /datum/power/thaumaturge/phantasmal_mastery
 	name = "Phantasmal Tool Mastery"
-	desc = "Your experience with the Phantasmal Tool spell allows it to be cast without needing charges, though it now requires Affinity in order 3 to cast."
+	desc = "Your experience with the Phantasmal Tool spell allows it to be cast without needing charges, though it now requires Affinity in order 3 to be cast."
 	value = 3
 	required_powers = list(/datum/power/thaumaturge/phantasmal_tool)
 

--- a/modular_doppler/modular_powers/code/powers/sorcerous/thaumaturge/phantasmal_mastery.dm
+++ b/modular_doppler/modular_powers/code/powers/sorcerous/thaumaturge/phantasmal_mastery.dm
@@ -10,6 +10,7 @@
 	var/datum/action/cooldown/power/thaumaturge/phantasmal_tool/tool_action = tool_power?.action_path
 	if(tool_action)
 		tool_action.max_charges = 0
+		tool_action.power_refunds = FALSE
 
 /datum/power/thaumaturge/phantasmal_mastery/remove()
 	. = ..()

--- a/modular_doppler/modular_powers/code/powers/sorcerous/thaumaturge/phantasmal_mastery.dm
+++ b/modular_doppler/modular_powers/code/powers/sorcerous/thaumaturge/phantasmal_mastery.dm
@@ -1,6 +1,6 @@
 /datum/power/thaumaturge/phantasmal_mastery
 	name = "Phantasmal Tool Mastery"
-	desc = "Your experience with the Phantasmal Tool spell allows its use without needing charges, though it now requires 3 Affinity to cast."
+	desc = "Your experience with the Phantasmal Tool spell allows it to be used without needing charges, though it now requires Affinity 3 to cast."
 	value = 3
 	required_powers = list(/datum/power/thaumaturge/phantasmal_tool)
 

--- a/modular_doppler/modular_powers/code/powers/sorcerous/thaumaturge/phantasmal_mastery.dm
+++ b/modular_doppler/modular_powers/code/powers/sorcerous/thaumaturge/phantasmal_mastery.dm
@@ -15,8 +15,8 @@
 		tool_action.enable()
 		var/atom/movable/ui_element = tool_action.get_atom_moveable()
 		if(ui_element && tool_action.charge_overlay)
-    		ui_element.cut_overlay(tool_action.charge_overlay)
-    		tool_action.charge_overlay = null
+			ui_element.cut_overlay(tool_action.charge_overlay)
+			tool_action.charge_overlay = null
 
 /datum/power/thaumaturge/phantasmal_mastery/remove()
 	. = ..()
@@ -26,3 +26,4 @@
 		tool_action.max_charges = THAUMATURGE_MAX_CHARGES_BASE
 		tool_action.power_refunds = TRUE
 		tool_action.required_affinity = 1
+		tool_action.disable()

--- a/modular_doppler/modular_powers/code/powers/sorcerous/thaumaturge/phantasmal_mastery.dm
+++ b/modular_doppler/modular_powers/code/powers/sorcerous/thaumaturge/phantasmal_mastery.dm
@@ -1,6 +1,6 @@
 /datum/power/thaumaturge/phantasmal_mastery
 	name = "Phantasmal Tool Mastery"
-	desc = "Your experience with the Phantasmal Tool spell allows it to be cast without needing charges, though it now requires Affinity in order 3 to be cast."
+	desc = "Your experience with the Phantasmal Tool spell allows it to be cast without needing charges, though it now requires Affinity 3 in order to be cast."
 	value = 3
 	required_powers = list(/datum/power/thaumaturge/phantasmal_tool)
 
@@ -9,9 +9,10 @@
 	var/datum/power/thaumaturge/phantasmal_tool/tool_power = power_holder.get_power(/datum/power/thaumaturge/phantasmal_tool)
 	var/datum/action/cooldown/power/thaumaturge/phantasmal_tool/tool_action = tool_power?.action_path
 	if(tool_action)
-		tool_action.max_charges = 0
+		tool_action.max_charges = null
 		tool_action.power_refunds = FALSE
 		tool_action.required_affinity = 3
+		tool_action.enable()
 
 /datum/power/thaumaturge/phantasmal_mastery/remove()
 	. = ..()

--- a/modular_doppler/modular_powers/code/powers/sorcerous/thaumaturge/phantasmal_mastery.dm
+++ b/modular_doppler/modular_powers/code/powers/sorcerous/thaumaturge/phantasmal_mastery.dm
@@ -1,7 +1,7 @@
 /datum/power/thaumaturge/phantasmal_mastery
-	name = "Phantasmal Mastery"
-	desc = "Your experience with the Phantasmal Tool spell allows you to make use of it as a cantrip."
-	value = 2
+	name = "Phantasmal Tool TMastery"
+	desc = "Your experience with the Phantasmal Tool spell allows its use without needing charges, though it now requires more Affinity to cast."
+	value = 3
 	required_powers = list(/datum/power/thaumaturge/phantasmal_tool)
 
 /datum/power/thaumaturge/phantasmal_mastery/post_add()
@@ -11,6 +11,7 @@
 	if(tool_action)
 		tool_action.max_charges = 0
 		tool_action.power_refunds = FALSE
+		tool_action.required_affinity = 3
 
 /datum/power/thaumaturge/phantasmal_mastery/remove()
 	. = ..()
@@ -18,3 +19,5 @@
 	var/datum/action/cooldown/power/thaumaturge/phantasmal_tool/tool_action = tool_power?.action_path
 	if(tool_action)
 		tool_action.max_charges = THAUMATURGE_MAX_CHARGES_BASE
+		tool_action.power_refunds = TRUE
+		tool_action.required_affinity = 1

--- a/modular_doppler/modular_powers/code/powers/sorcerous/thaumaturge/phantasmal_mastery.dm
+++ b/modular_doppler/modular_powers/code/powers/sorcerous/thaumaturge/phantasmal_mastery.dm
@@ -1,6 +1,6 @@
 /datum/power/thaumaturge/phantasmal_mastery
 	name = "Phantasmal Tool Mastery"
-	desc = "Your experience with the Phantasmal Tool spell allows its use without needing charges, though it now requires more Affinity to cast."
+	desc = "Your experience with the Phantasmal Tool spell allows its use without needing charges, though it now requires 3 Affinity to cast."
 	value = 3
 	required_powers = list(/datum/power/thaumaturge/phantasmal_tool)
 

--- a/modular_doppler/modular_powers/code/powers/sorcerous/thaumaturge/phantasmal_mastery.dm
+++ b/modular_doppler/modular_powers/code/powers/sorcerous/thaumaturge/phantasmal_mastery.dm
@@ -1,0 +1,19 @@
+/datum/power/thaumaturge/phantasmal_mastery
+	name = "Phantasmal Mastery"
+	desc = "Your experience with the Phantasmal Tool spell allows you to make use of it as a cantrip."
+	value = 2
+	required_powers = list(/datum/power/thaumaturge/phantasmal_tool)
+
+/datum/power/psyker_power/telepathy_area/post_add()
+	. = ..()
+	var/datum/power/thaumaturge/phantasmal_tool/tool_power = power_holder.get_power(/datum/power/thaumaturge/phantasmal_tool)
+	var/datum/action/cooldown/power/thaumaturge/phantasmal_tool/tool_action = tool_power?.action_path
+	if(tool_action)
+		tool_action.max_charges = 0
+
+/datum/power/psyker_power/telepathy_area/remove()
+	. = ..()
+	var/datum/power/thaumaturge/phantasmal_tool/tool_power = power_holder.get_power(/datum/power/thaumaturge/phantasmal_tool)
+	var/datum/action/cooldown/power/thaumaturge/phantasmal_tool/tool_action = tool_power?.action_path
+	if(tool_action)
+		tool_action.max_charges = THAUMATURGE_MAX_CHARGES_BASE

--- a/modular_doppler/modular_powers/code/powers/sorcerous/thaumaturge/phantasmal_mastery.dm
+++ b/modular_doppler/modular_powers/code/powers/sorcerous/thaumaturge/phantasmal_mastery.dm
@@ -1,6 +1,6 @@
 /datum/power/thaumaturge/phantasmal_mastery
 	name = "Phantasmal Tool Mastery"
-	desc = "Your experience with the Phantasmal Tool spell allows it to be used without needing charges, though it now requires Affinity 3 to cast."
+	desc = "Your experience with the Phantasmal Tool spell allows it to be cast without needing charges, though it now requires Affinity in order 3 to cast."
 	value = 3
 	required_powers = list(/datum/power/thaumaturge/phantasmal_tool)
 

--- a/modular_doppler/modular_powers/code/powers/sorcerous/thaumaturge/phantasmal_mastery.dm
+++ b/modular_doppler/modular_powers/code/powers/sorcerous/thaumaturge/phantasmal_mastery.dm
@@ -1,5 +1,5 @@
 /datum/power/thaumaturge/phantasmal_mastery
-	name = "Phantasmal Tool TMastery"
+	name = "Phantasmal Tool Mastery"
 	desc = "Your experience with the Phantasmal Tool spell allows its use without needing charges, though it now requires more Affinity to cast."
 	value = 3
 	required_powers = list(/datum/power/thaumaturge/phantasmal_tool)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7655,6 +7655,7 @@
 #include "modular_doppler\modular_powers\code\powers\sorcerous\thaumaturge\hemomancy.dm"
 #include "modular_doppler\modular_powers\code\powers\sorcerous\thaumaturge\magic_barrage.dm"
 #include "modular_doppler\modular_powers\code\powers\sorcerous\thaumaturge\mending.dm"
+#include "modular_doppler\modular_powers\code\powers\sorcerous\thaumaturge\phantasmal_mastery.dm"
 #include "modular_doppler\modular_powers\code\powers\sorcerous\thaumaturge\phantasmal_tool.dm"
 #include "modular_doppler\modular_powers\code\powers\sorcerous\thaumaturge\prestidigitation.dm"
 #include "modular_doppler\modular_powers\code\powers\sorcerous\thaumaturge\sanguine_absorption.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
made by request.. you take this and it costs 2 points and requires PT and it makes it not require preparation
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
someone wanted it!
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Testing Evidence
tested, it should work
<!-- Provide proof that the content added, edited, or removed by this pull request is working as intended in-game. Compiling alone doesn't guarantee functionality, so be sure to test thoroughly! -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:NewyearnewmeUwu
add: Added Phantasmal Tool Mastery, a 3-point power to make Phantasmal Tool not require preparation in exchange for needing Affinity 3.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
