### PR TITLE
adds a little more risk and reward with salvaged shuttle reactors

### DIFF
--- a/modular_doppler/shipbreaking/code/loot/cargo_sales.dm
+++ b/modular_doppler/shipbreaking/code/loot/cargo_sales.dm
@@ -53,14 +53,14 @@
 	)
 
 /datum/export/salvage_reactor
-	cost = CARGO_CRATE_VALUE * 5
+	cost = CARGO_CRATE_VALUE * 38
 	unit_name = "salvaged bloom reactor"
 	export_types = list(
 		/obj/structure/shuttle_decoration/liquid_tank/reactor,
 	)
 
 /datum/export/salvage_reactor
-	cost = CARGO_CRATE_VALUE * 7.5
+	cost = CARGO_CRATE_VALUE * 44
 	unit_name = "salvaged large bloom reactor"
 	export_types = list(
 		/obj/structure/shuttle_decoration/liquid_tank/reactor/super,

--- a/modular_doppler/shipbreaking/code/shuttle_parts/hazards.dm
+++ b/modular_doppler/shipbreaking/code/shuttle_parts/hazards.dm
@@ -265,7 +265,7 @@
 	visible_message(span_boldwarning("The chrysalid contained within [src] starts to grow through the cracks in the housing!"))
 	very_upset = TRUE
 
-/datum/component/fertile_egg/process(seconds_per_tick)
+/obj/structure/shuttle_decoration/liquid_tank/reactor/process(seconds_per_tick)
 	if(upset)
 		if(prob(1))
 			tesla_zap(source = src, zap_range = 2, power = 1e4, cutoff = 1e3, zap_flags = ZAP_MOB_DAMAGE | ZAP_OBJ_DAMAGE | ZAP_MOB_STUN | ZAP_LOW_POWER_GEN | ZAP_ALLOW_DUPLICATES)

--- a/modular_doppler/shipbreaking/code/shuttle_parts/hazards.dm
+++ b/modular_doppler/shipbreaking/code/shuttle_parts/hazards.dm
@@ -228,6 +228,53 @@
 	light_range = 3
 	light_color = LIGHT_COLOR_PURPLE
 	rupture_range = 14
+	/// How long after unsecuring a reactor until it starts to arc and make sounds
+	var/hazard_timer = 1.5 MINUTES
+	/// How long after a reactor starts to arc will it have a chance to explode
+	var/explode_hazard_timer = 1.5 MINUTES
+	/// If the process for destabilizing has already begun
+	var/melting_down = FALSE
+	/// If, while processing, this reactor can make electric arcs and sounds
+	var/upset = FALSE
+	/// If, while processing, this reactor can decide to explode
+	var/very_upset = FALSE
+
+/obj/structure/shuttle_decoration/liquid_tank/reactor/Destroy()
+	STOP_PROCESSING(SSobj, src)
+	return ..()
+
+/obj/structure/shuttle_decoration/liquid_tank/reactor/default_unfasten_wrench(mob/user, obj/item/wrench, time)
+	. = ..()
+	if(. != SUCCESSFUL_UNFASTEN)
+		return
+	if(melting_down)
+		return
+	Shake(1, 0, hazard_timer, 5 SECONDS)
+	addtimer(CALLBACK(src, PROC_REF(start_arcing)), hazard_timer)
+
+/// Tells the reactor to start processing and adds a random chance to fire arcs and make upset sounds
+/obj/structure/shuttle_decoration/liquid_tank/reactor/proc/start_arcing()
+	upset = TRUE
+	visible_message(span_warning("The outer shell of [src] starts to creak and groan!"))
+	START_PROCESSING(SSobj, src)
+	Shake(2, 1, explode_hazard_timer, 5 SECONDS)
+	addtimer(CALLBACK(src, PROC_REF(start_arcing)), explode_hazard_timer)
+
+/// Tells the reactor to start having a random chance to explode when processing
+/obj/structure/shuttle_decoration/liquid_tank/reactor/proc/start_exploding()
+	visible_message(span_boldwarning("The chrysalid contained within [src] starts to grow through the cracks in the housing!"))
+	very_upset = TRUE
+
+/datum/component/fertile_egg/process(seconds_per_tick)
+	if(upset)
+		if(prob(1))
+			tesla_zap(source = src, zap_range = 2, power = 1e4, cutoff = 1e3, zap_flags = ZAP_MOB_DAMAGE | ZAP_OBJ_DAMAGE | ZAP_MOB_STUN | ZAP_LOW_POWER_GEN | ZAP_ALLOW_DUPLICATES)
+		else if(prob(2))
+			radiation_pulse(src, max_range = rupture_range / 2, threshold = RAD_LIGHT_INSULATION, chance = 50)
+		if(prob(5))
+			playsound(src, SFX_SM_DELAM, 40, TRUE)
+	if(very_upset && prob(1))
+		rupture_tank()
 
 /obj/structure/shuttle_decoration/liquid_tank/reactor/rupture_tank()
 	playsound(src, 'modular_doppler/shipbreaking/sound/plasma_bomb.ogg', 100, FALSE, 70, 1, pressure_affected = FALSE, ignore_walls = TRUE)

--- a/modular_doppler/shipbreaking/code/shuttle_parts/hazards.dm
+++ b/modular_doppler/shipbreaking/code/shuttle_parts/hazards.dm
@@ -249,7 +249,9 @@
 		return
 	if(melting_down)
 		return
-	Shake(1, 0, hazard_timer, 5 SECONDS)
+	melting_down = TRUE
+	visible_message(span_warning("Warning lights on the shell of [src] start to light up one after another."))
+	Shake(1, 0, hazard_timer, 1 SECONDS)
 	addtimer(CALLBACK(src, PROC_REF(start_arcing)), hazard_timer)
 
 /// Tells the reactor to start processing and adds a random chance to fire arcs and make upset sounds
@@ -257,7 +259,7 @@
 	upset = TRUE
 	visible_message(span_warning("The outer shell of [src] starts to creak and groan!"))
 	START_PROCESSING(SSobj, src)
-	Shake(2, 1, explode_hazard_timer, 5 SECONDS)
+	Shake(2, 1, explode_hazard_timer)
 	addtimer(CALLBACK(src, PROC_REF(start_arcing)), explode_hazard_timer)
 
 /// Tells the reactor to start having a random chance to explode when processing

--- a/modular_doppler/shipbreaking/code/shuttle_parts/hazards.dm
+++ b/modular_doppler/shipbreaking/code/shuttle_parts/hazards.dm
@@ -257,6 +257,8 @@
 /// Tells the reactor to start processing and adds a random chance to fire arcs and make upset sounds
 /obj/structure/shuttle_decoration/liquid_tank/reactor/proc/start_arcing()
 	upset = TRUE
+	var/mutable_appearance/lightning_overlay = mutable_appearance(icon = 'icons/effects/effects.dmi', icon_state = "lightning")
+	add_overlay(lightning_overlay)
 	visible_message(span_warning("The outer shell of [src] starts to creak and groan!"))
 	START_PROCESSING(SSobj, src)
 	Shake(2, 1, explode_hazard_timer)

--- a/modular_doppler/shipbreaking/code/shuttle_parts/hazards.dm
+++ b/modular_doppler/shipbreaking/code/shuttle_parts/hazards.dm
@@ -305,7 +305,11 @@
 		if(prob(5))
 			playsound(src, SFX_SM_DELAM, 40, TRUE)
 	if((meltdown_state >= REACTOR_MELTDOWN_VERY_UPSET) && prob(1))
-		rupture_tank()
+		visible_message(span_boldwarning("That can't be good."))
+		var/mutable_appearance/about_to_blow = mutable_appearance('icons/effects/welding_effect.dmi', "welding_sparks", GASFIRE_LAYER, src, ABOVE_LIGHTING_PLANE, appearance_flags = RESET_COLOR|KEEP_APART)
+		add_overlay(about_to_blow)
+		playsound(src, 'sound/effects/compressed_air/tank_remove_thunk.ogg', 100, TRUE)
+		addtimer(CALLBACK(src, PROC_REF(rupture_tank)), rand(2 SECONDS, 4 SECONDS))
 
 /obj/structure/shuttle_decoration/liquid_tank/reactor/rupture_tank()
 	playsound(src, 'modular_doppler/shipbreaking/sound/plasma_bomb.ogg', 100, FALSE, 70, 1, pressure_affected = FALSE, ignore_walls = TRUE)

--- a/modular_doppler/shipbreaking/code/shuttle_parts/hazards.dm
+++ b/modular_doppler/shipbreaking/code/shuttle_parts/hazards.dm
@@ -211,7 +211,8 @@
 #define REACTOR_MELTDOWN_SAFE 0
 #define REACTOR_MELTDOWN_STARTED 1
 #define REACTOR_MELTDOWN_UPSET 2
-#define REACTOR_MELTDOWN_VERY_UPSET 2
+#define REACTOR_MELTDOWN_VERY_UPSET 3
+#define REACTOR_MELTDOWN_SHUTTLE_DISARMED 4
 
 /obj/structure/shuttle_decoration/liquid_tank/reactor
 	name = "ethereal bloom reactor"
@@ -251,6 +252,8 @@
 			. += span_warning("The reactor's chrysalid is becoming active and will breach the containment shell if not dealt with soon!")
 		if(REACTOR_MELTDOWN_VERY_UPSET)
 			. += span_boldwarning("The chrysalid inside the reactor has started to grow through cracks in the shell, now would be a good time to run!")
+	if(meltdown_state >= REACTOR_MELTDOWN_STARTED)
+		. += span_notice("Chrysalid containment breach can be prevented by shipping the reactor off through the supply shuttle, or recycling it.")
 
 /obj/structure/shuttle_decoration/liquid_tank/reactor/Destroy()
 	STOP_PROCESSING(SSobj, src)
@@ -265,26 +268,35 @@
 	meltdown_state = REACTOR_MELTDOWN_STARTED
 	visible_message(span_warning("Warning lights on the shell of [src] start to light up one after another."))
 	Shake(1, 0, hazard_timer, 1 SECONDS)
+	START_PROCESSING(SSobj, src)
 	addtimer(CALLBACK(src, PROC_REF(start_arcing)), hazard_timer)
 
 /// Tells the reactor to start processing and adds a random chance to fire arcs and make upset sounds
 /obj/structure/shuttle_decoration/liquid_tank/reactor/proc/start_arcing()
+	if(meltdown_state == REACTOR_MELTDOWN_SHUTTLE_DISARMED)
+		return
 	meltdown_state = REACTOR_MELTDOWN_UPSET
 	var/mutable_appearance/lightning_overlay = mutable_appearance(icon = 'icons/effects/effects.dmi', icon_state = "lightning")
 	add_overlay(lightning_overlay)
 	visible_message(span_warning("The outer shell of [src] starts to creak and groan!"))
-	START_PROCESSING(SSobj, src)
 	Shake(2, 1, explode_hazard_timer)
 	addtimer(CALLBACK(src, PROC_REF(start_exploding)), explode_hazard_timer)
 
 /// Tells the reactor to start having a random chance to explode when processing
 /obj/structure/shuttle_decoration/liquid_tank/reactor/proc/start_exploding()
+	if(meltdown_state == REACTOR_MELTDOWN_SHUTTLE_DISARMED)
+		return
 	visible_message(span_boldwarning("The chrysalid contained within [src] starts to grow through the cracks in the housing!"))
 	meltdown_state = REACTOR_MELTDOWN_VERY_UPSET
 	var/mutable_appearance/danger_overlay = mutable_appearance(icon = 'icons/effects/effects.dmi', icon_state = "void_chill_oh_fuck")
 	add_overlay(danger_overlay)
 
 /obj/structure/shuttle_decoration/liquid_tank/reactor/process(seconds_per_tick)
+	var/area/current_area = get_area(src)
+	if(istype(current_area, /area/shuttle/supply) && !is_station_level(z))
+		meltdown_state = REACTOR_MELTDOWN_SHUTTLE_DISARMED
+		STOP_PROCESSING(SSobj, src)
+		return
 	if(meltdown_state >= REACTOR_MELTDOWN_UPSET)
 		if(prob(1))
 			tesla_zap(source = src, zap_range = 2, power = 1e4, cutoff = 1e3, zap_flags = ZAP_MOB_DAMAGE | ZAP_OBJ_DAMAGE | ZAP_MOB_STUN | ZAP_LOW_POWER_GEN | ZAP_ALLOW_DUPLICATES)

--- a/modular_doppler/shipbreaking/code/shuttle_parts/hazards.dm
+++ b/modular_doppler/shipbreaking/code/shuttle_parts/hazards.dm
@@ -288,7 +288,7 @@
 		return
 	message_admins("[ADMIN_LOOKUPFLW(src)] has reached critical meltdown stage and will explode soon")
 	notify_ghosts(
-		"[src] has gone critical and explode at any moment!",
+		"[src] has gone critical and will explode at any moment!",
 		source = src,
 		header = "It's About To Go Critical!",
 		notify_flags = NOTIFY_CATEGORY_NOFLASH,

--- a/modular_doppler/shipbreaking/code/shuttle_parts/hazards.dm
+++ b/modular_doppler/shipbreaking/code/shuttle_parts/hazards.dm
@@ -208,6 +208,11 @@
 	explosion(src, heavy_impact_range = 0, light_impact_range = 0, flame_range = rupture_range, flash_range = rupture_range * 3, smoke = TRUE)
 	Destroy()
 
+#define REACTOR_MELTDOWN_SAFE 0
+#define REACTOR_MELTDOWN_STARTED 1
+#define REACTOR_MELTDOWN_UPSET 2
+#define REACTOR_MELTDOWN_VERY_UPSET 2
+
 /obj/structure/shuttle_decoration/liquid_tank/reactor
 	name = "ethereal bloom reactor"
 	desc = "Superceded by modern ship reactor designs, this older type of generator can be most accurately described as \
@@ -232,12 +237,20 @@
 	var/hazard_timer = 1.5 MINUTES
 	/// How long after a reactor starts to arc will it have a chance to explode
 	var/explode_hazard_timer = 1.5 MINUTES
-	/// If the process for destabilizing has already begun
-	var/melting_down = FALSE
-	/// If, while processing, this reactor can make electric arcs and sounds
-	var/upset = FALSE
-	/// If, while processing, this reactor can decide to explode
-	var/very_upset = FALSE
+	/// Tracks which state of meltdown the reactor is in
+	var/meltdown_state = REACTOR_MELTDOWN_SAFE
+
+/obj/structure/shuttle_decoration/liquid_tank/reactor/examine(mob/user)
+	. = ..()
+	switch(meltdown_state)
+		if(REACTOR_MELTDOWN_SAFE)
+			. += span_notice("The reactor is connected to cooling systems and safe. It may become unstable if disconnected from its housing.")
+		if(REACTOR_MELTDOWN_STARTED)
+			. += span_warning("The reactor is running on backup power and will become unstable if not dealt with.")
+		if(REACTOR_MELTDOWN_UPSET)
+			. += span_warning("The reactor's chrysalid is becoming active and will breach the containment shell if not dealt with soon!")
+		if(REACTOR_MELTDOWN_VERY_UPSET)
+			. += span_boldwarning("The chrysalid inside the reactor has started to grow through cracks in the shell, now would be a good time to run!")
 
 /obj/structure/shuttle_decoration/liquid_tank/reactor/Destroy()
 	STOP_PROCESSING(SSobj, src)
@@ -247,37 +260,39 @@
 	. = ..()
 	if(. != SUCCESSFUL_UNFASTEN)
 		return
-	if(melting_down)
+	if(meltdown_state > REACTOR_MELTDOWN_SAFE)
 		return
-	melting_down = TRUE
+	meltdown_state = REACTOR_MELTDOWN_STARTED
 	visible_message(span_warning("Warning lights on the shell of [src] start to light up one after another."))
 	Shake(1, 0, hazard_timer, 1 SECONDS)
 	addtimer(CALLBACK(src, PROC_REF(start_arcing)), hazard_timer)
 
 /// Tells the reactor to start processing and adds a random chance to fire arcs and make upset sounds
 /obj/structure/shuttle_decoration/liquid_tank/reactor/proc/start_arcing()
-	upset = TRUE
+	meltdown_state = REACTOR_MELTDOWN_UPSET
 	var/mutable_appearance/lightning_overlay = mutable_appearance(icon = 'icons/effects/effects.dmi', icon_state = "lightning")
 	add_overlay(lightning_overlay)
 	visible_message(span_warning("The outer shell of [src] starts to creak and groan!"))
 	START_PROCESSING(SSobj, src)
 	Shake(2, 1, explode_hazard_timer)
-	addtimer(CALLBACK(src, PROC_REF(start_arcing)), explode_hazard_timer)
+	addtimer(CALLBACK(src, PROC_REF(start_exploding)), explode_hazard_timer)
 
 /// Tells the reactor to start having a random chance to explode when processing
 /obj/structure/shuttle_decoration/liquid_tank/reactor/proc/start_exploding()
 	visible_message(span_boldwarning("The chrysalid contained within [src] starts to grow through the cracks in the housing!"))
-	very_upset = TRUE
+	meltdown_state = REACTOR_MELTDOWN_VERY_UPSET
+	var/mutable_appearance/danger_overlay = mutable_appearance(icon = 'icons/effects/effects.dmi', icon_state = "void_chill_oh_fuck")
+	add_overlay(danger_overlay)
 
 /obj/structure/shuttle_decoration/liquid_tank/reactor/process(seconds_per_tick)
-	if(upset)
+	if(meltdown_state >= REACTOR_MELTDOWN_UPSET)
 		if(prob(1))
 			tesla_zap(source = src, zap_range = 2, power = 1e4, cutoff = 1e3, zap_flags = ZAP_MOB_DAMAGE | ZAP_OBJ_DAMAGE | ZAP_MOB_STUN | ZAP_LOW_POWER_GEN | ZAP_ALLOW_DUPLICATES)
 		else if(prob(2))
 			radiation_pulse(src, max_range = rupture_range / 2, threshold = RAD_LIGHT_INSULATION, chance = 50)
 		if(prob(5))
 			playsound(src, SFX_SM_DELAM, 40, TRUE)
-	if(very_upset && prob(1))
+	if((meltdown_state >= REACTOR_MELTDOWN_VERY_UPSET) && prob(1))
 		rupture_tank()
 
 /obj/structure/shuttle_decoration/liquid_tank/reactor/rupture_tank()
@@ -312,3 +327,8 @@
 	goonchem_vortex(get_turf(src), FALSE, 13)
 	explosion(src, heavy_impact_range = 5, light_impact_range = 10, flame_range = 15, flash_range = 34, silent = TRUE, smoke = TRUE)
 	Destroy()
+
+#undef REACTOR_MELTDOWN_SAFE
+#undef REACTOR_MELTDOWN_STARTED
+#undef REACTOR_MELTDOWN_UPSET
+#undef REACTOR_MELTDOWN_VERY_UPSET

--- a/modular_doppler/shipbreaking/code/shuttle_parts/hazards.dm
+++ b/modular_doppler/shipbreaking/code/shuttle_parts/hazards.dm
@@ -286,6 +286,13 @@
 /obj/structure/shuttle_decoration/liquid_tank/reactor/proc/start_exploding()
 	if(meltdown_state == REACTOR_MELTDOWN_SHUTTLE_DISARMED)
 		return
+	message_admins("[ADMIN_LOOKUPFLW(src)] has reached critical meltdown stage and will explode soon")
+	notify_ghosts(
+		"[src] has gone critical and explode at any moment!",
+		source = src,
+		header = "It's About To Go Critical!",
+		notify_flags = NOTIFY_CATEGORY_NOFLASH,
+	)
 	visible_message(span_boldwarning("The chrysalid contained within [src] starts to grow through the cracks in the housing!"))
 	meltdown_state = REACTOR_MELTDOWN_VERY_UPSET
 	var/mutable_appearance/danger_overlay = mutable_appearance(icon = 'icons/effects/effects.dmi', icon_state = "void_chill_oh_fuck")
@@ -309,6 +316,7 @@
 		var/mutable_appearance/about_to_blow = mutable_appearance('icons/effects/welding_effect.dmi', "welding_sparks", GASFIRE_LAYER, src, ABOVE_LIGHTING_PLANE, appearance_flags = RESET_COLOR|KEEP_APART)
 		add_overlay(about_to_blow)
 		playsound(src, 'sound/effects/compressed_air/tank_remove_thunk.ogg', 100, TRUE)
+		STOP_PROCESSING(SSobj, src)
 		addtimer(CALLBACK(src, PROC_REF(rupture_tank)), rand(2 SECONDS, 4 SECONDS))
 
 /obj/structure/shuttle_decoration/liquid_tank/reactor/rupture_tank()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

upon unwrenching a salvage shuttle reactor, a countdown starts
after 90 seconds, the reactor will begin to spit electric arcs, radiation, and make upset sounds
after 120 more seconds, the reactor has a chance every processing tick to explode instantly
each of these stages are telegraphed through visual effects and chat messages, so watch out for them!

in exchange for this, the cargo sale value of reactor cores has been greatly increased, up to 7600 for a small reactor and more for larger types

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

as it stands, shipbreaking is pretty safe unless you're blowing yourself up with demo charges
this adds a little bit of a risk reward setup with the most dangerous thing on most ships
either you can take the safe route and recycle the reactor immediately, or you can gamble on being fast enough to sell the reactor to cargo

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: bloom reactors now become unstable when unwrenched, giving a total safe timer of three and a half minutes before things can start going wrong, but have a significantly higher sale value
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
