### PR TITLE
[NM] Genetics mutation sprite removal.

### DIFF
--- a/code/datums/mutations/adaptation.dm
+++ b/code/datums/mutations/adaptation.dm
@@ -15,7 +15,7 @@
 	..()
 	conflicts = typesof(/datum/mutation/adaptation)
 	if(!(type in visual_indicators))
-		visual_indicators[type] = list(mutable_appearance('icons/mob/effects/genetics.dmi', adapt_icon, -MUTATIONS_LAYER))
+		visual_indicators[type] = list(mutable_appearance('modular_doppler/sprite_swaps/icons/empty.dmi', adapt_icon, -MUTATIONS_LAYER)) // DOPPLER EDIT, removes overlay - old dmi: 'icons/mob/effects/genetics.dmi'
 
 /datum/mutation/adaptation/get_visual_indicator()
 	return visual_indicators[type][1]

--- a/code/datums/mutations/antenna.dm
+++ b/code/datums/mutations/antenna.dm
@@ -36,7 +36,7 @@
 /datum/mutation/antenna/New(datum/mutation/copymut)
 	..()
 	if(!(type in visual_indicators))
-		visual_indicators[type] = list(mutable_appearance('icons/mob/effects/genetics.dmi', "antenna", -FRONT_MUTATIONS_LAYER+1))//-MUTATIONS_LAYER+1
+		visual_indicators[type] = list(mutable_appearance('modular_doppler/sprite_swaps/icons/empty.dmi', "antenna", -FRONT_MUTATIONS_LAYER+1))//-MUTATIONS_LAYER+1
 
 /datum/mutation/antenna/get_visual_indicator()
 	return visual_indicators[type][1]
@@ -178,7 +178,7 @@
 /datum/mutation/mindreader/New(datum/mutation/copymut)
 	..()
 	if(!(type in visual_indicators))
-		visual_indicators[type] = list(mutable_appearance('icons/mob/effects/genetics.dmi', "antenna", -FRONT_MUTATIONS_LAYER+1))
+		visual_indicators[type] = list(mutable_appearance('modular_doppler/sprite_swaps/icons/empty.dmi', "antenna", -FRONT_MUTATIONS_LAYER+1)) // DOPPLER EDIT, removes overlay - old dmi: 'icons/mob/effects/genetics.dmi'
 
 /datum/mutation/mindreader/get_visual_indicator()
 	return visual_indicators[type][1]

--- a/code/datums/mutations/radioactive.dm
+++ b/code/datums/mutations/radioactive.dm
@@ -12,7 +12,7 @@
 /datum/mutation/radioactive/New(datum/mutation/copymut)
 	. = ..()
 	if(!(type in visual_indicators))
-		visual_indicators[type] = list(mutable_appearance('icons/mob/effects/genetics.dmi', "radiation", -MUTATIONS_LAYER))
+		visual_indicators[type] = list(mutable_appearance('modular_doppler/sprite_swaps/icons/empty.dmi', "radiation", -MUTATIONS_LAYER)) // DOPPLER EDIT, removes overlay - old dmi: 'icons/mob/effects/genetics.dmi'
 
 /datum/mutation/radioactive/get_visual_indicator()
 	return visual_indicators[type][1]


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the sprites on some of the genetics mutations.

## Why It's Good For The Game

Less sprite clash with the Genemodded quirk.

## Testing Evidence

Testing Environment works with no errors.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Removes sprites from select genetics mutations.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
