### PR TITLE
Fixes ayylmaos being ayytaurs, skeletons being skeletaurs and basically every other humanoid mob from having weird taur/tail features.

### DIFF
--- a/code/datums/bodypart_overlays/mutant_bodypart_overlay.dm
+++ b/code/datums/bodypart_overlays/mutant_bodypart_overlay.dm
@@ -33,7 +33,10 @@
 		stack_trace("adding a [parent.type] to a [receiver.type] when it shouldn't be!")
 
 	if(imprint_on_next_insertion) //We only want this set *once*
-		var/feature_name = receiver.dna.features[feature_key] || receiver.dna.species.mutant_organs[parent.type]
+		/* DOPPLER EDIT START -  Uses special_feature_key from modular instead of normal feature_keys */
+		var/dna_feature_key = special_feature_key || feature_key
+		var/feature_name = receiver.dna.features[dna_feature_key] || receiver.dna.species.mutant_organs[parent.type] // originally: var/feature_name = receiver.dna.features[feature_key] || receiver.dna.species.mutant_organs[parent.type]
+		/* DOPPLER EDIT END */
 		if (isnull(feature_name))
 			// DOPPLER REMOVAL (stack_trace works off of mutant part assumptions that aren't compatible with our own mutant part system) - stack_trace("[type] has no default feature name for organ [parent.type]!")
 			feature_name = get_consistent_feature_entry(get_global_feature_list()) //fallback to something

--- a/code/datums/bodypart_overlays/mutant_bodypart_overlay.dm
+++ b/code/datums/bodypart_overlays/mutant_bodypart_overlay.dm
@@ -35,7 +35,7 @@
 	if(imprint_on_next_insertion) //We only want this set *once*
 		var/feature_name = receiver.dna.features[feature_key] || receiver.dna.species.mutant_organs[parent.type]
 		if (isnull(feature_name))
-			stack_trace("[type] has no default feature name for organ [parent.type]!")
+			// DOPPLER REMOVAL (stack_trace works off of mutant part assumptions that aren't compatible with our own mutant part system) - stack_trace("[type] has no default feature name for organ [parent.type]!")
 			feature_name = get_consistent_feature_entry(get_global_feature_list()) //fallback to something
 		set_appearance_from_name(feature_name)
 		imprint_on_next_insertion = FALSE

--- a/code/modules/mob/living/carbon/human/dummy.dm
+++ b/code/modules/mob/living/carbon/human/dummy.dm
@@ -113,8 +113,10 @@ INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy)
 /proc/create_consistent_human_dna(mob/living/carbon/human/target)
 	target.dna.features[FEATURE_MUTANT_COLOR] = COLOR_VIBRANT_LIME
 	target.dna.features[FEATURE_ETHEREAL_COLOR] = COLOR_WHITE
+	/* DOPPLER REMOVAL START - Removes applying ALL consistent features just because they exist
 	for(var/feature_key in SSaccessories.feature_list)
 		target.dna.features[feature_key] = get_consistent_feature_entry(SSaccessories.feature_list[feature_key])
+	DOPPLER REMOVAL END */
 	// DOPPLER ADDITION START - Fix tri color features in dummies
 	target.dna.features[FEATURE_EARS_COLORS] = DEFAULT_MATRIXED_FEATURE_COLORS
 	target.dna.features[FEATURE_MARKINGS_COLORS] = DEFAULT_MATRIXED_FEATURE_COLORS

--- a/code/modules/surgery/organs/external/tails.dm
+++ b/code/modules/surgery/organs/external/tails.dm
@@ -81,6 +81,7 @@
 	/* DOPPLER ADDITION END */
 	tail_spines_overlay = new
 	tail_spines_overlay.tail_spine_key = tail_spine_key
+	//DOPPLER REMOVAL: var/feature_name = bodypart.owner.dna.features[FEATURE_SPINES] //tail spines don't live in DNA, but share feature names with regular spines
 	tail_spines_overlay.set_appearance_from_name(feature_name)
 	bodypart.add_bodypart_overlay(tail_spines_overlay)
 

--- a/code/modules/surgery/organs/external/tails.dm
+++ b/code/modules/surgery/organs/external/tails.dm
@@ -71,9 +71,16 @@
 	if(!tail_spine_key)
 		return
 
+	/* DOPPLER ADDITION START - Fixes tail spines throwing runtimes when spawning humanoid mobs/corpses with tails
+	 * The tail spines overlay is dependent on the owner's DNA, which may not be set yet.
+	 * If the owner doesn't have a valid DNA, don't insert the tail spines overlay.*/
+	var/obj/item/organ/spines/owner_spines = bodypart.owner.get_organ_slot(ORGAN_SLOT_EXTERNAL_SPINES)
+	var/feature_name = bodypart.owner.dna.features[FEATURE_SPINES] || bodypart.owner.dna.species.mutant_organs[owner_spines?.type]
+	if(!feature_name || feature_name == SPRITE_ACCESSORY_NONE)
+		return
+	/* DOPPLER ADDITION END */
 	tail_spines_overlay = new
 	tail_spines_overlay.tail_spine_key = tail_spine_key
-	var/feature_name = bodypart.owner.dna.features[FEATURE_SPINES] //tail spines don't live in DNA, but share feature names with regular spines
 	tail_spines_overlay.set_appearance_from_name(feature_name)
 	bodypart.add_bodypart_overlay(tail_spines_overlay)
 

--- a/code/modules/surgery/organs/external/tails.dm
+++ b/code/modules/surgery/organs/external/tails.dm
@@ -71,9 +71,17 @@
 	if(!tail_spine_key)
 		return
 
+	/* DOPPLER ADDITION START - Fixes tail spines throwing runtimes when spawning humanoid mobs/corpses with tails
+	 * The tail spines overlay is dependent on the owner's DNA, which may not be set yet.
+	 * If the owner doesn't have a valid DNA, don't insert the tail spines overlay.*/
+	var/obj/item/organ/spines/owner_spines = bodypart.owner.get_organ_slot(ORGAN_SLOT_EXTERNAL_SPINES)
+	var/feature_name = bodypart.owner.dna.features[FEATURE_SPINES] || bodypart.owner.dna.species.mutant_organs[owner_spines?.type]
+	if(!feature_name || feature_name == SPRITE_ACCESSORY_NONE)
+		return
+	/* DOPPLER ADDITION END */
 	tail_spines_overlay = new
 	tail_spines_overlay.tail_spine_key = tail_spine_key
-	var/feature_name = bodypart.owner.dna.features[FEATURE_SPINES] //tail spines don't live in DNA, but share feature names with regular spines
+	//DOPPLER REMOVAL: var/feature_name = bodypart.owner.dna.features[FEATURE_SPINES] //tail spines don't live in DNA, but share feature names with regular spines
 	tail_spines_overlay.set_appearance_from_name(feature_name)
 	bodypart.add_bodypart_overlay(tail_spines_overlay)
 

--- a/code/modules/surgery/organs/external/tails.dm
+++ b/code/modules/surgery/organs/external/tails.dm
@@ -71,17 +71,9 @@
 	if(!tail_spine_key)
 		return
 
-	/* DOPPLER ADDITION START - Fixes tail spines throwing runtimes when spawning humanoid mobs/corpses with tails
-	 * The tail spines overlay is dependent on the owner's DNA, which may not be set yet.
-	 * If the owner doesn't have a valid DNA, don't insert the tail spines overlay.*/
-	var/obj/item/organ/spines/owner_spines = bodypart.owner.get_organ_slot(ORGAN_SLOT_EXTERNAL_SPINES)
-	var/feature_name = bodypart.owner.dna.features[FEATURE_SPINES] || bodypart.owner.dna.species.mutant_organs[owner_spines?.type]
-	if(!feature_name || feature_name == SPRITE_ACCESSORY_NONE)
-		return
-	/* DOPPLER ADDITION END */
 	tail_spines_overlay = new
 	tail_spines_overlay.tail_spine_key = tail_spine_key
-	//DOPPLER REMOVAL: var/feature_name = bodypart.owner.dna.features[FEATURE_SPINES] //tail spines don't live in DNA, but share feature names with regular spines
+	var/feature_name = bodypart.owner.dna.features[FEATURE_SPINES] //tail spines don't live in DNA, but share feature names with regular spines
 	tail_spines_overlay.set_appearance_from_name(feature_name)
 	bodypart.add_bodypart_overlay(tail_spines_overlay)
 

--- a/modular_doppler/modular_customization/organs/mutant_bodypart_overlay.dm
+++ b/modular_doppler/modular_customization/organs/mutant_bodypart_overlay.dm
@@ -132,7 +132,7 @@
 /datum/bodypart_overlay/mutant/proc/get_feature_key_for_overlay()
 	return sprite_datum?.key || feature_key
 
-/// Returns the DNA feature which controls whether this organ's overlay is present, favoring doppler's version and falling back to the og.
+/// Returns the DNA feature which controls whether this organ's overlay is present.
 /obj/item/organ/proc/get_bodypart_overlay_dna_feature_key()
 	return bodypart_overlay?.special_feature_key || bodypart_overlay?.feature_key
 

--- a/modular_doppler/modular_customization/organs/mutant_bodypart_overlay.dm
+++ b/modular_doppler/modular_customization/organs/mutant_bodypart_overlay.dm
@@ -132,9 +132,14 @@
 /datum/bodypart_overlay/mutant/proc/get_feature_key_for_overlay()
 	return sprite_datum?.key || feature_key
 
-/// Returns the DNA feature which controls whether this organ's overlay is present.
-/obj/item/organ/proc/get_bodypart_overlay_dna_feature_key()
-	return bodypart_overlay?.special_feature_key || bodypart_overlay?.feature_key
+/// Returns the DNA feature which controls whether an organ type's overlay is present.
+/proc/get_bodypart_overlay_dna_feature_key_from_type(obj/item/organ/organ_type)
+	if(isnull(organ_type))
+		return null
+	var/datum/bodypart_overlay/mutant/overlay_type = initial(organ_type.bodypart_overlay)
+	if(isnull(overlay_type))
+		return null
+	return initial(overlay_type.special_feature_key) || initial(overlay_type.feature_key)
 
 #undef MAX_MATRIXED_COLORS
 #undef ALPHA_OPAQUE

--- a/modular_doppler/modular_customization/organs/mutant_bodypart_overlay.dm
+++ b/modular_doppler/modular_customization/organs/mutant_bodypart_overlay.dm
@@ -132,5 +132,9 @@
 /datum/bodypart_overlay/mutant/proc/get_feature_key_for_overlay()
 	return sprite_datum?.key || feature_key
 
+/// Returns the DNA feature which controls whether this organ's overlay is present, favoring doppler's version and falling back to the og.
+/obj/item/organ/proc/get_bodypart_overlay_dna_feature_key()
+	return bodypart_overlay?.special_feature_key || bodypart_overlay?.feature_key
+
 #undef MAX_MATRIXED_COLORS
 #undef ALPHA_OPAQUE

--- a/modular_doppler/modular_customization/preferences/tail.dm
+++ b/modular_doppler/modular_customization/preferences/tail.dm
@@ -13,7 +13,7 @@
 	var/use_species_default_tail = FALSE
 	if(isnull(target.dna.tail_type)) // always false when the target has prefs
 		var/obj/item/organ/species_tail_type = get_mutant_organ_type_for_slot(ORGAN_SLOT_EXTERNAL_TAIL)
-		if(species_tail_type) // always false when a mob doesn't have a tail
+		if(species_tail_type) // always false when a species doesn't normally have a tail
 			var/default_tail_appearance = mutant_organs[species_tail_type]
 			var/tail_feature_key = get_bodypart_overlay_dna_feature_key_from_type(species_tail_type)
 			if(tail_feature_key && default_tail_appearance)

--- a/modular_doppler/modular_customization/preferences/tail.dm
+++ b/modular_doppler/modular_customization/preferences/tail.dm
@@ -7,25 +7,18 @@
 	if(target == null)
 		return ..()
 
-	// This is a little roundabout: the normal organ code needs the correct DNA entry before it will add a tail, but the tail object itself tells us which DNA entry it uses. I don't know why we do it like this; but here we are.
-	// Check the mob's current tail when possible, or briefly take a matching one from the wardrobe cache, then fill in the species default before calling the normal organ code below.
-	// If we do not do this, generic mobs without player preferences will not get a tail when their species should (currently this is only lavaland corpses, but future-proofing doesn't hurt).
-	var/obj/item/organ/species_tail_type = get_mutant_organ_type_for_slot(ORGAN_SLOT_EXTERNAL_TAIL)
+	// The normal organ code will not add a tail while its DNA feature is set to "None".
+	// Read which feature the species' tail overlay uses directly from its type, then set that feature to the species default before calling the normal organ code below.
+	// Without this, generic mobs without player preferences will not get a tail when their species should.
 	var/use_species_default_tail = FALSE
-	if(species_tail_type && isnull(target.dna.tail_type)) // isnull() is always false here for mobs with prefs and mobs without a tail, so this is only true for mobs with a species default tail and no player preference.
-		var/default_tail_appearance = mutant_organs[species_tail_type]
-		var/obj/item/organ/tail_to_check = target.get_organ_slot(ORGAN_SLOT_EXTERNAL_TAIL)
-		// We need a real tail object to find which DNA entry controls it. If the mob does not have the right tail yet, take a temporary one from the wardrobe cache for this check.
-		var/using_temporary_tail = !istype(tail_to_check, species_tail_type)
-		if(using_temporary_tail)
-			tail_to_check = SSwardrobe.provide_type(species_tail_type)
-		var/tail_feature_key = tail_to_check.get_bodypart_overlay_dna_feature_key()
-		if(tail_feature_key && default_tail_appearance)
-			target.dna.features[tail_feature_key] = default_tail_appearance
-			use_species_default_tail = TRUE
-		// Put the temporary tail back. The parent call below will add the mob's real tail.
-		if(using_temporary_tail)
-			SSwardrobe.stash_object(tail_to_check)
+	if(isnull(target.dna.tail_type)) // always false when the target has prefs
+		var/obj/item/organ/species_tail_type = get_mutant_organ_type_for_slot(ORGAN_SLOT_EXTERNAL_TAIL)
+		if(species_tail_type) // always false when a mob doesn't have a tail
+			var/default_tail_appearance = mutant_organs[species_tail_type]
+			var/tail_feature_key = get_bodypart_overlay_dna_feature_key_from_type(species_tail_type)
+			if(tail_feature_key && default_tail_appearance)
+				target.dna.features[tail_feature_key] = default_tail_appearance
+				use_species_default_tail = TRUE
 
 	. = ..()
 	// The parent has now handled the species' usual tail. The customization branches below are only for player-prefs tail choices, including an explicit preference to have no tail.

--- a/modular_doppler/modular_customization/preferences/tail.dm
+++ b/modular_doppler/modular_customization/preferences/tail.dm
@@ -1,11 +1,37 @@
 /datum/dna
 	///	This variable is read by the regenerate_organs() proc to know what organ subtype to give
-	var/tail_type = NO_VARIATION
+	/// Null until a tail choice is applied, NO_VARIATION for an explicit opt-out, or a tail category to generate.
+	var/tail_type
 
 /datum/species/regenerate_organs(mob/living/carbon/target, datum/species/old_species, replace_current = TRUE, list/excluded_zones, visual_only = FALSE, replace_missing = TRUE)
-	. = ..()
 	if(target == null)
-		return
+		return ..()
+
+	// This is a little roundabout: the normal organ code needs the correct DNA entry before it will add a tail, but the tail object itself tells us which DNA entry it uses. I don't know why we do it like this; but here we are.
+	// Check the mob's current tail when possible, or briefly take a matching one from the wardrobe cache, then fill in the species default before calling the normal organ code below.
+	// If we do not do this, generic mobs without player preferences will not get a tail when their species should (currently this is only lavaland corpses, but future-proofing doesn't hurt).
+	var/obj/item/organ/species_tail_type = get_mutant_organ_type_for_slot(ORGAN_SLOT_EXTERNAL_TAIL)
+	var/use_species_default_tail = FALSE
+	if(species_tail_type && isnull(target.dna.tail_type)) // isnull() is always false here for mobs with prefs and mobs without a tail, so this is only true for mobs with a species default tail and no player preference.
+		var/default_tail_appearance = mutant_organs[species_tail_type]
+		var/obj/item/organ/tail_to_check = target.get_organ_slot(ORGAN_SLOT_EXTERNAL_TAIL)
+		// We need a real tail object to find which DNA entry controls it. If the mob does not have the right tail yet, take a temporary one from the wardrobe cache for this check.
+		var/using_temporary_tail = !istype(tail_to_check, species_tail_type)
+		if(using_temporary_tail)
+			tail_to_check = SSwardrobe.provide_type(species_tail_type)
+		var/tail_feature_key = tail_to_check.get_bodypart_overlay_dna_feature_key()
+		if(tail_feature_key && default_tail_appearance)
+			target.dna.features[tail_feature_key] = default_tail_appearance
+			use_species_default_tail = TRUE
+		// Put the temporary tail back. The parent call below will add the mob's real tail.
+		if(using_temporary_tail)
+			SSwardrobe.stash_object(tail_to_check)
+
+	. = ..()
+	// The parent has now handled the species' usual tail. The customization branches below are only for player-prefs tail choices, including an explicit preference to have no tail.
+	if(use_species_default_tail)
+		return .
+
 	if(!ishuman(target))
 		return
 
@@ -27,7 +53,7 @@
 		var/obj/item/organ/replacement = SSwardrobe.provide_type(/obj/item/organ/tail/fish)
 		replacement.Insert(target, special = TRUE, movement_flags = DELETE_IF_REPLACED)
 		return .
-	else if((target.dna.features[FEATURE_TAIL_OTHER] && can_regenerate_mutant_feature(FEATURE_TAIL_OTHER) && target.dna.features[FEATURE_TAIL_OTHER] != /datum/sprite_accessory/blank::name) && (target.dna.tail_type != NO_VARIATION))
+	else if((target.dna.features[FEATURE_TAIL_OTHER] && can_regenerate_mutant_feature(FEATURE_TAIL_OTHER) && target.dna.features[FEATURE_TAIL_OTHER] != /datum/sprite_accessory/blank::name) && (target.dna.tail_type && target.dna.tail_type != NO_VARIATION))
 		var/obj/item/organ/organ_path = text2path("/obj/item/organ/tail/[target.dna.tail_type]")
 		var/obj/item/organ/replacement = SSwardrobe.provide_type(organ_path)
 		replacement.Insert(target, special = TRUE, movement_flags = DELETE_IF_REPLACED)
@@ -35,11 +61,6 @@
 
 	var/obj/item/organ/tail/old_part = target.get_organ_slot(ORGAN_SLOT_EXTERNAL_TAIL)
 	if(istype(old_part))
-		// Keep an already-applied species tail (e.g regenerate_organs() for lizards) when no DNA-specific tail is appleid.
-		var/obj/item/organ/intrinsic_tail_type = get_mutant_organ_type_for_slot(ORGAN_SLOT_EXTERNAL_TAIL)
-		var/intrinsic_tail_feature_key = old_part.get_bodypart_overlay_dna_feature_key()
-		if(intrinsic_tail_type == old_part.type && (!intrinsic_tail_feature_key || isnull(target.dna.features[intrinsic_tail_feature_key])))
-			return .
 		old_part.Remove(target, special = TRUE, movement_flags = DELETE_IF_REPLACED)
 		old_part.moveToNullspace()
 
@@ -722,8 +743,9 @@
 	feature_key_sprite = "tail"
 
 /datum/bodypart_overlay/mutant/tail/color_images(list/image/overlays, layer, obj/item/bodypart/limb)
-	if((sprite_datum.color_src == USE_ONE_COLOR) && length(limb.owner?.dna.features[FEATURE_TAIL_COLORS]))
-		draw_color = limb.owner?.dna.features[FEATURE_TAIL_COLORS][1]
-	else
-		draw_color = limb.owner?.dna.features[FEATURE_TAIL_COLORS]
+	var/list/tail_colors = limb.owner?.dna.features[FEATURE_TAIL_COLORS]
+	// Preference colors override the tail's inherited limb color. Generic mobs do not have this
+	// preference data, so retaining draw_color makes their native tail match their mutant color.
+	if(length(tail_colors))
+		draw_color = sprite_datum.color_src == USE_ONE_COLOR ? tail_colors[1] : tail_colors
 	return ..()

--- a/modular_doppler/modular_customization/preferences/tail.dm
+++ b/modular_doppler/modular_customization/preferences/tail.dm
@@ -9,23 +9,25 @@
 	if(!ishuman(target))
 		return
 
-	if(can_regenerate_mutant_feature(FEATURE_TAIL_LIZARD) && target.dna.features[FEATURE_TAIL_LIZARD] != /datum/sprite_accessory/blank::name)
+	// Because we both have None & Null as possible values we check target.dna.features twice. First for null, then afterwards for "None"
+	// can_regenerate_mutant_feature() is used to prevent giving mutant parts to species on GLOB.species_blacklist_no_mutant
+	if(target.dna.features[FEATURE_TAIL_LIZARD] && can_regenerate_mutant_feature(FEATURE_TAIL_LIZARD) && target.dna.features[FEATURE_TAIL_LIZARD] != /datum/sprite_accessory/blank::name)
 		var/obj/item/organ/replacement = SSwardrobe.provide_type(/obj/item/organ/tail/lizard)
 		replacement.Insert(target, special = TRUE, movement_flags = DELETE_IF_REPLACED)
 		return .
-	else if(can_regenerate_mutant_feature(FEATURE_TAIL_CAT) && target.dna.features[FEATURE_TAIL_CAT] != /datum/sprite_accessory/blank::name)
+	else if(target.dna.features[FEATURE_TAIL_CAT] && can_regenerate_mutant_feature(FEATURE_TAIL_CAT) && target.dna.features[FEATURE_TAIL_CAT] != /datum/sprite_accessory/blank::name)
 		var/obj/item/organ/replacement = SSwardrobe.provide_type(/obj/item/organ/tail/cat)
 		replacement.Insert(target, special = TRUE, movement_flags = DELETE_IF_REPLACED)
 		return .
-	else if(can_regenerate_mutant_feature(FEATURE_TAIL_MONKEY) && target.dna.features[FEATURE_TAIL_MONKEY] != /datum/sprite_accessory/blank::name)
+	else if(target.dna.features[FEATURE_TAIL_MONKEY] && can_regenerate_mutant_feature(FEATURE_TAIL_MONKEY) && target.dna.features[FEATURE_TAIL_MONKEY] != /datum/sprite_accessory/blank::name)
 		var/obj/item/organ/replacement = SSwardrobe.provide_type(/obj/item/organ/tail/monkey)
 		replacement.Insert(target, special = TRUE, movement_flags = DELETE_IF_REPLACED)
 		return .
-	else if(can_regenerate_mutant_feature(FEATURE_TAIL_FISH) && target.dna.features[FEATURE_TAIL_FISH] != /datum/sprite_accessory/blank::name)
+	else if(target.dna.features[FEATURE_TAIL_FISH] && can_regenerate_mutant_feature(FEATURE_TAIL_FISH) && target.dna.features[FEATURE_TAIL_FISH] != /datum/sprite_accessory/blank::name)
 		var/obj/item/organ/replacement = SSwardrobe.provide_type(/obj/item/organ/tail/fish)
 		replacement.Insert(target, special = TRUE, movement_flags = DELETE_IF_REPLACED)
 		return .
-	else if((can_regenerate_mutant_feature(FEATURE_TAIL_OTHER) && target.dna.features[FEATURE_TAIL_OTHER] != /datum/sprite_accessory/blank::name) && (target.dna.tail_type != NO_VARIATION))
+	else if((target.dna.features[FEATURE_TAIL_OTHER] && can_regenerate_mutant_feature(FEATURE_TAIL_OTHER) && target.dna.features[FEATURE_TAIL_OTHER] != /datum/sprite_accessory/blank::name) && (target.dna.tail_type != NO_VARIATION))
 		var/obj/item/organ/organ_path = text2path("/obj/item/organ/tail/[target.dna.tail_type]")
 		var/obj/item/organ/replacement = SSwardrobe.provide_type(organ_path)
 		replacement.Insert(target, special = TRUE, movement_flags = DELETE_IF_REPLACED)
@@ -33,6 +35,11 @@
 
 	var/obj/item/organ/tail/old_part = target.get_organ_slot(ORGAN_SLOT_EXTERNAL_TAIL)
 	if(istype(old_part))
+		// Keep an already-applied species tail (e.g regenerate_organs() for lizards) when no DNA-specific tail is appleid.
+		var/obj/item/organ/intrinsic_tail_type = get_mutant_organ_type_for_slot(ORGAN_SLOT_EXTERNAL_TAIL)
+		var/intrinsic_tail_feature_key = old_part.get_bodypart_overlay_dna_feature_key()
+		if(intrinsic_tail_type == old_part.type && (!intrinsic_tail_feature_key || isnull(target.dna.features[intrinsic_tail_feature_key])))
+			return .
 		old_part.Remove(target, special = TRUE, movement_flags = DELETE_IF_REPLACED)
 		old_part.moveToNullspace()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<img width="1206" height="1152" alt="image" src="https://github.com/user-attachments/assets/b08404cd-830e-4549-a4fb-316929f5acbc" />
<img width="489" height="399" alt="image" src="https://github.com/user-attachments/assets/9b397b92-2be2-4bd0-b39b-9ddde8330017" />

The abductor taur-patrol is dead (or ayytaurs, whatever you want to cal lthem). Lavaland corpses no longer spawn with strange tails. 
Non player simple-mobs generated are now just a dude and don't come with mutant parts unless the species comes with a tail, in which case it is preserved.

This also fixes a bug where lavaland mobs spawn with weird tails constantly because the tail code was being confused by null not being "None".
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Holy shit my immersion why are the ayys taurs and why are they FLUFFY.
also lavaland corpses now look more natural.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Testing Evidence
<img width="767" height="377" alt="image" src="https://github.com/user-attachments/assets/bec1f106-ae2a-4f11-b2fb-be51a90849e7" />
I count two legs. TWO. Legs. And a clean shaved ayylmao.

I've test-ran this several times and made sure this doesn't alter any existing player customizations (it doesn't affect my characters, nor the screenshot test, so I think this is successfully compartmentalized despite having a lot of overlap with prefs code).

Also mining mob corpse features are still preserved and in fact now match the mob.
<img width="369" height="371" alt="image" src="https://github.com/user-attachments/assets/1ca8077b-5f7c-463b-839e-820e1c9ff741" />

<!-- Provide proof that the content added, edited, or removed by this pull request is working as intended in-game. Compiling alone doesn't guarantee functionality, so be sure to test thoroughly! -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:TheOneAndOnlyCreeperJoe
fix: Abductor simple-mobs, skeletons and other human-based simple mobs are no longer exclusively deer-taurs.
fix: Shadow (and other species) corpses in the Mining Z-level no longer have weird tails. Mobs with tails now always spawn with tails that match their color.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
