### PR TITLE
Moves up the erasure delam priority on the delam scale

### DIFF
--- a/code/modules/power/supermatter/supermatter_delamination/_sm_delam.dm
+++ b/code/modules/power/supermatter/supermatter_delamination/_sm_delam.dm
@@ -1,9 +1,9 @@
 /// Priority is top to bottom.
 GLOBAL_LIST_INIT(sm_delam_list, list(
 	/datum/sm_delam/cascade = new /datum/sm_delam/cascade,
+	/datum/sm_delam/erasure = new /datum/sm_delam/erasure, // DOPPLER EDIT ADDITION: Mending-specific delam
 	/datum/sm_delam/singularity = new /datum/sm_delam/singularity,
 	/datum/sm_delam/tesla = new /datum/sm_delam/tesla,
-	/datum/sm_delam/erasure = new /datum/sm_delam/erasure, // DOPPLER EDIT ADDITION: Mending-specific delam
 	/datum/sm_delam/explosive = new /datum/sm_delam/explosive,
 ))
 

--- a/modular_doppler/modular_powers/code/misc/erasure_event/erasure_delam.dm
+++ b/modular_doppler/modular_powers/code/misc/erasure_event/erasure_delam.dm
@@ -8,7 +8,7 @@
 	Hey so did you know that casting a Thaumaturge's Mending fixes the delam to this specific type?
 	This basically causes full-on erasure of the station, systmetically destroying everything (besides mobs) thats adjacent to space until nothing is left.
 	This exlcudes shuttles.
-	This has the lowest priorities of other delams, so you can bypass this by force-delamming into another special type (which may not be strictly better)
+	This is just beneath a resonance cascade delam interms of priorities.
 
 	For the actual controller thats responsible for erasing the station, see modular_doppler\modular_powers\code\misc\erasure_event\erasure_controller.dm
 */

--- a/modular_doppler/modular_powers/code/misc/erasure_event/erasure_delam.dm
+++ b/modular_doppler/modular_powers/code/misc/erasure_event/erasure_delam.dm
@@ -8,7 +8,7 @@
 	Hey so did you know that casting a Thaumaturge's Mending fixes the delam to this specific type?
 	This basically causes full-on erasure of the station, systmetically destroying everything (besides mobs) thats adjacent to space until nothing is left.
 	This exlcudes shuttles.
-	This is just beneath a resonance cascade delam interms of priorities.
+	This is just beneath a resonance cascade delam in terms of priorities.
 
 	For the actual controller thats responsible for erasing the station, see modular_doppler\modular_powers\code\misc\erasure_event\erasure_controller.dm
 */


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Hey so there's a particular interaction with Powers that makes the SM have a different meltdown that you may have seen during anchorfall (it erases the station). However as it turns out the spell responsible usually creates the circumstances for a tesla delam instead which is way less cool for how rare this delam's conditions are.

Moves the delam up in the list so it has higher priority over others (besides resonance cascade).
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Its cooler than a tesla.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Testing Evidence
I delam'd it alright.
<!-- Provide proof that the content added, edited, or removed by this pull request is working as intended in-game. Compiling alone doesn't guarantee functionality, so be sure to test thoroughly! -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:TheOneAndOnlyCreeperJoe
balance: The special Erasure delamination now overrides other delamination (not including Resonance Cascades)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
