### PR TITLE
makes salvage collectors immune to shuttle movement

### DIFF
--- a/modular_doppler/shipbreaking/code/tools/collector_vacuum.dm
+++ b/modular_doppler/shipbreaking/code/tools/collector_vacuum.dm
@@ -14,6 +14,9 @@
 	update_appearance(UPDATE_OVERLAYS)
 	light_color = color
 
+/obj/effect/wind/shipbreaking_collector/onShuttleMove()
+	return FALSE
+
 /obj/effect/wind/shipbreaking_collector/update_overlays()
 	. = ..()
 	. += emissive_appearance(icon, icon_state, src)

--- a/modular_doppler/shipbreaking/code/tools/collector_vacuum.dm
+++ b/modular_doppler/shipbreaking/code/tools/collector_vacuum.dm
@@ -8,6 +8,7 @@
 	light_range = 1
 	light_power = 2
 	light_on = TRUE
+	anchored = TRUE
 
 /obj/effect/wind/shipbreaking_collector/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

see title

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

salvage collectors would have an anchor spawn under them on some maps, which displaces them and makes them float away
this is because they were not anchored
salvage collectors thus then need to be immune to shuttle movement, or else clearing the bay would delete part of the collectors

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: salvage collector fields will no longer be disrupted on some station designs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
