### PR TITLE
Pubby - Switches the location of the RD's Office and Genetics - Adds some missing action figures

### DIFF
--- a/_maps/map_files/Pubbystation/pubbystation.dmm
+++ b/_maps/map_files/Pubbystation/pubbystation.dmm
@@ -12216,12 +12216,10 @@
 /area/station/commons/lounge)
 "bap" = (
 /obj/machinery/computer/slot_machine,
-/obj/structure/fish_mount/bar/directional/north,
 /turf/open/floor/carpet/purple,
 /area/station/commons/lounge)
 "baq" = (
 /obj/effect/spawner/random/entertainment/arcade,
-/obj/structure/fish_mount/bar/directional/north,
 /turf/open/floor/carpet/purple,
 /area/station/commons/lounge)
 "bar" = (
@@ -16651,6 +16649,10 @@
 /obj/machinery/rnd/production/circuit_imprinter,
 /turf/open/floor/iron/white/small,
 /area/station/science/research)
+"bvD" = (
+/mob/living/carbon/human/species/monkey,
+/turf/open/floor/grass,
+/area/station/science/genetics)
 "bvE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -19089,9 +19091,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "bHk" = (
-/obj/machinery/airalarm/directional/west,
-/obj/structure/flora/grass/jungle,
-/obj/structure/sign/poster/contraband/rush_propaganda/directional/north,
+/obj/structure/window/reinforced/spawner/directional/east,
+/mob/living/carbon/human/species/monkey,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/sign/poster/official/corporate_perks_vacation/directional/north,
 /turf/open/floor/grass,
 /area/station/science/genetics)
 "bHl" = (
@@ -24899,8 +24902,9 @@
 /turf/open/misc/asteroid/airless,
 /area/centcom/asteroid/nearstation/bomb_site)
 "cjB" = (
-/obj/machinery/camera/autoname/directional/west,
-/obj/effect/spawner/random/bananas_or_nothing,
+/obj/machinery/airalarm/directional/west,
+/obj/structure/flora/grass/jungle,
+/obj/structure/sign/poster/contraband/rush_propaganda/directional/north,
 /turf/open/floor/grass,
 /area/station/science/genetics)
 "cjC" = (
@@ -33046,10 +33050,7 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/psychology)
 "gRb" = (
-/obj/structure/window/reinforced/spawner/directional/east,
-/mob/living/carbon/human/species/monkey,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/structure/sign/poster/official/corporate_perks_vacation/directional/north,
+/obj/machinery/light/directional/west,
 /turf/open/floor/grass,
 /area/station/science/genetics)
 "gRJ" = (
@@ -45645,10 +45646,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
-"qtO" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/grass,
-/area/station/science/genetics)
 "qtR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -48148,6 +48145,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
+"shC" = (
+/obj/machinery/camera/autoname/directional/west,
+/obj/effect/spawner/random/bananas_or_nothing,
+/turf/open/floor/grass,
+/area/station/science/genetics)
 "shU" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -49418,10 +49420,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/medical/morgue,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
-"tbX" = (
-/mob/living/carbon/human/species/monkey,
-/turf/open/floor/grass,
-/area/station/science/genetics)
 "tck" = (
 /obj/structure/table,
 /obj/effect/spawner/random/armory/dragnet,
@@ -90075,10 +90073,10 @@ duF
 bxa
 byD
 syQ
-bHk
-tbX
-qtO
 cjB
+bvD
+gRb
+shC
 jiD
 sZD
 voL
@@ -90332,7 +90330,7 @@ eYV
 eYV
 byE
 syQ
-gRb
+bHk
 oQi
 bHi
 gLS

--- a/_maps/map_files/Pubbystation/pubbystation.dmm
+++ b/_maps/map_files/Pubbystation/pubbystation.dmm
@@ -15389,23 +15389,15 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/engineering/atmos)
 "bpR" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Research Lab Maintenance"
+/obj/machinery/door/window/right/directional/north{
+	name = "Medbay Front Desk";
+	req_access = list("medical")
 	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/access/any/science/general,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
+/obj/structure/table/reinforced,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "bpU" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
@@ -15920,10 +15912,9 @@
 	},
 /area/station/science/lab)
 "brJ" = (
-/obj/effect/turf_decal/siding/dark_blue{
-	dir = 8
-	},
-/turf/open/floor/wood/large,
+/obj/structure/table,
+/obj/item/kirbyplants/random/dead,
+/turf/open/floor/iron/dark/small,
 /area/station/command/heads_quarters/rd)
 "brK" = (
 /obj/machinery/holopad,
@@ -17794,7 +17785,9 @@
 /turf/open/floor/iron,
 /area/station/security/office)
 "bAo" = (
-/turf/closed/wall,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/station/science/genetics)
 "bAp" = (
 /obj/machinery/door/firedoor,
@@ -17918,10 +17911,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "bAR" = (
-/obj/structure/window/reinforced/spawner/directional/east,
-/mob/living/carbon/human/species/monkey,
-/turf/open/floor/iron/white/small,
-/area/station/science/genetics)
+/obj/effect/turf_decal/siding/dark_blue{
+	dir = 8
+	},
+/turf/open/floor/wood/large,
+/area/station/command/heads_quarters/rd)
 "bAW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/maintenance_loot_structure/medbox/random,
@@ -18447,15 +18441,10 @@
 	},
 /area/station/medical/chem_storage)
 "bDA" = (
-/obj/effect/turf_decal/tile/office_blue/anticorner/contrasted{
-	dir = 4
-	},
-/obj/structure/chair/office/light{
-	dir = 4
-	},
-/obj/effect/landmark/start/geneticist,
-/turf/open/floor/iron/white/textured,
-/area/station/science/genetics)
+/obj/structure/lattice,
+/obj/item/toy/figure/ninja,
+/turf/open/space/basic,
+/area/space/nearstation)
 "bDB" = (
 /obj/effect/turf_decal/siding{
 	dir = 4
@@ -19062,18 +19051,18 @@
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den/gaming)
 "bHh" = (
-/obj/structure/table,
-/obj/item/kirbyplants/random/dead,
+/obj/machinery/computer/robotics{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/small,
 /area/station/command/heads_quarters/rd)
 "bHi" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/left/directional/north{
-	name = "Genetics Desk"
+/obj/machinery/door/window/left/directional/east{
+	name = "Monkey Pen";
+	req_access = list("genetics")
 	},
-/obj/item/paper_bin,
-/obj/effect/spawner/random/bureaucracy/pen,
-/turf/open/floor/iron,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/white/small,
 /area/station/science/genetics)
 "bHj" = (
 /obj/item/storage/belt/utility,
@@ -19085,10 +19074,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "bHk" = (
-/obj/machinery/light_switch/directional/north,
-/obj/machinery/keycard_auth/wall_mounted/directional/west,
-/turf/open/floor/iron/dark/small,
-/area/station/command/heads_quarters/rd)
+/obj/effect/spawner/random/trash/deluxe_garbage/no_mobs_ever,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "bHl" = (
 /obj/effect/spawner/random/epic_loot/random_maint_loot_structure,
 /turf/open/floor/plating,
@@ -24894,10 +24882,9 @@
 /turf/open/misc/asteroid/airless,
 /area/centcom/asteroid/nearstation/bomb_site)
 "cjB" = (
-/obj/structure/lattice,
-/obj/item/toy/figure/ninja,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/effect/spawner/random/trash/bacteria,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "cjC" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -28490,11 +28477,12 @@
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/rd)
 "dqz" = (
-/obj/structure/lattice,
-/obj/structure/disposalpipe/segment,
-/obj/item/toy/figure/syndie,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/effect/turf_decal/siding/dark_blue{
+	dir = 4
+	},
+/obj/machinery/light_switch/directional/south,
+/turf/open/floor/wood/large,
+/area/station/command/heads_quarters/rd)
 "dqG" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/atmospherics/components/unary/airlock_pump{
@@ -32923,18 +32911,10 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
 "gLS" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/machinery/camera/autoname/directional/west,
+/turf/open/floor/iron/white/small,
+/area/station/science/genetics)
 "gMf" = (
 /obj/effect/spawner/random/engineering/tank,
 /turf/open/floor/plating,
@@ -32996,6 +32976,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/office_blue/half/contrasted,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/rd)
 "gQa" = (
@@ -35623,15 +35604,17 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "iXh" = (
-/obj/machinery/door/window/right/directional/north{
-	name = "Medbay Front Desk";
-	req_access = list("medical")
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
-/obj/structure/table/reinforced,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "iYH" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Bay"
@@ -35784,6 +35767,10 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/qm)
 "jdp" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Research Lab Maintenance"
+	},
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -35791,8 +35778,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/any/science/general,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "jdA" = (
@@ -36754,6 +36743,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/aluminum,
 /area/station/salvage_bay)
+"jSA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/wood/large,
+/area/station/command/heads_quarters/rd)
 "jSF" = (
 /turf/closed/wall/r_wall,
 /area/station/hallway/secondary/command)
@@ -41463,9 +41458,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "nyN" = (
-/obj/effect/spawner/random/trash/deluxe_garbage/no_mobs_ever,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/obj/structure/lattice,
+/obj/structure/disposalpipe/segment,
+/obj/item/toy/figure/syndie,
+/turf/open/space/basic,
+/area/space/nearstation)
 "nyO" = (
 /obj/item/kirbyplants/organic/plant22,
 /obj/machinery/light/small/directional/north,
@@ -43290,11 +43287,10 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/warden)
 "oQi" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/wood/large,
-/area/station/command/heads_quarters/rd)
+/obj/structure/window/reinforced/spawner/directional/east,
+/mob/living/carbon/human/species/monkey,
+/turf/open/floor/iron/white/small,
+/area/station/science/genetics)
 "oQn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -46656,6 +46652,7 @@
 /obj/structure/bed,
 /obj/item/bedsheet/rd,
 /obj/effect/landmark/start/research_director,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/rd)
 "rlk" = (
@@ -47982,9 +47979,8 @@
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
 "sci" = (
-/obj/machinery/computer/robotics{
-	dir = 4
-	},
+/obj/machinery/keycard_auth/wall_mounted/directional/west,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark/small,
 /area/station/command/heads_quarters/rd)
 "scp" = (
@@ -48647,9 +48643,7 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "syQ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
+/turf/closed/wall,
 /area/station/science/genetics)
 "syW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -50828,8 +50822,13 @@
 /turf/open/floor/plating,
 /area/station/security/range)
 "uaY" = (
-/obj/structure/window/reinforced/spawner/directional/east,
-/turf/open/floor/iron/white/small,
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/left/directional/north{
+	name = "Genetics Desk"
+	},
+/obj/item/paper_bin,
+/obj/effect/spawner/random/bureaucracy/pen,
+/turf/open/floor/iron,
 /area/station/science/genetics)
 "ubq" = (
 /obj/machinery/camera/autoname/directional/east,
@@ -51443,9 +51442,12 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/main)
 "uuN" = (
-/obj/effect/spawner/random/trash/bacteria,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/obj/effect/turf_decal/tile/office_blue/half/contrasted,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white/textured,
+/area/station/science/genetics)
 "uuS" = (
 /obj/structure/chair,
 /obj/structure/disposalpipe/segment{
@@ -51601,10 +51603,13 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/medical)
 "uzx" = (
-/obj/effect/turf_decal/tile/office_blue/half/contrasted,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+/obj/effect/turf_decal/tile/office_blue/anticorner/contrasted{
 	dir = 4
 	},
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/obj/effect/landmark/start/geneticist,
 /turf/open/floor/iron/white/textured,
 /area/station/science/genetics)
 "uzL" = (
@@ -55687,13 +55692,18 @@
 /turf/open/floor/plating,
 /area/station/service/library)
 "xnp" = (
-/obj/machinery/door/window/left/directional/east{
-	name = "Monkey Pen";
-	req_access = list("genetics")
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/white/small,
-/area/station/science/genetics)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "xog" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -77258,7 +77268,7 @@ rLV
 rLV
 nVU
 bUD
-dqz
+nyN
 ctS
 aaa
 aaa
@@ -83531,7 +83541,7 @@ ecV
 cAI
 vRp
 vRp
-cjB
+bDA
 ajs
 sip
 akX
@@ -86162,7 +86172,7 @@ lEs
 gMY
 xIP
 vPE
-iXh
+bpR
 lOw
 xca
 xca
@@ -86419,7 +86429,7 @@ tcV
 bmw
 tcV
 uzr
-iXh
+bpR
 hPm
 jWH
 nYu
@@ -89509,8 +89519,8 @@ gVk
 gVk
 gVk
 gVk
-gLS
-jdp
+xnp
+iXh
 uQB
 uQB
 cLB
@@ -89766,11 +89776,11 @@ qhP
 bro
 lRN
 lRN
-bpR
+jdp
 lRN
-uuN
+cjB
 gRb
-nyN
+bHk
 oPH
 oJj
 cGr
@@ -90281,11 +90291,11 @@ eYV
 eYV
 eYV
 byE
-bAo
-bAR
-bAR
-xnp
-uaY
+syQ
+oQi
+oQi
+bHi
+gLS
 jiD
 prg
 bIx
@@ -90538,12 +90548,12 @@ mdr
 mdr
 bxc
 nIU
-bAo
+syQ
 xLS
 bCE
 bDB
 bER
-syQ
+bAo
 skm
 bIx
 sAC
@@ -90800,7 +90810,7 @@ bBr
 qmR
 bDC
 bES
-bHi
+uaY
 skm
 bIx
 sAC
@@ -91052,12 +91062,12 @@ buq
 bvx
 bxe
 byH
-syQ
+bAo
 bBs
 bDF
-uzx
+uuN
 bET
-syQ
+bAo
 skm
 bIx
 sAC
@@ -91309,9 +91319,9 @@ bur
 bvy
 bxf
 vXf
-syQ
+bAo
 qgk
-bDA
+uzx
 bDE
 xdL
 jiD
@@ -91566,7 +91576,7 @@ wOt
 qeP
 bxg
 mdL
-syQ
+bAo
 bBu
 bCI
 bCI
@@ -91823,11 +91833,11 @@ rzS
 hqT
 bxh
 bqb
-bAo
-bAo
 syQ
 syQ
 bAo
+bAo
+syQ
 jiD
 eaB
 eKI
@@ -100302,10 +100312,10 @@ brR
 btt
 brR
 bkF
-bHk
+sci
 lNW
 mSc
-sci
+bHh
 bBp
 glf
 bFr
@@ -100559,9 +100569,9 @@ brT
 eOJ
 wkZ
 xJW
-brJ
-brJ
-brJ
+bAR
+bAR
+bAR
 gXg
 bBp
 pNy
@@ -101075,7 +101085,7 @@ bkF
 bkF
 lUC
 wjw
-oQi
+jSA
 wFT
 lRW
 bEf
@@ -102105,7 +102115,7 @@ cPT
 mzp
 dvR
 dvR
-dvR
+dqz
 fRs
 bFx
 bGB
@@ -102361,7 +102371,7 @@ bkF
 hfZ
 pNf
 kkQ
-bHh
+brJ
 xan
 fRs
 llS

--- a/_maps/map_files/Pubbystation/pubbystation.dmm
+++ b/_maps/map_files/Pubbystation/pubbystation.dmm
@@ -230,6 +230,7 @@
 /obj/machinery/firealarm/directional/east,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
+/obj/item/toy/figure/botanist,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "aaY" = (
@@ -3196,6 +3197,7 @@
 	dir = 1
 	},
 /obj/machinery/firealarm/directional/south,
+/obj/item/toy/figure/hos,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
 "anU" = (
@@ -3404,6 +3406,7 @@
 	pixel_x = -6
 	},
 /obj/item/paper/guides/jobs/security/labor_camp,
+/obj/item/toy/figure/prisoner,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "aoP" = (
@@ -3422,6 +3425,7 @@
 /area/station/security/warden)
 "aoS" = (
 /obj/structure/table/reinforced,
+/obj/item/toy/figure/warden,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/warden)
 "aoT" = (
@@ -4858,7 +4862,15 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/security/brig)
 "auw" = (
-/obj/structure/chair,
+/obj/item/gps{
+	gpstag = "RD0"
+	},
+/obj/item/assembly/prox_sensor{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/clothing/ears/earmuffs,
+/obj/structure/table/glass,
 /obj/effect/turf_decal/tile/office_blue{
 	dir = 1
 	},
@@ -5937,6 +5949,7 @@
 "ayq" = (
 /obj/structure/table/wood,
 /obj/item/folder,
+/obj/item/toy/figure/assistant,
 /turf/open/floor/carpet/donk,
 /area/station/commons/dorms)
 "ayu" = (
@@ -6654,6 +6667,7 @@
 /obj/structure/table/wood,
 /obj/structure/secure_safe/directional/west,
 /obj/machinery/light/directional/north,
+/obj/item/toy/figure/hop,
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/hop)
 "aBA" = (
@@ -6798,6 +6812,7 @@
 /obj/machinery/holopad,
 /obj/structure/table/wood,
 /obj/item/storage/briefcase,
+/obj/item/toy/figure/detective,
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
 "aCl" = (
@@ -8043,6 +8058,7 @@
 /area/station/command/heads_quarters/captain)
 "aGm" = (
 /obj/machinery/photocopier/prebuilt,
+/obj/item/toy/figure/captain,
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/captain)
 "aGn" = (
@@ -10045,6 +10061,10 @@
 "aQS" = (
 /obj/machinery/reagentgrinder,
 /obj/structure/table/wood,
+/obj/item/toy/figure/bartender{
+	pixel_x = -9;
+	pixel_y = 0
+	},
 /turf/open/floor/wood,
 /area/station/service/bar)
 "aQT" = (
@@ -10507,6 +10527,7 @@
 /obj/machinery/newscaster/directional/south,
 /obj/machinery/pdapainter/supply,
 /obj/effect/mapping_helpers/burnt_floor,
+/obj/item/toy/figure/qm,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/qm)
 "aTm" = (
@@ -10934,6 +10955,10 @@
 /obj/structure/dresser,
 /obj/machinery/light/directional/north,
 /obj/structure/sign/poster/contraband/clown/directional/north,
+/obj/item/toy/figure/mime{
+	pixel_x = 11;
+	pixel_y = -10
+	},
 /turf/open/floor/wood/tile,
 /area/station/service/theater)
 "aVm" = (
@@ -11278,6 +11303,7 @@
 	req_access = list("shipping");
 	name = "Cargo Desk"
 	},
+/obj/item/toy/figure/cargotech,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "aWu" = (
@@ -11764,6 +11790,10 @@
 /obj/item/soap,
 /obj/item/bikehorn,
 /obj/item/toy/cattoy,
+/obj/item/toy/figure/clown{
+	pixel_x = -8;
+	pixel_y = 13
+	},
 /turf/open/floor/wood/tile,
 /area/station/service/theater)
 "aYm" = (
@@ -12758,6 +12788,10 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/tile/brown/diagonal_edge,
+/obj/item/toy/figure/bitrunner{
+	pixel_x = 5;
+	pixel_y = 15
+	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/cargo/bitrunning/den)
 "bcE" = (
@@ -15073,6 +15107,7 @@
 /obj/structure/table/wood,
 /obj/item/folder,
 /obj/item/clipboard,
+/obj/item/toy/figure/scientist,
 /turf/open/floor/wood/large,
 /area/station/science/breakroom)
 "bod" = (
@@ -15354,15 +15389,23 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/engineering/atmos)
 "bpR" = (
-/obj/machinery/door/window/right/directional/north{
-	name = "Medbay Front Desk";
-	req_access = list("medical")
+/obj/machinery/door/airlock/maintenance{
+	name = "Research Lab Maintenance"
 	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
-/obj/structure/table/reinforced,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/science/general,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "bpU" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
@@ -15880,11 +15923,8 @@
 /obj/effect/turf_decal/siding/dark_blue{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/office_blue/anticorner/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/science/genetics)
+/turf/open/floor/wood/large,
+/area/station/command/heads_quarters/rd)
 "brK" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -16265,6 +16305,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/brown/filled/end,
+/obj/item/toy/figure/miner,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "btK" = (
@@ -16510,6 +16551,7 @@
 /obj/structure/table/wood,
 /obj/machinery/newscaster/directional/west,
 /obj/machinery/light/directional/west,
+/obj/item/toy/figure/md,
 /turf/open/floor/iron/terracotta,
 /area/station/medical/medbay/central)
 "bvk" = (
@@ -16905,14 +16947,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/mail_sorting/science/rd_office,
 /obj/effect/turf_decal/siding/dark_blue{
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/wood,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/wood/large,
 /area/station/science/research)
 "bxe" = (
@@ -17363,9 +17404,6 @@
 /turf/open/floor/grass,
 /area/station/medical/medbay/central)
 "byD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -17373,8 +17411,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/sign/semiotic/maintenance/directional/west,
-/obj/structure/sink/directional/east,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/white/small,
 /area/station/science/research)
 "byE" = (
@@ -17388,12 +17427,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/item/radio/intercom/directional/south,
 /obj/machinery/holopad,
 /turf/open/floor/iron/white/small,
 /area/station/science/research)
 "byG" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -17745,31 +17782,21 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "bAm" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Research Lab Maintenance"
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green{
+	pixel_x = -4;
+	pixel_y = 12
 	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
+/obj/item/folder/red{
+	pixel_x = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/access/any/science/general,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/obj/item/toy/figure/secofficer,
+/turf/open/floor/iron,
+/area/station/security/office)
 "bAo" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "rdprivacy";
-	name = "Privacy Shutters"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/command/heads_quarters/rd)
+/turf/closed/wall,
+/area/station/science/genetics)
 "bAp" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -17778,18 +17805,15 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/any/science/rd,
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 1
 	},
-/obj/structure/curtain/bounty{
-	color = "BACAFF"
+/obj/machinery/door/airlock/public{
+	name = "Genetics"
 	},
-/obj/machinery/door/airlock/command/glass{
-	name = "Research Director's Office"
-	},
+/obj/effect/mapping_helpers/airlock/access/any/science/genetics,
 /turf/open/floor/iron/white/small,
-/area/station/command/heads_quarters/rd)
+/area/station/science/genetics)
 "bAt" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -17894,19 +17918,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "bAR" = (
-/obj/effect/landmark/start/geneticist,
-/obj/structure/chair/office{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/dark_blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/office_blue/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 4
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
+/mob/living/carbon/human/species/monkey,
+/turf/open/floor/iron/white/small,
 /area/station/science/genetics)
 "bAW" = (
 /obj/effect/decal/cleanable/dirt,
@@ -17929,9 +17943,7 @@
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/rd)
 "bBr" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
+/obj/effect/turf_decal/siding,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -17939,54 +17951,21 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/wood/large,
-/area/station/command/heads_quarters/rd)
+/turf/open/floor/iron/dark/small,
+/area/station/science/genetics)
 "bBs" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/item/kirbyplants/random/dead,
-/obj/structure/closet/secure_closet/research_director,
-/turf/open/floor/wood/large,
-/area/station/command/heads_quarters/rd)
+/obj/machinery/vending/wardrobe/gene_wardrobe,
+/obj/effect/turf_decal/siding,
+/turf/open/floor/iron/dark/small,
+/area/station/science/genetics)
 "bBu" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/keycard_auth{
-	pixel_x = 24;
-	pixel_y = 6
-	},
-/obj/structure/cable,
-/obj/machinery/button/door/directional/east{
-	id = "rndshutters";
-	name = "Research Lockdown";
-	pixel_y = -5;
-	req_access = list("research")
-	},
-/obj/machinery/button/door/directional/east{
-	id = "research_shutters_2";
-	name = "Techfab Shutters";
-	pixel_x = 38;
-	pixel_y = 5;
-	req_access = list("research")
-	},
-/obj/machinery/button/door/directional/east{
-	id = "rdprivacy";
-	name = "Privacy Shutters";
-	pixel_x = 38;
-	pixel_y = -5;
-	req_access = list("rd")
-	},
-/obj/machinery/pdapainter/research,
-/obj/effect/turf_decal/siding/wood{
+/obj/machinery/dna_scannernew,
+/obj/effect/turf_decal/siding/corner{
 	dir = 8
 	},
-/turf/open/floor/iron/white/small,
-/area/station/command/heads_quarters/rd)
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/iron/dark/small,
+/area/station/science/genetics)
 "bBw" = (
 /obj/machinery/computer/security,
 /obj/machinery/light/directional/west,
@@ -18269,31 +18248,34 @@
 	},
 /area/station/medical/chem_storage)
 "bCE" = (
-/obj/machinery/computer/robotics{
+/obj/structure/table,
+/obj/item/radio/headset/headset_medsci{
+	pixel_x = -7;
+	pixel_y = 4
+	},
+/obj/item/radio/headset/headset_medsci{
+	pixel_x = -7;
+	pixel_y = 0
+	},
+/obj/effect/turf_decal/siding{
 	dir = 4
 	},
-/obj/machinery/airalarm/directional/west,
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/turf/open/floor/iron/white/small,
-/area/station/command/heads_quarters/rd)
+/obj/item/toy/figure/geneticist,
+/turf/open/floor/iron/dark/small,
+/area/station/science/genetics)
 "bCG" = (
 /obj/structure/displaycase/labcage,
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/rd)
 "bCI" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/siding/wood{
+/obj/machinery/computer/dna_console{
 	dir = 8
 	},
-/turf/open/floor/iron/white/small,
-/area/station/command/heads_quarters/rd)
+/obj/effect/turf_decal/siding{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/small,
+/area/station/science/genetics)
 "bCK" = (
 /obj/structure/table,
 /obj/machinery/camera/directional/west{
@@ -18304,6 +18286,7 @@
 	dir = 8
 	},
 /obj/item/paper_bin,
+/obj/effect/spawner/random/bureaucracy/pen,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/science)
 "bCL" = (
@@ -18464,52 +18447,56 @@
 	},
 /area/station/medical/chem_storage)
 "bDA" = (
-/obj/machinery/vending/cigarette,
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
-"bDB" = (
-/obj/machinery/computer/rdconsole{
+/obj/effect/turf_decal/tile/office_blue/anticorner/contrasted{
 	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/turf/open/floor/iron/white/small,
-/area/station/command/heads_quarters/rd)
-"bDC" = (
 /obj/structure/chair/office/light{
+	dir = 4
+	},
+/obj/effect/landmark/start/geneticist,
+/turf/open/floor/iron/white/textured,
+/area/station/science/genetics)
+"bDB" = (
+/obj/effect/turf_decal/siding{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/small,
+/area/station/science/genetics)
+"bDC" = (
+/obj/effect/turf_decal/tile/office_blue/anticorner/contrasted{
 	dir = 8
 	},
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/wood/large,
-/area/station/command/heads_quarters/rd)
+/turf/open/floor/iron/white/textured,
+/area/station/science/genetics)
 "bDD" = (
 /obj/machinery/holopad,
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/rd)
 "bDE" = (
-/obj/structure/chair/office/light,
-/obj/effect/landmark/start/research_director,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+/obj/effect/turf_decal/tile/office_blue/anticorner/contrasted,
+/obj/structure/chair/office/light{
+	dir = 4
 	},
-/turf/open/floor/wood/large,
-/area/station/command/heads_quarters/rd)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white/textured,
+/area/station/science/genetics)
 "bDF" = (
-/obj/machinery/modular_computer/preset/id{
-	dir = 8
+/obj/effect/turf_decal/tile/office_blue/half/contrasted{
+	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/turf/open/floor/iron/white/small,
-/area/station/command/heads_quarters/rd)
+/turf/open/floor/iron/white/textured,
+/area/station/science/genetics)
 "bDG" = (
 /obj/structure/table,
 /obj/machinery/recharger{
@@ -18696,55 +18683,61 @@
 /turf/closed/wall,
 /area/station/service/janitor)
 "bER" = (
-/obj/machinery/computer/mecha{
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = -10;
+	pixel_y = -1
+	},
+/obj/item/storage/box/monkeycubes{
+	pixel_x = 4
+	},
+/obj/item/storage/box/monkeycubes{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/obj/item/flesh_shears,
+/obj/item/storage/pill_bottle/mutadone{
+	pixel_x = -8;
+	pixel_y = 9
+	},
+/obj/effect/turf_decal/siding/corner{
 	dir = 4
 	},
-/obj/item/radio/intercom/directional/south,
-/obj/machinery/light_switch/directional/west,
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/white/small,
-/area/station/command/heads_quarters/rd)
+/turf/open/floor/iron/dark/small,
+/area/station/science/genetics)
 "bES" = (
-/obj/item/aicard,
-/obj/item/circuitboard/aicore,
-/obj/machinery/light/directional/south,
-/obj/machinery/newscaster/directional/south,
-/obj/structure/table,
-/obj/effect/turf_decal/siding/wood{
+/obj/structure/chair/office/light,
+/obj/effect/landmark/start/geneticist,
+/obj/effect/turf_decal/siding{
 	dir = 1
 	},
-/turf/open/floor/iron/white/small,
-/area/station/command/heads_quarters/rd)
+/turf/open/floor/iron/dark/small,
+/area/station/science/genetics)
 "bET" = (
-/obj/machinery/camera/directional/south{
-	c_tag = "Research Director's Office";
-	network = list("ss13","rd")
-	},
-/obj/machinery/suit_storage_unit/rd,
-/obj/machinery/airalarm/directional/south,
-/obj/machinery/status_display/evac/directional/south,
-/obj/effect/turf_decal/siding/wood{
+/obj/machinery/dna_infuser,
+/obj/item/infuser_book,
+/obj/effect/turf_decal/siding{
 	dir = 1
 	},
-/turf/open/floor/iron/white/small,
-/area/station/command/heads_quarters/rd)
+/turf/open/floor/iron/dark/small,
+/area/station/science/genetics)
 "bEV" = (
-/obj/machinery/modular_computer/preset/research{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wood/corner{
+/obj/machinery/dna_scannernew,
+/obj/effect/turf_decal/siding/corner{
 	dir = 1
 	},
-/turf/open/floor/iron/white/small,
-/area/station/command/heads_quarters/rd)
+/turf/open/floor/iron/dark/small,
+/area/station/science/genetics)
 "bEW" = (
 /obj/machinery/airalarm/directional/west,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 8
 	},
 /obj/structure/filingcabinet,
+/obj/item/toy/figure/secofficer{
+	pixel_x = -1;
+	pixel_y = 14
+	},
 /turf/open/floor/iron,
 /area/station/security/checkpoint/science)
 "bEX" = (
@@ -18821,13 +18814,13 @@
 /turf/open/floor/iron/dark/small,
 /area/station/science/ordnance/testlab)
 "bFx" = (
-/obj/machinery/door/window/left/directional/north{
-	name = "Monkey Pen";
-	req_access = list("genetics")
+/obj/effect/turf_decal/tile/office_blue/half/contrasted{
+	dir = 1
 	},
-/obj/item/food/grown/banana/bunch,
-/turf/open/floor/grass,
-/area/station/science/genetics)
+/obj/structure/table/wood/fancy/purple,
+/obj/item/flashlight/lamp/green,
+/turf/open/floor/iron/white,
+/area/station/command/heads_quarters/rd)
 "bFB" = (
 /obj/item/newspaper,
 /obj/structure/urinal/directional/west,
@@ -19029,11 +19022,10 @@
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "bGB" = (
-/obj/structure/flora/bush/flowers_br/style_random,
 /obj/machinery/light/directional/south,
-/mob/living/carbon/human/species/monkey,
-/turf/open/floor/grass,
-/area/station/science/genetics)
+/obj/effect/turf_decal/tile/office_blue/half/contrasted,
+/turf/open/floor/iron/white,
+/area/station/command/heads_quarters/rd)
 "bGF" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external{
@@ -19070,20 +19062,19 @@
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den/gaming)
 "bHh" = (
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/tile/office_blue{
-	dir = 1
-	},
-/obj/machinery/status_display/evac/directional/north,
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/obj/structure/table,
+/obj/item/kirbyplants/random/dead,
+/turf/open/floor/iron/dark/small,
+/area/station/command/heads_quarters/rd)
 "bHi" = (
-/obj/structure/chair,
-/obj/effect/turf_decal/tile/office_blue{
-	dir = 1
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/left/directional/north{
+	name = "Genetics Desk"
 	},
+/obj/item/paper_bin,
+/obj/effect/spawner/random/bureaucracy/pen,
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/station/science/genetics)
 "bHj" = (
 /obj/item/storage/belt/utility,
 /obj/item/clothing/glasses/science,
@@ -19094,20 +19085,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "bHk" = (
-/obj/item/gps{
-	gpstag = "RD0"
-	},
-/obj/item/assembly/prox_sensor{
-	pixel_x = -8;
-	pixel_y = 4
-	},
-/obj/item/clothing/ears/earmuffs,
-/obj/structure/table/glass,
-/obj/effect/turf_decal/tile/office_blue{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/obj/machinery/light_switch/directional/north,
+/obj/machinery/keycard_auth/wall_mounted/directional/west,
+/turf/open/floor/iron/dark/small,
+/area/station/command/heads_quarters/rd)
 "bHl" = (
 /obj/effect/spawner/random/epic_loot/random_maint_loot_structure,
 /turf/open/floor/plating,
@@ -20034,6 +20015,7 @@
 /obj/item/pipe_dispenser,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /obj/structure/table/glass,
+/obj/item/toy/figure/atmos,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1
 	},
@@ -21992,7 +21974,6 @@
 /area/station/cargo/storage)
 "bUi" = (
 /obj/structure/table,
-/obj/item/book/manual/wiki/security_space_law,
 /obj/machinery/camera/directional/west{
 	c_tag = "Engineering Security Post"
 	},
@@ -22001,6 +21982,7 @@
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 1
 	},
+/obj/item/toy/figure/secofficer,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/engineering)
 "bUj" = (
@@ -24912,9 +24894,10 @@
 /turf/open/misc/asteroid/airless,
 /area/centcom/asteroid/nearstation/bomb_site)
 "cjB" = (
-/obj/structure/sign/departments/genetics/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
+/obj/structure/lattice,
+/obj/item/toy/figure/ninja,
+/turf/open/space/basic,
+/area/space/nearstation)
 "cjC" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -25858,6 +25841,7 @@
 "cpn" = (
 /obj/item/holosign_creator/robot_seat/restaurant,
 /obj/structure/table/wood,
+/obj/item/toy/figure/chef,
 /turf/open/floor/iron/kitchen/small,
 /area/station/service/kitchen)
 "cpo" = (
@@ -26412,6 +26396,10 @@
 "cso" = (
 /obj/structure/table/wood,
 /obj/item/nullrod,
+/obj/item/toy/figure/chaplain{
+	pixel_x = 7;
+	pixel_y = 0
+	},
 /turf/open/floor/carpet/black,
 /area/station/service/chapel/office)
 "csp" = (
@@ -27966,16 +27954,9 @@
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
 "cPT" = (
-/obj/item/reagent_containers/dropper{
-	pixel_x = -1;
-	pixel_y = 12
-	},
 /obj/item/radio/intercom/directional/north,
-/obj/item/paper_bin,
-/obj/structure/table,
-/obj/effect/spawner/random/bureaucracy/pen,
 /turf/open/floor/iron/dark/small,
-/area/station/science/genetics)
+/area/station/command/heads_quarters/rd)
 "cQs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -28129,6 +28110,7 @@
 	pixel_y = -36;
 	req_access = list("hop")
 	},
+/obj/item/toy/figure/ian,
 /turf/open/floor/carpet/green,
 /area/station/command/heads_quarters/hop)
 "cZT" = (
@@ -28500,20 +28482,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "sci-gene-passthrough"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/science/genetics,
-/obj/machinery/door/airlock/public/glass{
-	name = "Genetics"
-	},
 /obj/effect/turf_decal/tile/office_blue/fourcorners,
+/obj/machinery/door/airlock/command/glass{
+	name = "Research Director's Office"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/science/rd,
 /turf/open/floor/iron/white,
-/area/station/science/genetics)
+/area/station/command/heads_quarters/rd)
 "dqz" = (
-/obj/machinery/holopad,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/science/genetics)
+/obj/structure/lattice,
+/obj/structure/disposalpipe/segment,
+/obj/item/toy/figure/syndie,
+/turf/open/space/basic,
+/area/space/nearstation)
 "dqG" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/atmospherics/components/unary/airlock_pump{
@@ -28689,13 +28670,8 @@
 /obj/effect/turf_decal/siding/dark_blue{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/office_blue/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 8
-	},
-/area/station/science/genetics)
+/turf/open/floor/wood/large,
+/area/station/command/heads_quarters/rd)
 "dvT" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -32073,19 +32049,13 @@
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/pharmacy)
 "gdJ" = (
-/obj/item/storage/box/bodybags{
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/obj/item/storage/box/disks{
-	pixel_x = 6;
-	pixel_y = 4
-	},
 /obj/machinery/newscaster/directional/north,
-/obj/item/radio/headset/headset_medsci,
-/obj/structure/table,
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/obj/effect/landmark/start/research_director,
 /turf/open/floor/iron/dark/small,
-/area/station/science/genetics)
+/area/station/command/heads_quarters/rd)
 "gex" = (
 /obj/effect/spawner/random/trash/food_packaging,
 /turf/open/floor/plating,
@@ -32953,16 +32923,18 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
 "gLS" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/office_blue{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
-/turf/open/floor/iron/white/smooth_corner{
-	dir = 8
-	},
-/area/station/science/genetics)
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "gMf" = (
 /obj/effect/spawner/random/engineering/tank,
 /turf/open/floor/plating,
@@ -33020,9 +32992,12 @@
 /turf/open/floor/plating,
 /area/station/cargo/miningfoundry)
 "gOV" = (
-/mob/living/carbon/human/species/monkey,
-/turf/open/floor/grass,
-/area/station/science/genetics)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/office_blue/half/contrasted,
+/turf/open/floor/iron/white,
+/area/station/command/heads_quarters/rd)
 "gQa" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -33070,17 +33045,7 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/psychology)
 "gRb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/spawner/random/trash/bin,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "gRJ" = (
@@ -33179,11 +33144,8 @@
 /obj/effect/turf_decal/siding/dark_blue{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/office_blue/anticorner/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/science/genetics)
+/turf/open/floor/wood/large,
+/area/station/command/heads_quarters/rd)
 "gXh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/modular_computer/preset/curator{
@@ -33311,9 +33273,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "hfZ" = (
-/obj/machinery/vending/wardrobe/gene_wardrobe,
+/obj/machinery/pdapainter/research,
+/obj/effect/turf_decal/bot_red,
 /turf/open/floor/iron/dark/small,
-/area/station/science/genetics)
+/area/station/command/heads_quarters/rd)
 "hgG" = (
 /obj/structure/shuttle_decoration/headlight/directional/west,
 /turf/closed/wall/r_wall,
@@ -35431,12 +35394,13 @@
 /obj/effect/turf_decal/siding/dark_blue{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/office_blue/anticorner/contrasted{
-	dir = 4
+/obj/structure/table,
+/obj/machinery/fax{
+	fax_name = "Research Director's Office";
+	name = "Research Director's Fax Machine"
 	},
-/obj/structure/sink/directional/south,
-/turf/open/floor/iron/white,
-/area/station/science/genetics)
+/turf/open/floor/wood/large,
+/area/station/command/heads_quarters/rd)
 "iLF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -35710,6 +35674,7 @@
 	pixel_y = 4
 	},
 /obj/structure/fireaxecabinet/mechremoval/directional/east,
+/obj/item/toy/figure/roboticist,
 /turf/open/floor/iron/dark/small,
 /area/station/science/robotics/lab)
 "iZP" = (
@@ -35819,12 +35784,17 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/qm)
 "jdp" = (
-/obj/effect/turf_decal/siding/dark_blue{
-	dir = 1
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/office_blue/fourcorners,
-/turf/open/floor/iron/white,
-/area/station/science/genetics)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "jdA" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/purple/half/contrasted{
@@ -36784,10 +36754,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/aluminum,
 /area/station/salvage_bay)
-"jSA" = (
-/obj/structure/sign/departments/science,
-/turf/closed/wall,
-/area/station/maintenance/department/medical)
 "jSF" = (
 /turf/closed/wall/r_wall,
 /area/station/hallway/secondary/command)
@@ -37237,14 +37203,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "kkQ" = (
-/obj/machinery/computer/dna_console{
-	dir = 8
-	},
 /obj/machinery/camera/directional/east{
 	c_tag = "Genetics Lab East"
 	},
+/obj/machinery/modular_computer/preset/id{
+	dir = 8
+	},
 /turf/open/floor/iron/dark/small,
-/area/station/science/genetics)
+/area/station/command/heads_quarters/rd)
 "kkU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -37310,11 +37276,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/office_blue/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/white/smooth_edge,
-/area/station/science/genetics)
+/turf/open/floor/wood/large,
+/area/station/command/heads_quarters/rd)
 "kmV" = (
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/engine/o2,
@@ -37574,8 +37537,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron/white/smooth_large,
-/area/station/science/genetics)
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/turf/open/floor/wood/large,
+/area/station/command/heads_quarters/rd)
 "kuM" = (
 /obj/machinery/computer/security/telescreen/entertainment,
 /turf/closed/wall,
@@ -37923,6 +37889,7 @@
 	dir = 4
 	},
 /obj/structure/table,
+/obj/item/toy/figure/engineer,
 /turf/open/floor/iron/large,
 /area/station/engineering/lobby)
 "kJw" = (
@@ -38585,11 +38552,12 @@
 	},
 /area/station/medical/medbay/central)
 "llS" = (
-/obj/structure/water_source/puddle,
-/obj/structure/window/reinforced/spawner/directional/north,
-/mob/living/carbon/human/species/monkey,
-/turf/open/floor/grass,
-/area/station/science/genetics)
+/obj/structure/closet/secure_closet/research_director,
+/obj/effect/turf_decal/tile/office_blue/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/command/heads_quarters/rd)
 "llV" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -38816,6 +38784,7 @@
 	req_access = list("cmo")
 	},
 /obj/structure/table,
+/obj/item/toy/figure/cmo,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "lsy" = (
@@ -39040,10 +39009,10 @@
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/surgery)
 "lDw" = (
-/obj/structure/flora/grass/jungle,
-/mob/living/carbon/human/species/monkey,
-/turf/open/floor/grass,
-/area/station/science/genetics)
+/obj/machinery/suit_storage_unit/rd,
+/obj/effect/turf_decal/stripes/box,
+/turf/open/floor/iron/white,
+/area/station/command/heads_quarters/rd)
 "lDB" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/wood{
@@ -39293,11 +39262,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "lNW" = (
-/obj/machinery/computer/dna_console{
+/obj/machinery/computer/mecha{
 	dir = 4
 	},
 /turf/open/floor/iron/dark/small,
-/area/station/science/genetics)
+/area/station/command/heads_quarters/rd)
 "lOw" = (
 /obj/effect/turf_decal/tile/pine_green/anticorner/contrasted{
 	dir = 1
@@ -39384,7 +39353,7 @@
 /obj/machinery/door/firedoor/heavy,
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
-/area/station/science/genetics)
+/area/station/command/heads_quarters/rd)
 "lSM" = (
 /obj/machinery/requests_console/directional/south{
 	department = "Security";
@@ -39434,11 +39403,8 @@
 "lUC" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/office_blue/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/white/smooth_edge,
-/area/station/science/genetics)
+/turf/open/floor/wood/large,
+/area/station/command/heads_quarters/rd)
 "lUY" = (
 /obj/item/radio/intercom/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -40215,6 +40181,10 @@
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/table/reinforced,
 /obj/structure/microscope,
+/obj/item/toy/figure/coroner{
+	pixel_x = -8;
+	pixel_y = 0
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "mwc" = (
@@ -40284,11 +40254,8 @@
 /obj/effect/turf_decal/siding/dark_blue{
 	dir = 5
 	},
-/obj/effect/turf_decal/tile/office_blue/anticorner/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/science/genetics)
+/turf/open/floor/wood/large,
+/area/station/command/heads_quarters/rd)
 "mzA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -40501,15 +40468,17 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/main)
 "mJm" = (
-/obj/machinery/door/window/left/directional/north{
-	name = "Monkey Pen";
-	req_access = list("genetics")
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/grass,
-/area/station/science/genetics)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/office_blue/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/command/heads_quarters/rd)
 "mJL" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/wood/corner{
@@ -40732,14 +40701,14 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "mSc" = (
-/obj/machinery/computer/dna_console{
-	dir = 4
-	},
 /obj/machinery/camera/directional/west{
 	c_tag = "Genetics Lab West"
 	},
+/obj/machinery/computer/rdconsole{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/small,
-/area/station/science/genetics)
+/area/station/command/heads_quarters/rd)
 "mSt" = (
 /obj/item/stack/rods/fifty,
 /turf/open/floor/plating,
@@ -40837,6 +40806,7 @@
 /obj/item/taperecorder,
 /obj/structure/table/wood,
 /obj/machinery/airalarm/directional/south,
+/obj/item/toy/figure/lawyer,
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
 "mYX" = (
@@ -40888,8 +40858,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/iron/white/smooth_large,
-/area/station/science/genetics)
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/turf/open/floor/wood/large,
+/area/station/command/heads_quarters/rd)
 "naq" = (
 /obj/structure/disposaloutlet{
 	dir = 4
@@ -41180,8 +41153,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron/white/smooth_large,
-/area/station/science/genetics)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/wood/large,
+/area/station/command/heads_quarters/rd)
 "nls" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -41487,7 +41463,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "nyN" = (
-/obj/effect/spawner/random/structure/crate,
+/obj/effect/spawner/random/trash/deluxe_garbage/no_mobs_ever,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "nyO" = (
@@ -43314,18 +43290,11 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/warden)
 "oQi" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/turf/open/floor/wood/large,
+/area/station/command/heads_quarters/rd)
 "oQn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -43345,8 +43314,8 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron/white/smooth_large,
-/area/station/science/genetics)
+/turf/open/floor/wood/large,
+/area/station/command/heads_quarters/rd)
 "oQL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -44413,12 +44382,12 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/coldroom)
 "pEa" = (
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/effect/turf_decal/tile/office_blue/anticorner/contrasted{
 	dir = 1
 	},
-/turf/open/floor/grass,
-/area/station/science/genetics)
+/obj/structure/dresser,
+/turf/open/floor/iron/white,
+/area/station/command/heads_quarters/rd)
 "pEh" = (
 /obj/machinery/computer/atmos_control/nitrogen_tank{
 	dir = 1
@@ -44709,8 +44678,9 @@
 /area/station/service/library)
 "pNf" = (
 /obj/machinery/light/directional/east,
+/obj/machinery/photocopier/prebuilt,
 /turf/open/floor/iron/dark/small,
-/area/station/science/genetics)
+/area/station/command/heads_quarters/rd)
 "pNy" = (
 /obj/machinery/atmospherics/components/binary/tank_compressor{
 	dir = 4
@@ -44964,22 +44934,15 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "pXg" = (
-/obj/item/storage/pill_bottle/mutadone{
-	pixel_x = 10;
-	pixel_y = 11
-	},
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = 9;
-	pixel_y = -1
-	},
 /obj/machinery/requests_console/directional/north{
 	department = "Genetics";
 	name = "Genetics Requests Console"
 	},
-/obj/structure/table,
-/obj/item/storage/box/monkeycubes,
+/obj/effect/mapping_helpers/requests_console/assistance,
+/obj/effect/mapping_helpers/requests_console/announcement,
+/obj/effect/mapping_helpers/requests_console/information,
 /turf/open/floor/iron/dark/small,
-/area/station/science/genetics)
+/area/station/command/heads_quarters/rd)
 "pXH" = (
 /obj/effect/landmark/start/shaft_miner,
 /turf/open/floor/iron,
@@ -45170,15 +45133,9 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
 "qgk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/machinery/photocopier/prebuilt,
-/turf/open/floor/wood/large,
-/area/station/command/heads_quarters/rd)
+/obj/effect/turf_decal/siding,
+/turf/open/floor/iron/dark/small,
+/area/station/science/genetics)
 "qgA" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -45406,12 +45363,17 @@
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/captain/private)
 "qmR" = (
-/obj/structure/cable,
+/obj/effect/turf_decal/tile/office_blue/anticorner/contrasted{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/wood/large,
-/area/station/command/heads_quarters/rd)
+/turf/open/floor/iron/white/textured,
+/area/station/science/genetics)
 "qne" = (
 /obj/machinery/door/poddoor/massdriver_ordnance,
 /obj/machinery/atmos_shield_gen/active{
@@ -45584,13 +45546,9 @@
 /obj/effect/turf_decal/siding/dark_blue/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/office_blue{
-	dir = 4
-	},
-/turf/open/floor/iron/white/smooth_corner{
-	dir = 4
-	},
-/area/station/science/genetics)
+/obj/structure/table,
+/turf/open/floor/wood/large,
+/area/station/command/heads_quarters/rd)
 "qqX" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/tile/yellow,
@@ -46692,9 +46650,14 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/chapel/monastery)
 "rlj" = (
-/obj/structure/flora/bush/large/style_random,
-/turf/open/floor/grass,
-/area/station/science/genetics)
+/obj/effect/turf_decal/tile/office_blue/anticorner/contrasted{
+	dir = 8
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/rd,
+/obj/effect/landmark/start/research_director,
+/turf/open/floor/iron/white,
+/area/station/command/heads_quarters/rd)
 "rlk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -48019,9 +47982,11 @@
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
 "sci" = (
-/obj/machinery/dna_scannernew,
+/obj/machinery/computer/robotics{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/small,
-/area/station/science/genetics)
+/area/station/command/heads_quarters/rd)
 "scp" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Auxiliary Base Maintenance"
@@ -48112,6 +48077,7 @@
 	dir = 4
 	},
 /obj/structure/table/reinforced/plasmarglass,
+/obj/item/toy/figure/ce,
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 8
 	},
@@ -48205,14 +48171,8 @@
 /area/station/hallway/primary/central/fore)
 "skj" = (
 /obj/machinery/firealarm/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/office_blue/anticorner/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/science/genetics)
+/turf/closed/wall,
+/area/station/command/heads_quarters/rd)
 "skm" = (
 /obj/effect/turf_decal/tile/office_blue{
 	dir = 1
@@ -48687,19 +48647,9 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "syQ" = (
-/obj/effect/landmark/start/geneticist,
-/obj/structure/chair/office{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/dark_blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/office_blue/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 8
-	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/station/science/genetics)
 "syW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -48775,6 +48725,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/destructible/cult/item_dispenser/archives/library,
 /obj/machinery/airalarm/directional/west,
+/obj/item/toy/figure/curator,
 /turf/open/floor/iron/dark,
 /area/station/service/library/private)
 "sBZ" = (
@@ -48806,11 +48757,10 @@
 /obj/effect/turf_decal/siding/dark_blue{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/office_blue/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/white/smooth_edge,
-/area/station/science/genetics)
+/obj/structure/table,
+/obj/item/anomaly_releaser,
+/turf/open/floor/wood/large,
+/area/station/command/heads_quarters/rd)
 "sDB" = (
 /obj/machinery/requests_console/directional/east{
 	department = "Bridge";
@@ -50878,16 +50828,9 @@
 /turf/open/floor/plating,
 /area/station/security/range)
 "uaY" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/obj/structure/window/reinforced/spawner/directional/east,
+/turf/open/floor/iron/white/small,
+/area/station/science/genetics)
 "ubq" = (
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/engine/plasma,
@@ -51500,12 +51443,9 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/main)
 "uuN" = (
-/obj/effect/turf_decal/siding/dark_blue/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/office_blue/anticorner/contrasted,
-/turf/open/floor/iron/white,
-/area/station/science/genetics)
+/obj/effect/spawner/random/trash/bacteria,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "uuS" = (
 /obj/structure/chair,
 /obj/structure/disposalpipe/segment{
@@ -51661,12 +51601,12 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/medical)
 "uzx" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Genetics Maintenance"
+/obj/effect/turf_decal/tile/office_blue/half/contrasted,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/any/science/genetics,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
+/turf/open/floor/iron/white/textured,
+/area/station/science/genetics)
 "uzL" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/mapping_helpers/dead_body_placer,
@@ -51729,11 +51669,17 @@
 /obj/effect/turf_decal/siding/dark_blue{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/office_blue/half/contrasted{
-	dir = 1
+/obj/structure/table,
+/obj/item/stamp/head/rd{
+	pixel_x = -8;
+	pixel_y = 14
 	},
-/turf/open/floor/iron/white/smooth_edge,
-/area/station/science/genetics)
+/obj/item/paper_bin{
+	pixel_y = 4
+	},
+/obj/effect/spawner/random/bureaucracy/pen,
+/turf/open/floor/wood/large,
+/area/station/command/heads_quarters/rd)
 "uAF" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/dark,
@@ -52059,9 +52005,6 @@
 	},
 /area/station/medical/treatment_center)
 "uQB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -52069,6 +52012,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "uQR" = (
@@ -53995,8 +53939,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron/white/smooth_large,
-/area/station/science/genetics)
+/turf/open/floor/wood/large,
+/area/station/command/heads_quarters/rd)
 "wjH" = (
 /obj/effect/turf_decal/tile/electric_yellow/half/contrasted{
 	dir = 4
@@ -54511,11 +54455,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/office_blue/half/contrasted,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/airlock/command{
+	name = "Research Director's Bunk"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/science/rd,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1
 	},
-/area/station/science/genetics)
+/area/station/command/heads_quarters/rd)
 "wDf" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "telelab";
@@ -54637,11 +54587,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "wFT" = (
-/obj/effect/turf_decal/tile/office_blue/half/contrasted,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/science/genetics)
+/turf/open/floor/wood/large,
+/area/station/command/heads_quarters/rd)
 "wFZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -55219,10 +55166,11 @@
 /turf/open/floor/carpet/green,
 /area/station/command/bridge)
 "xan" = (
-/obj/machinery/dna_infuser,
-/obj/item/infuser_book,
+/obj/structure/table,
+/obj/item/aicard,
+/obj/item/toy/figure/rd,
 /turf/open/floor/iron/dark/small,
-/area/station/science/genetics)
+/area/station/command/heads_quarters/rd)
 "xat" = (
 /obj/effect/landmark/atmospheric_sanity/ignore_area,
 /turf/open/floor/carpet,
@@ -55346,30 +55294,15 @@
 /turf/open/floor/iron/dark/small,
 /area/station/science/xenobiology)
 "xdL" = (
-/obj/item/stamp/head/rd{
-	pixel_x = -8;
-	pixel_y = 14
-	},
-/obj/item/computer_disk/ordnance,
-/obj/item/computer_disk/ordnance,
-/obj/item/computer_disk/ordnance,
-/obj/item/folder/white{
-	pixel_x = 7;
-	pixel_y = 4
-	},
-/obj/structure/table,
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding{
 	dir = 1
 	},
-/obj/item/anomaly_releaser,
-/obj/item/radio/headset/headset_med{
-	name = "CMO Hotline";
-	desc = "A headset provided by medical to assist collaboration on mechanical patients.";
-	icon_state = "rob_headset"
-	},
 /obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/white/small,
-/area/station/command/heads_quarters/rd)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/small,
+/area/station/science/genetics)
 "xdY" = (
 /obj/machinery/door/window/right/directional/east{
 	name = "Danger: Conveyor Access";
@@ -55700,11 +55633,8 @@
 /area/station/command/heads_quarters/cmo)
 "xlA" = (
 /obj/machinery/airalarm/directional/south,
-/obj/effect/turf_decal/tile/office_blue/half/contrasted,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/science/genetics)
+/turf/open/floor/wood/large,
+/area/station/command/heads_quarters/rd)
 "xlD" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -55757,15 +55687,12 @@
 /turf/open/floor/plating,
 /area/station/service/library)
 "xnp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
+/obj/machinery/door/window/left/directional/east{
+	name = "Monkey Pen";
+	req_access = list("genetics")
 	},
-/obj/effect/turf_decal/tile/office_blue/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 4
-	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/white/small,
 /area/station/science/genetics)
 "xog" = (
 /obj/structure/cable,
@@ -56402,23 +56329,24 @@
 /turf/open/floor/iron/large,
 /area/station/engineering/lobby)
 "xLS" = (
-/obj/machinery/requests_console/directional/west{
-	department = "Research Director's Desk";
-	name = "Research Director's Requests Console"
+/obj/structure/rack,
+/obj/item/storage/box/bodybags{
+	pixel_x = -3;
+	pixel_y = -1
 	},
-/obj/effect/mapping_helpers/requests_console/announcement,
-/obj/effect/mapping_helpers/requests_console/information,
-/obj/effect/mapping_helpers/requests_console/assistance,
-/obj/structure/table/glass,
-/obj/machinery/fax{
-	fax_name = "Research Director's Office";
-	name = "Research Director's Fax Machine"
+/obj/item/storage/box/gloves{
+	pixel_x = 1;
+	pixel_y = 3
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
+/obj/item/storage/box/disks{
+	pixel_x = 5;
+	pixel_y = 6
 	},
-/turf/open/floor/iron/white/small,
-/area/station/command/heads_quarters/rd)
+/obj/effect/turf_decal/siding/corner,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/small,
+/area/station/science/genetics)
 "xMg" = (
 /obj/machinery/power/turbine/inlet_compressor,
 /turf/open/floor/engine,
@@ -77330,7 +77258,7 @@ rLV
 rLV
 nVU
 bUD
-bPy
+dqz
 ctS
 aaa
 aaa
@@ -81294,7 +81222,7 @@ kTl
 ajl
 ajY
 idZ
-qAT
+bAm
 amn
 qzW
 amn
@@ -83603,7 +83531,7 @@ ecV
 cAI
 vRp
 vRp
-aht
+cjB
 ajs
 sip
 akX
@@ -86491,7 +86419,7 @@ tcV
 bmw
 tcV
 uzr
-bpR
+iXh
 hPm
 jWH
 nYu
@@ -89581,9 +89509,9 @@ gVk
 gVk
 gVk
 gVk
-gVk
-gVk
-gVk
+gLS
+jdp
+uQB
 uQB
 cLB
 cLB
@@ -89838,11 +89766,11 @@ qhP
 bro
 lRN
 lRN
+bpR
 lRN
-lRN
-oJj
+uuN
 gRb
-oPH
+nyN
 oPH
 oJj
 cGr
@@ -90096,12 +90024,12 @@ cSK
 duF
 bxa
 byD
-bAm
-uaY
-oQi
-bDA
-nyN
-jSA
+lRN
+lRN
+lRN
+lRN
+lRN
+lRN
 sZD
 voL
 bJD
@@ -90353,12 +90281,12 @@ eYV
 eYV
 eYV
 byE
-lRN
-lRN
-lRN
-lRN
-lRN
-lRN
+bAo
+bAR
+bAR
+xnp
+uaY
+jiD
 prg
 bIx
 sAC
@@ -90615,8 +90543,8 @@ xLS
 bCE
 bDB
 bER
-bBp
-bHh
+syQ
+skm
 bIx
 sAC
 qOx
@@ -90872,8 +90800,8 @@ bBr
 qmR
 bDC
 bES
-bBp
 bHi
+skm
 bIx
 sAC
 qOx
@@ -91124,13 +91052,13 @@ buq
 bvx
 bxe
 byH
-bAo
+syQ
 bBs
-bCG
-qOD
+bDF
+uzx
 bET
-bBp
-bHj
+syQ
+skm
 bIx
 sAC
 uSE
@@ -91381,13 +91309,13 @@ bur
 bvy
 bxf
 vXf
-bAo
+syQ
 qgk
-bDD
+bDA
 bDE
 xdL
-bBp
-bHk
+jiD
+bHj
 bIx
 bJE
 qOx
@@ -91638,12 +91566,12 @@ wOt
 qeP
 bxg
 mdL
-bAo
+syQ
 bBu
 bCI
-bDF
+bCI
 bEV
-bBp
+jiD
 auw
 bIx
 bJF
@@ -91895,12 +91823,12 @@ rzS
 hqT
 bxh
 bqb
-fRs
-fRs
 bAo
 bAo
-fRs
-bBp
+syQ
+syQ
+bAo
+jiD
 eaB
 eKI
 tWh
@@ -100374,11 +100302,11 @@ brR
 btt
 brR
 bkF
-sci
+bHk
 lNW
 mSc
 sci
-jiD
+bBp
 glf
 bFr
 joE
@@ -100632,10 +100560,10 @@ eOJ
 wkZ
 xJW
 brJ
-bAR
-bAR
+brJ
+brJ
 gXg
-jiD
+bBp
 pNy
 bFr
 fbf
@@ -101147,7 +101075,7 @@ bkF
 bkF
 lUC
 wjw
-nkZ
+oQi
 wFT
 lRW
 bEf
@@ -101404,9 +101332,9 @@ xzp
 bkF
 iLl
 qqS
-dqz
+bDD
 xlA
-jiD
+bBp
 hzn
 hzn
 hzn
@@ -101662,8 +101590,8 @@ bkF
 gdJ
 uAx
 kut
-gLS
-xnp
+qOD
+bCG
 skj
 pEa
 rlj
@@ -102175,14 +102103,14 @@ wFN
 bkF
 cPT
 mzp
-syQ
 dvR
 dvR
-uuN
+dvR
+fRs
 bFx
 bGB
 rKi
-cjB
+lWy
 bwm
 aht
 bwm
@@ -102433,12 +102361,12 @@ bkF
 hfZ
 pNf
 kkQ
-sci
+bHh
 xan
-jdp
+fRs
 llS
 lDw
-uzx
+rKi
 uug
 bwm
 aht

--- a/_maps/map_files/Pubbystation/pubbystation.dmm
+++ b/_maps/map_files/Pubbystation/pubbystation.dmm
@@ -17950,6 +17950,9 @@
 "bBs" = (
 /obj/machinery/vending/wardrobe/gene_wardrobe,
 /obj/effect/turf_decal/siding,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark/small,
 /area/station/science/genetics)
 "bBu" = (
@@ -18449,7 +18452,10 @@
 /obj/effect/turf_decal/siding{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/dark/small,
@@ -18464,6 +18470,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white/textured,
 /area/station/science/genetics)
 "bDD" = (
@@ -18700,6 +18707,7 @@
 /obj/effect/turf_decal/siding{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/small,
 /area/station/science/genetics)
 "bET" = (
@@ -19061,8 +19069,13 @@
 	name = "Monkey Pen";
 	req_access = list("genetics")
 	},
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/white/small,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/grass,
 /area/station/science/genetics)
 "bHj" = (
 /obj/item/storage/belt/utility,
@@ -19074,9 +19087,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "bHk" = (
-/obj/effect/spawner/random/trash/deluxe_garbage/no_mobs_ever,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/obj/machinery/camera/autoname/directional/west,
+/obj/effect/spawner/random/bananas_or_nothing,
+/turf/open/floor/grass,
+/area/station/science/genetics)
 "bHl" = (
 /obj/effect/spawner/random/epic_loot/random_maint_loot_structure,
 /turf/open/floor/plating,
@@ -24882,9 +24896,9 @@
 /turf/open/misc/asteroid/airless,
 /area/centcom/asteroid/nearstation/bomb_site)
 "cjB" = (
-/obj/effect/spawner/random/trash/bacteria,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/obj/machinery/light/directional/west,
+/turf/open/floor/grass,
+/area/station/science/genetics)
 "cjC" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -32912,8 +32926,10 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "gLS" = (
 /obj/structure/window/reinforced/spawner/directional/east,
-/obj/machinery/camera/autoname/directional/west,
-/turf/open/floor/iron/white/small,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/grass,
 /area/station/science/genetics)
 "gMf" = (
 /obj/effect/spawner/random/engineering/tank,
@@ -33026,9 +33042,13 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/psychology)
 "gRb" = (
-/obj/effect/spawner/random/trash/bin,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/obj/structure/window/reinforced/spawner/directional/east,
+/mob/living/carbon/human/species/monkey,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/station/science/genetics)
 "gRJ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
@@ -39243,6 +39263,12 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
+"lMS" = (
+/obj/machinery/airalarm/directional/west,
+/obj/structure/flora/grass/jungle,
+/obj/structure/sign/poster/contraband/rush_propaganda/directional/north,
+/turf/open/floor/grass,
+/area/station/science/genetics)
 "lMT" = (
 /obj/machinery/power/tracker,
 /obj/structure/cable,
@@ -43289,7 +43315,9 @@
 "oQi" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /mob/living/carbon/human/species/monkey,
-/turf/open/floor/iron/white/small,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/sign/poster/official/corporate_perks_vacation/directional/north,
+/turf/open/floor/grass,
 /area/station/science/genetics)
 "oQn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -45130,6 +45158,9 @@
 /area/station/service/chapel/office)
 "qgk" = (
 /obj/effect/turf_decal/siding,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark/small,
 /area/station/science/genetics)
 "qgA" = (
@@ -45368,6 +45399,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white/textured,
 /area/station/science/genetics)
 "qne" = (
@@ -48834,6 +48866,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/security/range)
+"sGM" = (
+/mob/living/carbon/human/species/monkey,
+/turf/open/floor/grass,
+/area/station/science/genetics)
 "sHy" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Holodeck Control";
@@ -50828,6 +50864,8 @@
 	},
 /obj/item/paper_bin,
 /obj/effect/spawner/random/bureaucracy/pen,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/science/genetics)
 "ubq" = (
@@ -89778,10 +89816,10 @@ lRN
 lRN
 jdp
 lRN
-cjB
-gRb
-bHk
-oPH
+lRN
+lRN
+lRN
+lRN
 oJj
 cGr
 bIu
@@ -90034,12 +90072,12 @@ cSK
 duF
 bxa
 byD
-lRN
-lRN
-lRN
-lRN
-lRN
-lRN
+syQ
+lMS
+sGM
+cjB
+bHk
+jiD
 sZD
 voL
 bJD
@@ -90293,7 +90331,7 @@ eYV
 byE
 syQ
 oQi
-oQi
+gRb
 bHi
 gLS
 jiD

--- a/_maps/map_files/Pubbystation/pubbystation.dmm
+++ b/_maps/map_files/Pubbystation/pubbystation.dmm
@@ -18284,6 +18284,7 @@
 	},
 /obj/item/paper_bin,
 /obj/effect/spawner/random/bureaucracy/pen,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/science)
 "bCL" = (
@@ -18294,6 +18295,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/science)
 "bCM" = (
@@ -19087,8 +19089,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "bHk" = (
-/obj/machinery/camera/autoname/directional/west,
-/obj/effect/spawner/random/bananas_or_nothing,
+/obj/machinery/airalarm/directional/west,
+/obj/structure/flora/grass/jungle,
+/obj/structure/sign/poster/contraband/rush_propaganda/directional/north,
 /turf/open/floor/grass,
 /area/station/science/genetics)
 "bHl" = (
@@ -24896,7 +24899,8 @@
 /turf/open/misc/asteroid/airless,
 /area/centcom/asteroid/nearstation/bomb_site)
 "cjB" = (
-/obj/machinery/light/directional/west,
+/obj/machinery/camera/autoname/directional/west,
+/obj/effect/spawner/random/bananas_or_nothing,
 /turf/open/floor/grass,
 /area/station/science/genetics)
 "cjC" = (
@@ -33044,9 +33048,8 @@
 "gRb" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /mob/living/carbon/human/species/monkey,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/sign/poster/official/corporate_perks_vacation/directional/north,
 /turf/open/floor/grass,
 /area/station/science/genetics)
 "gRJ" = (
@@ -39263,12 +39266,6 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
-"lMS" = (
-/obj/machinery/airalarm/directional/west,
-/obj/structure/flora/grass/jungle,
-/obj/structure/sign/poster/contraband/rush_propaganda/directional/north,
-/turf/open/floor/grass,
-/area/station/science/genetics)
 "lMT" = (
 /obj/machinery/power/tracker,
 /obj/structure/cable,
@@ -43315,8 +43312,9 @@
 "oQi" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /mob/living/carbon/human/species/monkey,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/structure/sign/poster/official/corporate_perks_vacation/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/grass,
 /area/station/science/genetics)
 "oQn" = (
@@ -45647,6 +45645,10 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
+"qtO" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/grass,
+/area/station/science/genetics)
 "qtR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -48866,10 +48868,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/security/range)
-"sGM" = (
-/mob/living/carbon/human/species/monkey,
-/turf/open/floor/grass,
-/area/station/science/genetics)
 "sHy" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Holodeck Control";
@@ -49420,6 +49418,10 @@
 /obj/effect/mapping_helpers/airlock/access/any/medical/morgue,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
+"tbX" = (
+/mob/living/carbon/human/species/monkey,
+/turf/open/floor/grass,
+/area/station/science/genetics)
 "tck" = (
 /obj/structure/table,
 /obj/effect/spawner/random/armory/dragnet,
@@ -90073,10 +90075,10 @@ duF
 bxa
 byD
 syQ
-lMS
-sGM
-cjB
 bHk
+tbX
+qtO
+cjB
 jiD
 sZD
 voL
@@ -90330,8 +90332,8 @@ eYV
 eYV
 byE
 syQ
-oQi
 gRb
+oQi
 bHi
 gLS
 jiD


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Genetics is a crew-facing service. The RD's office is a private area. And yet, their locations on Pubby were counter to their purpose. The RD's office was surrounded by a public hall, and genetics was stuffed in a back room. This PR switches their locations.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It should be much easier for genetics players to interact with the crew, advertise their services, and get help when their test subjects attack them. They also get the benefit of a desk and windoor facing a public hall.
The RD's office is now a more private location, and has the added benefit of a bunk/private storage.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Testing Evidence
<img width="766" height="641" alt="Screenshot 2026-08-06 150902" src="https://github.com/user-attachments/assets/0503d237-6ea7-4ad9-b11a-264ed50f4592" />
<img width="407" height="510" alt="Screenshot 2026-08-06 150914" src="https://github.com/user-attachments/assets/297488d2-5415-475b-8e10-c2571b4f6a41" />
<!-- Provide proof that the content added, edited, or removed by this pull request is working as intended in-game. Compiling alone doesn't guarantee functionality, so be sure to test thoroughly! -->

## Changelog
Exchanged the location of Genetics and the RD's office. RD's office is now slightly bigger than before, while genetics is slightly smaller. Expanded the footprint of the new genetics location to compensate.
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
map: added/modified/removed map content
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
