### PR TITLE
fixes issue #826, signers can use the DO verb if they are holding things

### DIFF
--- a/modular_doppler/verbs/code/do_verbs.dm
+++ b/modular_doppler/verbs/code/do_verbs.dm
@@ -14,9 +14,6 @@
 	if (!message || !doverb_checks(message))
 		return
 
-	if (!try_speak(message)) // ensure we pass the vibe check (filters, etc)
-		return
-
 	var/name_stub = " (<b>[usr]</b>)"
 	message = usr.apply_message_emphasis(message)
 	message = trim(copytext_char(message, 1, (MAX_MESSAGE_LEN - length(name_stub))))


### PR DESCRIPTION
## About The Pull Request

fixes #826, which prevented sign languager players from participating as narrators in their own stories under special circumstances

## Why It's Good For The Game

i fixed the bug the way that i did, thinking that narration should NOT be checked the same way character dialogue is, since the two perspectives are wildly different. a third-person narrator would say things that would be filtered if it was spoken through first-person speech.

## Testing Evidence

minute-and-a-half-long silent video of me showing that you can indeed *do with your hands full now

https://github.com/user-attachments/assets/e4d19427-cf19-4e77-9d0e-6f890f8015b5


## Changelog


:cl: PowerfulAtom111
fix: players with characters using sign language can now use the *do verb even if their character's hands are occupied
/:cl:
