### PR TITLE
Makes the Piledriver actually spawn

### DIFF
--- a/modular_doppler/ruins_but_epic/code/space_junk.dm
+++ b/modular_doppler/ruins_but_epic/code/space_junk.dm
@@ -7,6 +7,8 @@
 	name = "Space-Ruin Marauder Piledriver-class Wreck"
 	description = "Sometimes, a more aggressive form of action is required. Decisive ramming into boarding is how the Piledriver was meant to operate. \
 		Such crews are often hunted, and directly killed by 4CA Void Corps interceptors before performing their raids."
+	cost = 0
+	always_place = TRUE
 
 // New 9LP lore that buoys are always launched in groups of nine, for good luck
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes the Piledriver-class space ruin made for Doppler actually generate in-game, after I made an oversight in the code. It worked when I force-spawned it, but I didn't realize it wasn't actually spawning naturally.

## Why It's Good For The Game

Merged content made to actually appear in the game should do just that.

## Testing Evidence

Naturally, I'm having trouble actually locating this when jumping in-game and I can't force it else it ruins the test, but it compiles and otherwise the ruin is perfectly functional. This should just make it generate naturally.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Piledriver ruin actually loads
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
