### PR TITLE
AutoDrobe in Pubbystation

### DIFF
--- a/_maps/map_files/Pubbystation/pubbystation.dmm
+++ b/_maps/map_files/Pubbystation/pubbystation.dmm
@@ -6766,7 +6766,6 @@
 /area/station/service/chapel/storage)
 "aBT" = (
 /obj/machinery/wall_healer/directional/south,
-/obj/structure/closet/wardrobe/mixed,
 /turf/open/floor/iron/white/corner,
 /area/station/commons/fitness)
 "aBU" = (
@@ -6774,7 +6773,7 @@
 /turf/open/floor/iron/white/corner,
 /area/station/commons/fitness)
 "aBV" = (
-/obj/structure/closet/wardrobe/green,
+/obj/structure/closet/wardrobe/mixed,
 /turf/open/floor/iron/white/corner,
 /area/station/commons/fitness)
 "aBW" = (

--- a/_maps/map_files/Pubbystation/pubbystation.dmm
+++ b/_maps/map_files/Pubbystation/pubbystation.dmm
@@ -6766,10 +6766,11 @@
 /area/station/service/chapel/storage)
 "aBT" = (
 /obj/machinery/wall_healer/directional/south,
+/obj/structure/closet/wardrobe/mixed,
 /turf/open/floor/iron/white/corner,
 /area/station/commons/fitness)
 "aBU" = (
-/obj/structure/closet/wardrobe/mixed,
+/obj/structure/closet/wardrobe/grey,
 /turf/open/floor/iron/white/corner,
 /area/station/commons/fitness)
 "aBV" = (
@@ -6777,13 +6778,13 @@
 /turf/open/floor/iron/white/corner,
 /area/station/commons/fitness)
 "aBW" = (
-/obj/structure/closet/wardrobe/grey,
 /obj/machinery/light/directional/south,
+/obj/structure/closet/wardrobe/black,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/white/corner,
 /area/station/commons/fitness)
 "aBX" = (
-/obj/structure/closet/wardrobe/black,
-/obj/machinery/firealarm/directional/south,
+/obj/machinery/vending/autodrobe,
 /turf/open/floor/iron/white/corner,
 /area/station/commons/fitness)
 "aCc" = (
@@ -97992,7 +97993,7 @@ lFK
 pcg
 eWq
 pfF
-aBU
+aBV
 xkF
 aEg
 aGF
@@ -98249,7 +98250,7 @@ ayu
 mKl
 azD
 pfF
-aBV
+aBU
 xkF
 aEg
 ycl


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<details>
  <summary>AutoDrobe in Pubbystation.</summary>
  This PR adds an AutoDrobe to Pubbystation's dormitories across the ClothesMate, for ease of access to outfitting supplies. It also shifts the closets to the left, so this will not be blocking the Deforest First Aid Station (and shifts the fire alarm to the side as well, for similar reasoning). A side-effect is that Cursed players cannot enter the Holodeck from this side without risk. I consider this a feature.
</details>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<details>
  <summary>AutoDrobe in Pubbystation.</summary>
  In case someone is wishing to make a change to their outfit mid-game, it is nice to have a greater array of options available at roundstart, not to mention that having an AutoDrobe accessible in these areas is quite typical for other maps.
</details>

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Testing Evidence

<img width="1714" height="1834" alt="image" src="https://github.com/user-attachments/assets/b835423c-be51-4e64-9459-8efaa559efa2" />

<!-- Provide proof that the content added, edited, or removed by this pull request is working as intended in-game. Compiling alone doesn't guarantee functionality, so be sure to test thoroughly! -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Virelai
add: AutoDrobe in Pubbystation.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
