### PR TITLE
Busts the Cargo Union - Removal of Union Alt Titles

### DIFF
--- a/modular_doppler/modular_jobs/code/alt_job_titles/departments/supply.dm
+++ b/modular_doppler/modular_jobs/code/alt_job_titles/departments/supply.dm
@@ -6,7 +6,6 @@
 		"Head of Supply",
 		"Logistics Coordinator",
 		"Supply Foreman",
-		"Union Requisitions Officer",
 		"Warehouse Supervisor",
 	)
 
@@ -22,13 +21,11 @@
 		"Courier",
 		"Mail Carrier",
 		"Receiving Clerk",
-		"Union Associate",
 	)
 
 /datum/job/shaft_miner
 	alt_titles = list(
 		JOB_SHAFT_MINER,
-		"Union Miner",
 		"Excavator",
 		"Drill Technician",
 		"Prospector",
@@ -43,6 +40,5 @@
 		"Data Retrieval Specialist",
 		"Netdiver",
 		"Pod Jockey",
-		"Union Bitrunner",
 		"Junior Runner",
 	)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

All union alt titles for cargo have been removed, for compliance with lore. These are holdovers from NovaStation, which we are not.

## Why It's Good For The Game

Maintainers wanted to remove them, so they're going poof.

## Testing Evidence

<!-- Provide proof that the content added, edited, or removed by this pull request is working as intended in-game. Compiling alone doesn't guarantee functionality, so be sure to test thoroughly! -->

## Changelog

<img width="163" height="177" alt="image" src="https://github.com/user-attachments/assets/88c090ad-3541-4696-9a40-5774819949ea" />
<img width="173" height="201" alt="image" src="https://github.com/user-attachments/assets/837f672b-a198-4d5d-8e77-e3fe71ee875a" />

:cl:
del: Cargo lost the union negotiations, and no longer has union job titles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
