### PR TITLE
Certain things now only alter records if they're for crew

### DIFF
--- a/modular_doppler/modular_powers/code/powers_living.dm
+++ b/modular_doppler/modular_powers/code/powers_living.dm
@@ -146,6 +146,8 @@
 	var/lookup_name = name
 	if(ishuman(src))
 		var/mob/living/carbon/human/human_self = src
+		if(human_self.mind.assigned_role.faction != FACTION_STATION)
+			return
 		lookup_name = human_self.real_name
 
 	var/datum/record/crew/target = find_record(lookup_name)

--- a/modular_doppler/prescription_quirk/prescription_quirk.dm
+++ b/modular_doppler/prescription_quirk/prescription_quirk.dm
@@ -16,6 +16,9 @@
 	icon = FA_ICON_PRESCRIPTION_BOTTLE_MEDICAL
 
 /datum/quirk/item_quirk/prescription/post_add()
+	var/mob/living/carbon/human/human_holder = quirk_holder
+	if(human_holder.mind.assigned_role.faction != FACTION_STATION)
+		return
 	var/obj/machinery/announcement_system/aas = get_announcement_system(source = src)
 	if (aas)
 		aas.broadcast(medical_record_text, list(RADIO_CHANNEL_MEDICAL))

--- a/modular_doppler/underworld_connections/underworld_connections_quirk.dm
+++ b/modular_doppler/underworld_connections/underworld_connections_quirk.dm
@@ -49,7 +49,7 @@
 	// Set us as 'suspected' on HUDs at roundstart and leave a note about our dark and mysterious past. No permits for us! If we're human.
 	if (ishuman(quirk_holder))
 		var/mob/living/carbon/human/human_holder = quirk_holder
-		if(HAS_TRAIT(human_holder, TRAIT_BITRUNNER_AVATAR))
+		if(human_holder.mind.assigned_role.faction != FACTION_STATION)
 			return
 		var/datum/record/crew/our_record = find_record(human_holder.name)
 		if (our_record)
@@ -59,7 +59,7 @@
 /datum/quirk/item_quirk/underworld_connections/remove()
 	if (ishuman(quirk_holder))
 		var/mob/living/carbon/human/human_holder = quirk_holder
-		if(HAS_TRAIT(human_holder, TRAIT_BITRUNNER_AVATAR))
+		if(human_holder.mind.assigned_role.faction != FACTION_STATION)
 			return
 		var/datum/record/crew/our_record = find_record(human_holder.name)
 		if (isnull(our_record))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Certain quirks (and powers) only update/interact with records if your job's assigned faction is STATION. This overwrites some of my previous fixes to things like bitrunner avatars spamming records with black market quirk stuff.
Powers will also not update records for non-crew. This is niche, but if someone has the same name (like if you're doing a clone cantag of a crew member) it won't override the records of the crew member. It also won't announce to medical if you're using the prescription quirk as non-crew (for some reason).
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
If you're running a clone bit they won't give you false power records. Also being put to 'Suspected' is bad.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Testing Evidence
Tested it, it works. Joined as a crewmember on the test map, aghosted, put on the black market quirk and made a Regular at the Cantina sleeper. Joined like that, and the crewmember wasn't suddenly put to suspected sec status.
<!-- Provide proof that the content added, edited, or removed by this pull request is working as intended in-game. Compiling alone doesn't guarantee functionality, so be sure to test thoroughly! -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:NewyearnewmeUwu
fix:Changed how quirks like Black Market Connections affected records in relation to non-crew. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
