### PR TITLE
Uplink Melee Price Edits & 3 New Kits

### DIFF
--- a/modular_doppler/modular_uplink/code/dangerous.dm
+++ b/modular_doppler/modular_uplink/code/dangerous.dm
@@ -3,7 +3,7 @@
 	desc = "A sheath carrying a rare Tajaran vibroblade. The oscillation allows the tip to bite through many \
 	substances by the weapon's own weight alone."
 	item = /obj/item/storage/belt/tajaran_sheath/vibro
-	cost = 8 // esword but it ignores 75% of armor and has a cool sheath
+	cost = 6 // esword sidegrade
 	purchasable_from = ~(UPLINK_ALL_SYNDIE_OPS)
 
 /datum/uplink_item/dangerous/bolt_thrower
@@ -29,35 +29,35 @@
 	to achieve such a lengthy blade. Exotic amendments to its constituent alloys allow for keener edge and help alleviate a rare \
 	phenomena where clashed blades in near vacuum can contact weld to one another."
 	item = /obj/item/melee/tizirian_sword/megachoppa
-	cost = 5 // weaker than an esword & can't be hidden at all
+	cost = 4 // weaker than an esword & can't be hidden at all
 	purchasable_from = ~(UPLINK_ALL_SYNDIE_OPS)
 
 /datum/uplink_item/dangerous/saber
 	name = "Saber"
 	desc = "Forged by the artisan clans of the Uz'ka, it's a medium-sized, one-handed weapon that can cut through lightly armored or unarmored foes with utter ease. A staple for every member when going through their rites."
 	item = /obj/item/claymore/cutlass
-	cost = 8 // identical to an esword but cool looking
+	cost = 6 // identical to an esword but cool looking
 	purchasable_from = ~(UPLINK_ALL_SYNDIE_OPS)
 
 /datum/uplink_item/dangerous/baseball
 	name = "Ablative Bat"
 	desc = "Specially forged by the highest ranking artisan clans, this bat was given to some of the Zar'Khet to act as vanguards. Used to dispel laser fire more commonly used in hostile lands, it gave a sense of courage and pride to those in the ranks."
 	item = /obj/item/melee/baseball_bat/ablative
-	cost = 6 // weaker than an esword but makes you laser immune which is really funny
+	cost = 4 // weaker than an esword but makes you laser immune which is really funny
 	purchasable_from = ~(UPLINK_ALL_SYNDIE_OPS)
 
 /datum/uplink_item/dangerous/minigun
 	name = "Laser Minigun Backpack"
 	desc = "A hefty power-pack that comes with a linked laser minigun capable of outputting a terrifying volley of firepower in full-auto. The power-pack must be worn on your back to be utilized properly, and the minigun may need time to cool after overheating."
 	item = /obj/item/minigunpack
-	cost = 8 // can't exactly hide it and it has some clear downsides
+	cost = 6 // can't exactly hide it and it has some clear downsides
 	purchasable_from = ~(UPLINK_ALL_SYNDIE_OPS)
 
 /datum/uplink_item/dangerous/shrink_ray
 	name = "Shrink Ray"
 	desc = "This is a piece of frightening Grey tech that enhances the magnetic pull of atoms in a localized space to temporarily make an object shrink. Great for break-ins, or cutting a foe down to size. "
 	item = /obj/item/gun/energy/shrink_ray/thinktank
-	cost = 16 // free instant passage through walls & makes an opponent drop literally all of their stuff when hit
+	cost = 15 // free instant passage through walls & makes an opponent drop literally all of their stuff when hit
 	purchasable_from = ~(UPLINK_ALL_SYNDIE_OPS)
 
 /datum/uplink_item/dangerous/spikeroach_nade

--- a/modular_doppler/modular_uplink/code/kit_special.dm
+++ b/modular_doppler/modular_uplink/code/kit_special.dm
@@ -14,12 +14,12 @@
 	cost = 20
 	purchasable_from = ~(UPLINK_ALL_SYNDIE_OPS | UPLINK_SPY)
 
-/datum/uplink_item/speckit/juggernuat
+/datum/uplink_item/speckit/juggernaut
 	name = "Juggernaut Care Package"
 	desc = "The heaviest suit of armor sophont hands could possibly make alongside a laser minigun backpack, various medical \
 		airhypos, a shell launch system, and a hormone regulator, purpose-built to keep the user standing no matter the damage \
 		that they might physically take."
-	item = /obj/item/storage/box/syndicate/bundle/juggernuat
+	item = /obj/item/storage/box/syndicate/bundle/juggernaut
 	cost = 20
 	purchasable_from = ~(UPLINK_ALL_SYNDIE_OPS | UPLINK_SPY)
 

--- a/modular_doppler/modular_uplink/code/kit_special.dm
+++ b/modular_doppler/modular_uplink/code/kit_special.dm
@@ -5,6 +5,24 @@
 /datum/uplink_item/speckit
 	category = /datum/uplink_category/special_kits
 
+/datum/uplink_item/speckit/tizzyraider
+	name = "Tiziran Raider Suite"
+	desc = "A bolt-thrower, raider MODsuit, Tiziran greatsword, and spare ammunition, alongside a jet harness, set \
+		of clothing, and extraneous equipment suitable for any aspiring raider looking to pillage unwitting cargo haulers \
+		and the occasional homesteader."
+	item = /obj/item/storage/box/syndicate/bundle/tizzyraider
+	cost = 20
+	purchasable_from = ~(UPLINK_ALL_SYNDIE_OPS | UPLINK_SPY)
+
+/datum/uplink_item/speckit/juggernuat
+	name = "Juggernaut Care Package"
+	desc = "The heaviest suit of armor sophont hands could possibly make alongside a laser minigun backpack, various medical \
+		airhypos, a shell launch system, and a hormone regulator, purpose-built to keep the user standing no matter the damage \
+		that they might physically take."
+	item = /obj/item/storage/box/syndicate/bundle/juggernuat
+	cost = 20
+	purchasable_from = ~(UPLINK_ALL_SYNDIE_OPS | UPLINK_SPY)
+
 /datum/uplink_item/speckit/bond
 	name = "Secret Agent Gear"
 	desc = "A handgun & ammo, agent ID card, chameleon suit, stimulant pen, freedom implant, EMP flashlight, brick of \

--- a/modular_doppler/modular_uplink/code/kit_tactical.dm
+++ b/modular_doppler/modular_uplink/code/kit_tactical.dm
@@ -5,6 +5,16 @@
 /datum/uplink_item/tackit
 	category = /datum/uplink_category/tactical_kits
 
+/datum/uplink_item/tackit/shocktrooper
+	name = "Shocktrooper Equipment"
+	desc = "High-speed ballistic armor paired with a suppressed Kieran pistol and energy sword, thermal goggles, and \
+		spare magazines and medical airhypos alongside a full set of high-quality tactical clothing, including a heavy \
+		rucksack for lugging around extra tools and supplies. Perfect for the aspiring infiltrator looking to cover every \
+		possible engagement range."
+	item = /obj/item/storage/box/syndicate/bundle/shocktrooper
+	cost = 20
+	purchasable_from = ~(UPLINK_ALL_SYNDIE_OPS | UPLINK_SPY)
+
 /datum/uplink_item/tackit/recon
 	name = "Recon Equipment"
 	desc = "Featuring x-ray goggles, a briefcase launchpad, binoculars, grenades, a MODsuit, a portable EMP device, \

--- a/modular_doppler/modular_uplink/code/uplink_kits.dm
+++ b/modular_doppler/modular_uplink/code/uplink_kits.dm
@@ -287,3 +287,48 @@
 	new /obj/item/ammo_box/magazine/m10mm(src)
 	new /obj/item/card/emag/doorjack(src) // 3 TC
 	new /obj/item/knife/combat(src) //comparable to the e-dagger, 2 TC
+
+/obj/item/storage/box/syndicate/bundle/tizzyraider
+
+/obj/item/storage/box/syndicate/bundle/tizzyraider/PopulateContents()
+	new /obj/item/clothing/under/lizard_kilt(src)
+	new /obj/item/clothing/suit/armor/lizard(src) // You can get this stuff in the loadout it's just here for posterity
+	new /obj/item/storage/backpack/lizard(src)
+	new /obj/item/clothing/glasses/lizard_hud(src)
+	new /obj/item/clothing/gloves/lizard_gloves(src)
+	new /obj/item/clothing/head/helmet/lizard(src)
+	new /obj/item/clothing/shoes/lizard_shins(src)
+	new /obj/item/clothing/mask/snout_balaclava(src)
+	new /obj/item/mod/control/pre_equipped/raider(src) // 10 TC
+	new /obj/item/tank/jetpack/oxygen/harness(src) // 1 TC
+	new /obj/item/melee/tizirian_sword/megachoppa(src) // 4 TC
+	new /obj/item/gun/ballistic/bolt_thrower(src) // 10 TC (maybe more, but who cares)
+	new /obj/item/ammo_box/magazine/ammo_stack/bolt_slug/full(src) // 1 TC
+	new /obj/item/ammo_box/magazine/ammo_stack/bolt_shot/full(src) // <1 TC
+
+/obj/item/storage/box/syndicate/bundle/shocktrooper
+
+/obj/item/storage/box/syndicate/bundle/shocktrooper/PopulateContents()
+	new /obj/item/clothing/under/syndicate/combat/shocktrooper(src) // priceless larp
+	new /obj/item/clothing/suit/armor/bulletproof(src) // 1 TC?
+	new /obj/item/clothing/head/helmet/alt/visorless(src) // 1 TC?
+	new /obj/item/clothing/gloves/combat(src)
+	new /obj/item/clothing/shoes/combat(src)
+	new /obj/item/clothing/mask/neck_gaiter(src)
+	new /obj/item/clothing/glasses/thermal/shocktrooper(src) // 4 TC
+	new /obj/item/storage/epic_loot_org_pouch/ert_ammo_preset(src) // four sindaryo mags, 2-3 TC?
+	new /obj/item/storage/epic_loot_medpen_case/ert_med_preset(src) // six medical airhypos
+	new /obj/item/storage/backpack/rucksack(src) // >2 TC, direct upgrade from a syndie duffel
+	new /obj/item/gun/ballistic/automatic/pistol/kieran/suppressed/syndicate_pin(src) // 7 + 1 TC, comes w/ suppressor
+	new /obj/item/melee/energy/sword/saber(src) // 6 TC
+
+/obj/item/storage/box/syndicate/bundle/juggernaut
+
+/obj/item/storage/box/syndicate/bundle/juggernaut/PopulateContents()
+	new /obj/item/clothing/suit/armor/heavy_ballistic // >10 TC
+	new /obj/item/clothing/head/helmet/alt/visorless(src) // 1 TC?
+	new /obj/item/clothing/mask/gas/sechailer/swat(src)
+	new /obj/item/minigunpack(src) // 6 TC
+	new /obj/item/storage/epic_loot_medpen_case/ert_med_preset(src) // six medical airhypos
+	new /obj/item/autosurgeon/syndicate/shell_launcher(src)
+	new /obj/item/autosurgeon/syndicate/berserk_os(src) // walking tank power fantasy


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Tweaks (read: lowers across most of the board) the price of Doppler-specific melee weapons in the traitor uplink, because the last PR to touch them was foolishly made with the idea that the esword is 8 TC (it's not, it's 6 TC)

Also adds three new kits to the uplink: Tiziran Raider, Juggernaut, and Shocktrooper. These kits fill in specific niches by making a full set of raider gear available to cantags when they'd normally need more than 20 TC, with the Juggernaut and Shocktrooper kits making unique ERT-specific gear like the heavy ballistic armor & Kieran pistol more readily available in normal play (for a steep price, of course, because larping is a full-time job)

## Why It's Good For The Game

Some people want to play cantina antagonists that are Tiziran raiders; this lets them do that while still keeping the current pick-n-mix pricing structure present. The other two kits offer an ample bit of extra versatility, and more player-facing Doppler-specific content.

Melee weapon prices were always meant to be based off of the esword, so it was my mistake that some of them were really silly high (like the vibroblade costing 8)

## Testing Evidence

<!-- Provide proof that the content added, edited, or removed by this pull request is working as intended in-game. Compiling alone doesn't guarantee functionality, so be sure to test thoroughly! -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Three new traitor uplink kits
balance: Cheaper Doppler-specific melee weapons in the uplink
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
